### PR TITLE
Fix goreleaser flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
 	-X k8c.io/kubeone/pkg/cmd.commit=$(GITCOMMIT) \
 	-X k8c.io/kubeone/pkg/cmd.date=$(BUILD_DATE)
 
-GORELEASER_FLAGS ?= --clean
+# TODO(xmudrii): Rename the flag to "--clean" after updating goreleaser.
+GORELEASER_FLAGS ?= --rm-dist
 
 .PHONY: all
 all: install


### PR DESCRIPTION
**What this PR does / why we need it**:

The `--clean` flag is only available in the latest `goreleaser` version. In the version that we currently use, this flag is called `--rm-dist`. We'll revisit this once we update `goreleaser` to the latest version.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```