### PR TITLE
quote less when logging evictions

### DIFF
--- a/pkg/nodeutils/drain.go
+++ b/pkg/nodeutils/drain.go
@@ -97,7 +97,7 @@ func (dr *drainer) drainHelper(ctx context.Context) (*drain.Helper, error) {
 			if !usingEviction {
 				evicted = "deleted"
 			}
-			dr.logger.Infof("pod %q/%q is %s", pod.GetNamespace(), pod.GetName(), evicted)
+			dr.logger.Infof("pod %s/%s is %s", pod.GetNamespace(), pod.GetName(), evicted)
 		},
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings the logging KubeOne does in-line with that kubectl does. This is how 1.6 output looks like now:

![screenshot-2023-02-28-104403](https://user-images.githubusercontent.com/127499/221814994-1946fef5-76b1-4a25-96e6-d521c69e95fa.png)

The excessive quotes make the logging messages hard to read.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
