### PR TITLE
fix: Explicitly start docker in vSphere flatcar

### DIFF
--- a/examples/terraform/vsphere_flatcar/main.tf
+++ b/examples/terraform/vsphere_flatcar/main.tf
@@ -103,6 +103,18 @@ resource "vsphere_virtual_machine" "control_plane" {
         ignition = {
           version = "2.2.0"
         }
+        systemd = {
+          units = [
+            {
+              name = "docker.socket"
+              enabled = false
+            },
+            {
+              name = "docker.service"
+              enabled = true
+            }
+          ]
+        },
         storage = {
           files = [
             {


### PR DESCRIPTION
**What this PR does / why we need it**:
Turns out that now we need to explicitly enable docker (to allow KubeOne to properly function) in flatcar ignition generated by the terraform.

**Which issue(s) this PR fixes**:
Fixes #2736 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
fix: Explicitly start docker in vSphere flatcar
```

**Documentation**:
```documentation
NONE
```
