### PR TITLE
Invoke goreleaser from Makefile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ builds:
       - "-s -w"
       - "-extldflags=-zrelro"
       - "-extldflags=-znow"
+      - "-X k8c.io/kubeone/pkg/cmd.defaultKubeVersion={{ .Env.DEFAULT_STABLE }}"
       - "-X k8c.io/kubeone/pkg/cmd.version={{.Version}}"
       - "-X k8c.io/kubeone/pkg/cmd.commit={{.FullCommit}}"
       - "-X k8c.io/kubeone/pkg/cmd.date={{.Date}}"

--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,18 @@ export CGO_ENABLED=0
 export GOPROXY?=https://proxy.golang.org
 export GO111MODULE=on
 export GOFLAGS?=-mod=readonly -trimpath
+export DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.26.txt)
 
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
-DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.26.txt)
 GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
 	-X k8c.io/kubeone/pkg/cmd.defaultKubeVersion=$(DEFAULT_STABLE) \
 	-X k8c.io/kubeone/pkg/cmd.version=$(GITTAG) \
 	-X k8c.io/kubeone/pkg/cmd.commit=$(GITCOMMIT) \
 	-X k8c.io/kubeone/pkg/cmd.date=$(BUILD_DATE)
+
+GORELEASER_FLAGS ?= --clean
 
 .PHONY: all
 all: install
@@ -128,3 +130,7 @@ fmt: shfmt prowfmt
 gogenerate:
 	go generate ./pkg/...
 	go generate ./test/...
+
+.PHONY: goreleaser
+goreleaser:
+	goreleaser release $(GORELEASER_FLAGS)

--- a/hack/run-ci-release.sh
+++ b/hack/run-ci-release.sh
@@ -26,4 +26,4 @@ cd $(dirname $0)/..
 
 git remote add origin git@github.com:kubermatic/kubeone.git
 
-goreleaser release
+make goreleaser


### PR DESCRIPTION
**What this PR does / why we need it**:

As reported in https://github.com/kubermatic/kubeone/issues/2670#issuecomment-1438397048, `kubeone init` doesn't work when using binaries downloaded from GitHub, i.e. built by `goreleaser`.

That's because the default value for the `--kubernetes-version` flag is set by downloading the stable version marker and using `ldflags`. However, we didn't add that `ldflag` to `goreleaser`, so the `--kubernetes-version` flag doesn't have the default value and the `kubeone init` command misbehaves because of that.

To avoid redefining the value of that `ldflag` in `.goreleaser.yaml`, we leave that flag in Makefile and invoke `goreleaser` from Makefile instead of directly in the bash script.

**Which issue(s) this PR fixes**:
xref #2670

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```