### PR TITLE
csi-vmware-cloud-director: overwrite clusterId with param

### DIFF
--- a/addons/csi-vmware-cloud-director/vcloud-csi-config.yaml
+++ b/addons/csi-vmware-cloud-director/vcloud-csi-config.yaml
@@ -12,5 +12,5 @@ data:
       org: {{ required "Please provide VCD_ORG" .Credentials.VCD_ORG }}
       vdc: {{ required "Please provide VCD_VDC" .Credentials.VCD_VDC }}
       vAppName: {{ .Config.CloudProvider.VMwareCloudDirector.VApp }}
-    clusterid: {{ .Config.Name }}
+    clusterid: {{ default .Config.Name .Params.clusterid }}
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to overwrite and customize the `clusterid` value in the embedded [csi-vmware-cloud-director](https://github.com/kubermatic/kubeone/tree/main/addons/csi-vmware-cloud-director) addon. ClusterId can then be set to different values, most notably to include the prefix `NO_RDE_`, to disable RDE in the csi-driver when interacting with the vCloud API.
See https://github.com/vmware/cloud-director-named-disk-csi-driver/issues/117 and https://github.com/vmware/cloud-director-named-disk-csi-driver/pull/22 for reference.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Support for customizing clusterid for VMware Cloud Director CSI driver
```

**Documentation**:
```documentation
NONE
```
