### PR TITLE
vCD Terraform - add hairpin snat rule

### DIFF
--- a/examples/terraform/vmware-cloud-director/main.tf
+++ b/examples/terraform/vmware-cloud-director/main.tf
@@ -170,3 +170,13 @@ resource "vcd_nsxv_snat" "rule_internet" {
   original_address   = "${var.gateway_ip}/24"
   translated_address = local.external_network_ip
 }
+
+# Create Hairpin SNAT rule
+resource "vcd_nsxv_snat" "rule_internal" {
+  edge_gateway = data.vcd_edgegateway.edge_gateway.name
+  network_type = "org"
+  network_name = vcd_network_routed.network.name
+
+  original_address   = "${var.gateway_ip}/24"
+  translated_address = var.gateway_ip
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a SNAT rule for hairpinning on the edge gateway for the routed network.

**Which issue(s) this PR fixes**:
Allows NATed traffic from the routed network to flow properly.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
