### PR TITLE
Require external CCM/CSI on vSphere starting with Kubernetes 1.25

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -324,8 +324,19 @@ func ValidateKubernetesSupport(c kubeoneapi.KubeOneCluster, fldPath *field.Path)
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes versions 1.27.0 and newer are currently not supported for vsphere clusters"))
 	}
 
+	// We require external CCM/CSI on vSphere starting with Kubernetes 1.25
+	// because the in-tree volume plugin requires the CSI driver to be
+	// deployed for Kubernetes 1.25 and newer.
+	// Existing clusters running the in-tree cloud provider must be migrated
+	// to the external CCM/CSI before upgrading to Kubernetes 1.25.
+	if v.Minor() >= 25 && c.CloudProvider.Vsphere != nil && !c.CloudProvider.External {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.25 and newer doesn't support in-tree cloud provider with vsphere"))
+	}
+
+	// The in-tree cloud provider for OpenStack has been removed in
+	// Kubernetes 1.26.
 	if v.Minor() >= 26 && c.CloudProvider.Openstack != nil && !c.CloudProvider.External {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes 1.26 and newer doesn't support in-tree cloud provider with openstack"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.26 and newer doesn't support in-tree cloud provider with openstack"))
 	}
 
 	return allErrs

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -926,9 +926,65 @@ func TestValidateKubernetesSupport(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "vSphere 1.26.0 cluster",
+			name: "vSphere 1.24.0 cluster without external CCM/CSI",
 			providerConfig: kubeoneapi.CloudProviderSpec{
-				Vsphere: &kubeoneapi.VsphereSpec{},
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: false,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.24.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "vSphere 1.24.0 cluster with external CCM/CSI",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: true,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.24.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "vSphere 1.25.0 cluster without external CCM/CSI",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: false,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.25.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "vSphere 1.25.0 cluster with external CCM/CSI",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: true,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.25.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "vSphere 1.26.0 cluster without external CCM/CSI",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: false,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.26.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "vSphere 1.26.0 cluster with external CCM/CSI",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: true,
 			},
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.26.0",
@@ -938,7 +994,8 @@ func TestValidateKubernetesSupport(t *testing.T) {
 		{
 			name: "vSphere 1.27.0 cluster",
 			providerConfig: kubeoneapi.CloudProviderSpec{
-				Vsphere: &kubeoneapi.VsphereSpec{},
+				Vsphere:  &kubeoneapi.VsphereSpec{},
+				External: true,
 			},
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.27.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

While testing vSphere CCM/CSI migration, we discovered that the CSI operations (i.e. operations with volumes) are not working with the in-tree cloud provider on Kubernetes 1.25 and newer. This is because the `CSIMigrationVsphere` feature gate is enabled by default starting with Kubernetes 1.25 and it requires the CSI driver to be deployed: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

Currently, we deploy vSphere CSI only if the external CCM/CSI is enabled (`.cloudProvider.external` is true). This is not inline with other providers that enabled `CSIMigration*` feature gates in Kubernetes 1.23 -- we unconditionally deploy CSI for those providers, regardless if in-tree cloud provider or external CCM is used.

However, we can't do the same easily for vSphere. vSphere requires the specific CSI config (`.cloudProvider.csiConfig`) to be provided for the CSI driver to work. That CSI config is different than cloud-config (the main difference is the `cluster-id` field), so users must provide the CSI config on their own. Additionally, the webhook to handle the CSI migration must be deployed to the cluster, and there are some internal CSI parameters that must be adjusted for CSI-migrated cluster.

The last point (deploying the webhook and adjusting internal CSI parameters) would require significant changes in logic for determining when do we need to do that, so after internal discussion, we decided to require vSphere clusters to be migrated to the external CCM/CSI before upgrading to Kubernetes 1.25.

This is inline with what are we going to do for KKP: https://github.com/kubermatic/kubermatic/pull/11951

**What type of PR is this?**
/kind api-change
/priority critical-urgent

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] External CCM/CSI is required for vSphere clusters starting with Kubernetes 1.25. If your vSphere clusters are using the in-tree cloud provider (`.cloudProvider.external` is `false` or unset), you must migrate your vSphere clusters to the external CCM/CSI before upgrading to Kubernetes 1.25. Please check the documentation for more details about the CCM/CSI migration. This change is introduced because vSphere requires the CSI driver to be deployed starting with Kubernetes 1.25 
```

**Documentation**:
```documentation
TBD
```