### PR TITLE
vCD API logging in Terraform examples

### DIFF
--- a/examples/terraform/vmware-cloud-director/README.md
+++ b/examples/terraform/vmware-cloud-director/README.md
@@ -85,6 +85,7 @@ No modules.
 | <a name="input_initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployments, only applicable if operating-system-manager addon is enabled.<br>If not specified, the default value will be added by machine-controller addon. | `string` | `""` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | number of replicas per MachineDeployment | `number` | `2` | no |
 | <a name="input_kubeapi_hostname"></a> [kubeapi\_hostname](#input\_kubeapi\_hostname) | DNS name for the kube-apiserver | `string` | `""` | no |
+| <a name="input_logging"></a> [logging](#input\_logging) | Enable logging of VMware Cloud Director API activities into go-vcloud-director.log | `bool` | `false` | no |
 | <a name="input_network_dns_server_1"></a> [network\_dns\_server\_1](#input\_network\_dns\_server\_1) | Primary DNS server for the routed network | `string` | `""` | no |
 | <a name="input_network_dns_server_2"></a> [network\_dns\_server\_2](#input\_network\_dns\_server\_2) | Secondary DNS server for the routed network. | `string` | `""` | no |
 | <a name="input_network_interface_type"></a> [network\_interface\_type](#input\_network\_interface\_type) | Type of interface for the routed network | `string` | `"internal"` | no |

--- a/examples/terraform/vmware-cloud-director/main.tf
+++ b/examples/terraform/vmware-cloud-director/main.tf
@@ -23,6 +23,7 @@ provider "vcd" {
   org                  = var.vcd_org_name
   vdc                  = var.vcd_vdc_name
   allow_unverified_ssl = var.allow_insecure
+  logging              = var.logging
 }
 
 locals {

--- a/examples/terraform/vmware-cloud-director/variables.tf
+++ b/examples/terraform/vmware-cloud-director/variables.tf
@@ -36,6 +36,12 @@ variable "allow_insecure" {
   type        = bool
 }
 
+variable "logging" {
+  description = "Enable logging of VMware Cloud Director API activites into go-vcloud-director.log"
+  default     = false
+  type        = bool
+}
+
 # Cluster specific configuration
 variable "cluster_name" {
   description = "Name of the cluster"

--- a/examples/terraform/vmware-cloud-director/variables.tf
+++ b/examples/terraform/vmware-cloud-director/variables.tf
@@ -37,7 +37,7 @@ variable "allow_insecure" {
 }
 
 variable "logging" {
-  description = "Enable logging of VMware Cloud Director API activites into go-vcloud-director.log"
+  description = "Enable logging of VMware Cloud Director API activities into go-vcloud-director.log"
   default     = false
   type        = bool
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
It introduces a new, optional variable for the vmware-cloud-director terraform example: `logging`.
When set to `true` it will log all vCD API activities into the logfile "go-vcloud-director.log". The default value is `false`, so nothing changes for existing configurations.

**Which issue(s) this PR fixes**:
Not necessarily an issue that is being fixed by this PR, but it allows for actively debugging vCD API interaction if there is a problem.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
