### PR TITLE
Make HelmRelease.RepoURL an optional field

### DIFF
--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2023-01-30T19:59:26+05:00
+date = 2023-03-13T11:51:05+02:00
 weight = 11
 +++
 ## v1beta2
@@ -407,7 +407,7 @@ GCESpec defines the GCE cloud provider
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | chart | Chart is [CHART] part of the `helm upgrade [RELEASE] [CHART]` command. | string | true |
-| repoURL | RepoURL is a chart repository URL where to locate the requested chart. | string | true |
+| repoURL | RepoURL is a chart repository URL where to locate the requested chart. | string | false |
 | version | Version is --version flag of the `helm upgrade` command. Specify the exact chart version to use. If this is not specified, the latest version is used. | string | false |
 | releaseName | ReleaseName is [RELEASE] part of the `helm upgrade [RELEASE] [CHART]` command. Empty is defaulted to chart. | string | false |
 | namespace | Namespace is --namespace flag of the `helm upgrade` command. A namespace to use for a release. | string | true |

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -96,7 +96,7 @@ type HelmRelease struct {
 	Chart string `json:"chart"`
 
 	// RepoURL is a chart repository URL where to locate the requested chart.
-	RepoURL string `json:"repoURL"`
+	RepoURL string `json:"repoURL,omitempty"`
 
 	// Version is --version flag of the `helm upgrade` command. Specify the exact chart version to use. If this is not
 	// specified, the latest version is used.

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -93,7 +93,7 @@ type HelmRelease struct {
 	Chart string `json:"chart"`
 
 	// RepoURL is a chart repository URL where to locate the requested chart.
-	RepoURL string `json:"repoURL"`
+	RepoURL string `json:"repoURL,omitempty"`
 
 	// Version is --version flag of the `helm upgrade` command. Specify the exact chart version to use. If this is not
 	// specified, the latest version is used.

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -704,10 +704,6 @@ func ValidateHelmReleases(helmReleases []kubeoneapi.HelmRelease, fldPath *field.
 			allErrs = append(allErrs, field.Required(fldPath.Child("chart"), hr.Chart))
 		}
 
-		if hr.RepoURL == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("repoURL"), hr.RepoURL))
-		}
-
 		if hr.Namespace == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), hr.Namespace))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
RepoURL has been marked as a required by mistake. There are legitimate situations where it can be optional, for example it's possible to use a direct link to the chart archive or a custom directory on local machine where chart is located.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
Documentation is in the PR, will be updated automatically in the docs site.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Make HelmRelease.RepoURL an optional field
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
