### PR TITLE
vCD Terraform - switch from deprecated metadata to metadata_entry

### DIFF
--- a/examples/terraform/vmware-cloud-director/main.tf
+++ b/examples/terraform/vmware-cloud-director/main.tf
@@ -63,10 +63,26 @@ resource "vcd_vapp" "cluster" {
   name        = var.cluster_name
   description = "vApp for ${var.vcd_vdc_name} cluster"
 
-  metadata = {
-    provisioner  = "Kubeone"
-    cluster_name = "${var.cluster_name}"
-    type         = "Kubernetes Cluster"
+  metadata_entry {
+    key         = "provisioner"
+    value       = "KubeOne"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+  metadata_entry {
+    key         = "cluster_name"
+    value       = var.cluster_name
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+  metadata_entry {
+    key         = "type"
+    value       = "Kubernetes Cluster"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
   }
 
   depends_on = [vcd_network_routed.network]
@@ -97,10 +113,26 @@ resource "vcd_vapp_vm" "control_plane" {
   name          = "${var.cluster_name}-cp-${count.index + 1}"
   computer_name = "${var.cluster_name}-cp-${count.index + 1}"
 
-  metadata = {
-    provisioner  = "Kubeone"
-    cluster_name = "${var.cluster_name}"
-    role         = "control-plane"
+  metadata_entry {
+    key         = "provisioner"
+    value       = "KubeOne"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+  metadata_entry {
+    key         = "cluster_name"
+    value       = var.cluster_name
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+  metadata_entry {
+    key         = "role"
+    value       = "control-plane"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
   }
 
   guest_properties = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes all metadata entries on vApp and VMs from using the deprecated `metadata` property to `metadata_entry`.
See documentation at https://registry.terraform.io/providers/vmware/vcd/latest/docs/resources/vapp_vm#metadata

**Which issue(s) this PR fixes**:
Getting rid of deprecation warnings from Terraform / VCD provider about using the `metadata` property.

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
