### PR TITLE
Update Go to 1.19.6

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push-kubermatic: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-8
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-8
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.30
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.30
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.4
+        - image: golang:1.19.6
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.4
+        - image: golang:1.19.6
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-8
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.4
+        - image: golang:1.19.6
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.4
+        - image: golang:1.19.6
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-8
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.4 as builder
+FROM docker.io/golang:1.19.6 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.19.4 as builder
+FROM golang:1.19.6 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
@@ -22,23 +22,23 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /download
 
 # Source: https://github.com/hashicorp/terraform
-ENV TERRAFORM_VERSION "1.3.6"
+ENV TERRAFORM_VERSION "1.3.9"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
 # Source: https://github.com/vmware-tanzu/sonobuoy
-ENV SONOBUOY_VERSION "0.56.14"
+ENV SONOBUOY_VERSION "0.56.15"
 RUN curl -fL https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz | tar vxz
 RUN chmod +x sonobuoy
 
 # Source: https://dl.k8s.io/release/stable-1.25.txt
-ENV KUBECTL_VERSION="v1.25.5"
+ENV KUBECTL_VERSION="v1.25.6"
 RUN curl --fail -Lo kubectl https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
 RUN chmod +x kubectl
 
 # resulting image
 
-FROM golang:1.19.4
+FROM golang:1.19.6
 
 ARG version
 

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.29
+TAG=v0.1.30
 
 docker build --build-arg version=${TAG} --pull -t quay.io/kubermatic/kubeone-e2e:${TAG} .
 docker push quay.io/kubermatic/kubeone-e2e:${TAG}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.29"
+	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.30"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -328,7 +328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -351,7 +351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -374,7 +374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -397,7 +397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -420,7 +420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -443,7 +443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -466,7 +466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -489,7 +489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -512,7 +512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -536,7 +536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -559,7 +559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -582,7 +582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -605,7 +605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -630,7 +630,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -655,7 +655,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -680,7 +680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -706,7 +706,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -731,7 +731,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -754,7 +754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -777,7 +777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -800,7 +800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -823,7 +823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -846,7 +846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -869,7 +869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -892,7 +892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -915,7 +915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -938,7 +938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -961,7 +961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -984,7 +984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1008,7 +1008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1031,7 +1031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1054,7 +1054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1077,7 +1077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1102,7 +1102,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1127,7 +1127,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1152,7 +1152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1178,7 +1178,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1203,7 +1203,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1226,7 +1226,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1249,7 +1249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1272,7 +1272,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1295,7 +1295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1318,7 +1318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1341,7 +1341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1364,7 +1364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1387,7 +1387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1410,7 +1410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1438,7 +1438,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1466,7 +1466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1494,7 +1494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1522,7 +1522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1550,7 +1550,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1578,7 +1578,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1608,7 +1608,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1638,7 +1638,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1668,7 +1668,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1699,7 +1699,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1729,7 +1729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1757,7 +1757,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1785,7 +1785,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1813,7 +1813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1841,7 +1841,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1869,7 +1869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1897,7 +1897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1925,7 +1925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1953,7 +1953,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1981,7 +1981,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2009,7 +2009,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2037,7 +2037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2065,7 +2065,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2093,7 +2093,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2121,7 +2121,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2149,7 +2149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2179,7 +2179,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2209,7 +2209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2239,7 +2239,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2270,7 +2270,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2300,7 +2300,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2328,7 +2328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2356,7 +2356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2384,7 +2384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2412,7 +2412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2440,7 +2440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2468,7 +2468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2496,7 +2496,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2524,7 +2524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2552,7 +2552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2575,7 +2575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2598,7 +2598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2621,7 +2621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2644,7 +2644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2667,7 +2667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2690,7 +2690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2715,7 +2715,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2740,7 +2740,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2765,7 +2765,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2791,7 +2791,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2816,7 +2816,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2839,7 +2839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2862,7 +2862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2885,7 +2885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2908,7 +2908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2931,7 +2931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2954,7 +2954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2977,7 +2977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3000,7 +3000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3023,7 +3023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3046,7 +3046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3069,7 +3069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3092,7 +3092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3115,7 +3115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3138,7 +3138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3161,7 +3161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3186,7 +3186,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3211,7 +3211,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3236,7 +3236,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3262,7 +3262,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3287,7 +3287,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3310,7 +3310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3333,7 +3333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3356,7 +3356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3379,7 +3379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3402,7 +3402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3425,7 +3425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3448,7 +3448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3471,7 +3471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3494,7 +3494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3517,7 +3517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3540,7 +3540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3563,7 +3563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3586,7 +3586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3609,7 +3609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3632,7 +3632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3657,7 +3657,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3682,7 +3682,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3707,7 +3707,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3733,7 +3733,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3758,7 +3758,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3781,7 +3781,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3804,7 +3804,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3827,7 +3827,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3850,7 +3850,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3873,7 +3873,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3896,7 +3896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3919,7 +3919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3942,7 +3942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3965,7 +3965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3990,7 +3990,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4015,7 +4015,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4040,7 +4040,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4065,7 +4065,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4090,7 +4090,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4115,7 +4115,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4138,7 +4138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4161,7 +4161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4184,7 +4184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4207,7 +4207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4230,7 +4230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4253,7 +4253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4276,7 +4276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4301,7 +4301,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4326,7 +4326,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4351,7 +4351,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4377,7 +4377,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4402,7 +4402,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4425,7 +4425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4448,7 +4448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4471,7 +4471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4494,7 +4494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4517,7 +4517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4540,7 +4540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4563,7 +4563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4586,7 +4586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4609,7 +4609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4632,7 +4632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4655,7 +4655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4678,7 +4678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4701,7 +4701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4724,7 +4724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4747,7 +4747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4772,7 +4772,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4797,7 +4797,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4822,7 +4822,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4848,7 +4848,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4873,7 +4873,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4896,7 +4896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4919,7 +4919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4942,7 +4942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4965,7 +4965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4988,7 +4988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5011,7 +5011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5034,7 +5034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5057,7 +5057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5080,7 +5080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5103,7 +5103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5126,7 +5126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5149,7 +5149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5172,7 +5172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5195,7 +5195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5218,7 +5218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5243,7 +5243,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5268,7 +5268,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5293,7 +5293,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5319,7 +5319,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5344,7 +5344,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5367,7 +5367,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5390,7 +5390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5413,7 +5413,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5436,7 +5436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5459,7 +5459,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5482,7 +5482,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5505,7 +5505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5528,7 +5528,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5551,7 +5551,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5574,7 +5574,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5597,7 +5597,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5620,7 +5620,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5643,7 +5643,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5666,7 +5666,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5689,7 +5689,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5714,7 +5714,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5739,7 +5739,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5764,7 +5764,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5790,7 +5790,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5815,7 +5815,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5838,7 +5838,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5861,7 +5861,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5884,7 +5884,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5907,7 +5907,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5930,7 +5930,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5953,7 +5953,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5976,7 +5976,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5999,7 +5999,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6022,7 +6022,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6047,7 +6047,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6072,7 +6072,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6097,7 +6097,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6123,7 +6123,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6148,7 +6148,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6171,7 +6171,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6194,7 +6194,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6217,7 +6217,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6240,7 +6240,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6263,7 +6263,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6286,7 +6286,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6309,7 +6309,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6332,7 +6332,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6355,7 +6355,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6380,7 +6380,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6405,7 +6405,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6430,7 +6430,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6456,7 +6456,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6481,7 +6481,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6504,7 +6504,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6527,7 +6527,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6550,7 +6550,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6573,7 +6573,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6596,7 +6596,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6619,7 +6619,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6642,7 +6642,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6665,7 +6665,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6688,7 +6688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6713,7 +6713,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6738,7 +6738,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6763,7 +6763,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6789,7 +6789,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6814,7 +6814,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6837,7 +6837,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6860,7 +6860,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6883,7 +6883,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6906,7 +6906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6929,7 +6929,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6952,7 +6952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6975,7 +6975,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6998,7 +6998,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7021,7 +7021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7044,7 +7044,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7067,7 +7067,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7090,7 +7090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7113,7 +7113,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7136,7 +7136,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7159,7 +7159,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7182,7 +7182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7205,7 +7205,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7228,7 +7228,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7251,7 +7251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7274,7 +7274,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7297,7 +7297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7320,7 +7320,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7343,7 +7343,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7366,7 +7366,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7391,7 +7391,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7416,7 +7416,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7441,7 +7441,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7467,7 +7467,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7492,7 +7492,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7515,7 +7515,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7538,7 +7538,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7561,7 +7561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7584,7 +7584,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7607,7 +7607,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7630,7 +7630,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7653,7 +7653,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7676,7 +7676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7699,7 +7699,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7722,7 +7722,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7745,7 +7745,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7768,7 +7768,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7791,7 +7791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7814,7 +7814,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7837,7 +7837,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7860,7 +7860,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7883,7 +7883,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7906,7 +7906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7929,7 +7929,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7952,7 +7952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7975,7 +7975,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7998,7 +7998,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8021,7 +8021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8044,7 +8044,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8069,7 +8069,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8094,7 +8094,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8119,7 +8119,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8145,7 +8145,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8170,7 +8170,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8193,7 +8193,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8216,7 +8216,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8239,7 +8239,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8262,7 +8262,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8285,7 +8285,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8308,7 +8308,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8331,7 +8331,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8354,7 +8354,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8377,7 +8377,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8400,7 +8400,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8423,7 +8423,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8446,7 +8446,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8469,7 +8469,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8492,7 +8492,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8515,7 +8515,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8538,7 +8538,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8561,7 +8561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8584,7 +8584,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8612,7 +8612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8640,7 +8640,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8668,7 +8668,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8696,7 +8696,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8724,7 +8724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8752,7 +8752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8782,7 +8782,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8812,7 +8812,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8842,7 +8842,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8873,7 +8873,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8903,7 +8903,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8931,7 +8931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8959,7 +8959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8987,7 +8987,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9015,7 +9015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9043,7 +9043,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9071,7 +9071,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9099,7 +9099,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9127,7 +9127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9155,7 +9155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9183,7 +9183,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9211,7 +9211,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9239,7 +9239,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9267,7 +9267,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9295,7 +9295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9323,7 +9323,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9351,7 +9351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9379,7 +9379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9407,7 +9407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9435,7 +9435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9463,7 +9463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9491,7 +9491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9519,7 +9519,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9547,7 +9547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9575,7 +9575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9605,7 +9605,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9635,7 +9635,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9665,7 +9665,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9696,7 +9696,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9726,7 +9726,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9754,7 +9754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9782,7 +9782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9810,7 +9810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9838,7 +9838,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9866,7 +9866,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9894,7 +9894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9922,7 +9922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9950,7 +9950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9978,7 +9978,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10006,7 +10006,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10034,7 +10034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10062,7 +10062,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10090,7 +10090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10118,7 +10118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10146,7 +10146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10174,7 +10174,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10202,7 +10202,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10230,7 +10230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10253,7 +10253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10276,7 +10276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10299,7 +10299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10322,7 +10322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10345,7 +10345,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10368,7 +10368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10393,7 +10393,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10418,7 +10418,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10443,7 +10443,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10469,7 +10469,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10494,7 +10494,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10517,7 +10517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10540,7 +10540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10563,7 +10563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10586,7 +10586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10609,7 +10609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10632,7 +10632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10655,7 +10655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10678,7 +10678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10701,7 +10701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10724,7 +10724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10747,7 +10747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10770,7 +10770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10793,7 +10793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10816,7 +10816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10839,7 +10839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10862,7 +10862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10885,7 +10885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10908,7 +10908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10931,7 +10931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10954,7 +10954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10977,7 +10977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11000,7 +11000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11023,7 +11023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11046,7 +11046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11071,7 +11071,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11096,7 +11096,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11121,7 +11121,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11147,7 +11147,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11172,7 +11172,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11195,7 +11195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11218,7 +11218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11241,7 +11241,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11264,7 +11264,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11287,7 +11287,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11310,7 +11310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11333,7 +11333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11356,7 +11356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11379,7 +11379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11402,7 +11402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11425,7 +11425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11448,7 +11448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11471,7 +11471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11494,7 +11494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11517,7 +11517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11540,7 +11540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11563,7 +11563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11586,7 +11586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11609,7 +11609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11632,7 +11632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11655,7 +11655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11678,7 +11678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11701,7 +11701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11724,7 +11724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11749,7 +11749,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11774,7 +11774,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11799,7 +11799,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11825,7 +11825,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11850,7 +11850,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11873,7 +11873,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11896,7 +11896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11919,7 +11919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11942,7 +11942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11965,7 +11965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11988,7 +11988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12011,7 +12011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12034,7 +12034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12057,7 +12057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12080,7 +12080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12103,7 +12103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12126,7 +12126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12149,7 +12149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12172,7 +12172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12195,7 +12195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12218,7 +12218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12241,7 +12241,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12264,7 +12264,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.30
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Go to 1.19.6.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KubeOne is now built with Go 1.19.6
```

**Documentation**:
```documentation
NONE
```