### PR TITLE
Don't regenerate cloud-config on nodes on CCM/CSI migration

### DIFF
--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -168,7 +168,7 @@ spec:
           command: ["cloud-controller-manager"]
           args:
             - "--allocate-node-cidrs=false" # "false" as we use IPAM in kube-controller-manager
-            - "--cloud-config=/etc/kubernetes/cloud-config"
+            - "--cloud-config=/etc/cloud/cloud-config"
             - "--cloud-provider=azure"
             - "--cluster-name={{ .Config.Name }}"
             - "--controllers=*,-cloud-node" # disable cloud-node controller
@@ -193,8 +193,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           volumeMounts:
-            - name: etc-kubernetes
-              mountPath: /etc/kubernetes
             - name: etc-ssl
               mountPath: /etc/ssl
               readOnly: true
@@ -207,10 +205,10 @@ spec:
             - name: msi
               mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
+            - mountPath: /etc/cloud
+              name: cloud-config-volume
+              readOnly: true
       volumes:
-        - name: etc-kubernetes
-          hostPath:
-            path: /etc/kubernetes
         - name: etc-ssl
           hostPath:
             path: /etc/ssl
@@ -223,6 +221,9 @@ spec:
         - name: msi
           hostPath:
             path: /var/lib/waagent/ManagedIdentity-Settings
+        - name: cloud-config-volume
+          secret:
+            secretName: cloud-config
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -510,8 +510,8 @@ func WithCCMCSIMigration(t Tasks) Tasks {
 				return s.CCMMigrationComplete
 			},
 		},
+		{Fn: generateKubeadm, Operation: "generating kubeadm config files"},
 	}...).
-		append(kubernetesConfigFiles()...).
 		append(
 			Task{Fn: ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfig, Operation: "regenerating static pod manifests and kubelet config"},
 			Task{

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -524,6 +524,21 @@ func WithCCMCSIMigration(t Tasks) Tasks {
 		).
 		append(WithResources(nil)...).
 		append(
+			// Regenerate files only when finishing the CCM/CSI migration.
+			Task{
+				Fn:        generateConfigurationFiles,
+				Operation: "generating config files",
+				Predicate: func(s *state.State) bool {
+					return s.CCMMigrationComplete
+				},
+			},
+			Task{
+				Fn:        uploadConfigurationFiles,
+				Operation: "uploading config files",
+				Predicate: func(s *state.State) bool {
+					return s.CCMMigrationComplete
+				},
+			},
 			Task{
 				Fn:        migrateOpenStackPVs,
 				Operation: "migrating openstack persistentvolumes",


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of the CCM/CSI migration, we are:

- regenerating the Kubeadm config and uploading it to the nodes
- regenerating the `/etc/kubernetes/cloud-config` file on all nodes

The first step is required, however, the second step is problematic and unneeded. First of all, `/etc/kubernetes/cloud-config` is only used by the legacy in-tree cloud providers (i.e. Kubelet, to be precise), it's not used by external CCM/CSI. The external CCM/CSI is supposed to read config from the `cloud-config` Secret.

The reason why we have problem with CCM/CSI migration is that the config used for in-tree cloud provider and external CCM can differ. Once we regenerate `/etc/kubernetes/cloud-config` at the beginning, Kubelet will try to use it because it's still configured with the `--cloud-provider` flag (we change this flag to `external` in the very last step to ensure volumes are working while migration is in progress). If configs differ, Kubelet might not be able to read it and it starts crashing, causing the Node to become NotReady.

We're still going to regenerate `/etc/kubernetes/cloud-config`, however, we're doing this now at the very end of the process (when completing the CCM/CSI migration).

This PR also ensures that Azure CCM uses the `cloud-config` Secret instead of reading config from the node's file system (`/etc/kubernetes/cloud-config`).

**What type of PR is this?**
/kind bug
/priority critical-urgent

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Do not regenerate/update `/etc/kubernetes/cloud-config` file on nodes upon performing CCM/CSI migration because that file is not used by external CCM/CSI
- Ensure that Azure CCM reads cloud-config from the `cloud-config` Secret instead from the node's file system (`/etc/kubernetes/cloud-config`)
```

**Documentation**:
```documentation
NONE
```