### PR TITLE
Allows ubuntu/debian configuration for containerd

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -141,9 +141,9 @@ var (
 			{{ if .CONFIGURE_REPOSITORIES }}
 			sudo apt-get update
 			sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
-			curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
+			curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg |
 				sudo apt-key add -
-			sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+			sudo add-apt-repository "deb https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable"
 			{{ end }}
 
 			sudo apt-mark unhold containerd.io || true


### PR DESCRIPTION
With this change it will allow correct configuration for both Ubuntu and Debian.

This does not promotes Debian as supported, but allows to start working on it.

`tr` is from `coreutils` package, so it is impossible it would be missed.

**Which issue(s) this PR fixes**:

Fixes #2719

**What type of PR is this?**
Add one of the following kinds:
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
NONE
```release-note
Introduces initial support for Debian. Changes containerd repository configuration to allow Ubuntu or Debian.
```

**Documentation**:
NONE
```documentation

```