### PR TITLE
Remove the master taint starting with Kubernetes 1.25

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -20,7 +20,7 @@ consult the changelog below before upgrading to this minor release.
 
 ### API Change
 
-- Stop applying `node-role.kubernetes.io/master` taint for Kubernetes 1.26+ nodes ([#2604](https://github.com/kubermatic/kubeone/pull/2604), [@xmudrii](https://github.com/xmudrii))
+- Stop applying `node-role.kubernetes.io/master` taint for Kubernetes 1.25+ nodes. The taint will be removed from existing nodes upon upgrading to Kubernetes 1.25 ([#2604](https://github.com/kubermatic/kubeone/pull/2604), [#2688](https://github.com/kubermatic/kubeone/pull/2688), [@xmudrii](https://github.com/xmudrii))
 - Add a new `NodeLocalDNS` field to the KubeOneCluster API used to control should the NodeLocalDNSCache component be deployed or not. Run `kubeone config print --full` for details on how to use this field ([#2356](https://github.com/kubermatic/kubeone/pull/2356), [@kron4eg](https://github.com/kron4eg))
 - Introduce a new `.addons.addons[*].disableTemplating` field to the KubeOneCluster API which can be used to disable templatization for an addon ([#2630](https://github.com/kubermatic/kubeone/pull/2630), [@ahmedwaleedmalik](https://github.com/ahmedwaleedmalik))
 - `.cloudProvider.csiConfig` is now a mandatory field for vSphere clusters using the external cloud provider (`.cloudProvider.external: true`) ([#2430](https://github.com/kubermatic/kubeone/pull/2430), [@xmudrii](https://github.com/xmudrii))

--- a/pkg/apis/kubeone/v1beta1/defaults.go
+++ b/pkg/apis/kubeone/v1beta1/defaults.go
@@ -66,7 +66,7 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 	setDefaultLeader := true
 
 	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
-	ltKube126Condition, _ := semver.NewConstraint("< 1.26")
+	ltKube125Condition, _ := semver.NewConstraint("< 1.25")
 	actualVer, err := semver.NewVersion(obj.Versions.Kubernetes)
 	if err != nil {
 		return
@@ -82,7 +82,7 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 		obj.ControlPlane.Hosts[idx].ID = idx
 		defaultHostConfig(&obj.ControlPlane.Hosts[idx])
 		if obj.ControlPlane.Hosts[idx].Taints == nil {
-			if ltKube126Condition.Check(actualVer) {
+			if ltKube125Condition.Check(actualVer) {
 				obj.ControlPlane.Hosts[idx].Taints = []corev1.Taint{
 					{
 						Effect: corev1.TaintEffectNoSchedule,

--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -90,7 +90,7 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 	setDefaultLeader := true
 
 	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
-	ltKube126Condition, _ := semver.NewConstraint("< 1.26")
+	ltKube125Condition, _ := semver.NewConstraint("< 1.25")
 	actualVer, err := semver.NewVersion(obj.Versions.Kubernetes)
 	if err != nil {
 		return
@@ -106,7 +106,7 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 		obj.ControlPlane.Hosts[idx].ID = idx
 		defaultHostConfig(&obj.ControlPlane.Hosts[idx])
 		if obj.ControlPlane.Hosts[idx].Taints == nil {
-			if ltKube126Condition.Check(actualVer) {
+			if ltKube125Condition.Check(actualVer) {
 				obj.ControlPlane.Hosts[idx].Taints = []corev1.Taint{
 					{
 						Effect: corev1.TaintEffectNoSchedule,


### PR DESCRIPTION
**What this PR does / why we need it**:

We removed the master taint starting with Kubernetes 1.26 in #2604. However, Kubernetes actually removed this taint in Kubernetes 1.25. The logic to remove this taint from existing nodes is only present in Kubeadm v1.25 and is executed upon upgrading from 1.24 to 1.25. That being said, if we upgrade 1.25 cluster that has nodes with the master taint, that taint is not going to be removed because:

- we enforced the master taint on nodes running 1.25 via our API (because of the API defaulting putting that taint by default for all nodes running Kubernetes < 1.26)
- the logic to remove that taint doesn't exist in Kubernetes 1.26 and the taint is not going to be removed even if it's not present in the taints list any longer

This is a very critical PR as not removing this taint can cause a major outage in some cases.

**What type of PR is this?**
/kind bug
/priority critical-urgent

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```