### PR TITLE
Refactor vSphere example terraform disk UUID code

### DIFF
--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -92,9 +92,7 @@ resource "vsphere_virtual_machine" "control_plane" {
     template_uuid = data.vsphere_virtual_machine.template.id
   }
 
-  extra_config = {
-    "disk.enableUUID" = "TRUE"
-  }
+  enable_disk_uuid = true
 
   vapp {
     properties = {

--- a/examples/terraform/vsphere_centos/main.tf
+++ b/examples/terraform/vsphere_centos/main.tf
@@ -92,8 +92,9 @@ resource "vsphere_virtual_machine" "control_plane" {
     template_uuid = data.vsphere_virtual_machine.template.id
   }
 
+  enable_disk_uuid = true
+
   extra_config = {
-    "disk.enableUUID" = "TRUE"
     "guestinfo.metadata" = base64gzip(templatefile("./cloud-config-metadata.tftpl", {
       machine_name = "${var.cluster_name}-cp-${count.index + 1}"
       ssh_key      = file(var.ssh_public_key_file)

--- a/examples/terraform/vsphere_flatcar/main.tf
+++ b/examples/terraform/vsphere_flatcar/main.tf
@@ -92,9 +92,7 @@ resource "vsphere_virtual_machine" "control_plane" {
     template_uuid = data.vsphere_virtual_machine.template.id
   }
 
-  extra_config = {
-    "disk.enableUUID" = "TRUE"
-  }
+  enable_disk_uuid = true
 
   vapp {
     properties = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

As Terraform note you shouldn't use `extra_config` if you are using "a template imported from OVF/OVA".
See the note at [extra_config](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine#extra_config)

You can use the advanced option [enable_disk_uuid](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine#enable_disk_uuid) for the correct behaviour.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

Using the `extra_config` version will lead Terraform to constantly try to update the value, see below:

```console
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # vsphere_virtual_machine.control_plane[0] will be updated in-place
  ~ resource "vsphere_virtual_machine" "control_plane" {
      - enable_disk_uuid                        = true -> null
        id                                      = "421d8f7d-fab3-fe5d-4e5a-5c4664a67945"
        name                                    = "kkp-test-kubeone-cp-1"
        tags                                    = []
        # (67 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }
```

**Does this PR introduce a user-facing change? Then add your Release Note here:**

```release-note
 Refactor vSphere example terraform disk UUID code
```

**Documentation:**

```documentation
NONE
```