### PR TITLE
Fix kubeone setup on Hetzner

### DIFF
--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -43,7 +43,7 @@ Acquire::http::Proxy "{{ .HTTP_PROXY }}";
 {{- end }}
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -91,7 +91,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -67,18 +67,14 @@ sudo systemctl enable --now iscsid
 {{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -67,7 +67,7 @@ sudo systemctl enable --now iscsid
 {{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -67,7 +67,25 @@ sudo systemctl enable --now iscsid
 {{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -43,8 +43,12 @@ Acquire::http::Proxy "{{ .HTTP_PROXY }}";
 {{- end }}
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -69,8 +73,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 {{- end }}
 

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -49,7 +49,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -97,7 +97,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 {{- end }}
 
 kube_ver="{{ .KUBERNETES_VERSION }}*"

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -43,6 +43,8 @@ Acquire::http::Proxy "{{ .HTTP_PROXY }}";
 {{- end }}
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -67,6 +69,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 {{- end }}
 

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -43,7 +43,7 @@ Acquire::http::Proxy "{{ .HTTP_PROXY }}";
 {{- end }}
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -91,7 +91,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -67,21 +67,22 @@ sudo systemctl enable --now iscsid
 {{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -59,7 +59,7 @@ var (
 			# Therefore, we use bionic repo which has all Docker versions.
 			echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 				sudo tee /etc/apt/sources.list.d/docker.list
-			sudo apt-get update
+			sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 			{{ end }}
 
 			sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
@@ -139,7 +139,7 @@ var (
 
 		"apt-containerd": heredoc.Docf(`
 			{{ if .CONFIGURE_REPOSITORIES }}
-			sudo apt-get update
+			sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 			sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 			curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg |
 				sudo apt-key add -

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -55,7 +55,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -93,7 +93,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -61,7 +61,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -99,7 +99,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -55,7 +55,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -93,7 +93,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -55,8 +55,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -71,8 +75,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -69,7 +69,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -69,21 +69,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -69,18 +69,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -55,6 +55,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -69,6 +71,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -69,7 +69,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -66,21 +66,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -66,18 +66,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -90,7 +90,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -68,8 +72,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -96,7 +96,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -90,7 +90,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -66,7 +66,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -66,7 +66,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -66,6 +68,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -107,7 +107,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Therefore, we use bionic repo which has all Docker versions.
 echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -107,7 +107,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Therefore, we use bionic repo which has all Docker versions.
 echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -107,7 +107,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Therefore, we use bionic repo which has all Docker versions.
 echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -103,7 +103,7 @@ cri_ver="1.26.0*"
 
 
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg |
 	sudo apt-key add -

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -103,7 +103,7 @@ cri_ver="1.26.0*"
 
 
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg |
 	sudo apt-key add -

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -108,7 +108,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Therefore, we use bionic repo which has all Docker versions.
 echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -63,7 +63,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+get_return_code_from_uri() {
+	return $((curl -s -o /dev/null -w "%{http_code}" $1))
+}
+
+primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+
+if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+	echo "Add $primary_k8s_apt_key_uri to apt key store"
+	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
+else
+	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+		echo "Add $backup_k8s_apt_key_uri to apt key store"
+		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
+	else
+		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
+		exit 1
+	fi
+fi
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
+update_pid="$(lsof | grep ' /var/lib/apt/lists/lock' || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -63,21 +63,22 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
+k8s_apt_key_path=/etc/apt/keyrings/kubernetes-archive-keyring.gpg
+successfully_added_k8s_apt_key=false
 
-if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
-	echo "Add $primary_k8s_apt_key_uri to apt key store"
-	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
-else
-	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
-		echo "Add $backup_k8s_apt_key_uri to apt key store"
-		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
-	else
-		echo "We can not reach '$primary_k8s_apt_key_uri' and '$backup_k8s_apt_key_uri'"
-		exit 1
+# Thank to fucking Hetzner :-)
+while [ "$successfully_added_k8s_apt_key" != "true" ]
+do
+	sudo curl -fsSLo $k8s_apt_key_path https://packages.cloud.google.com/apt/doc/apt-key.gpg || true
+
+	if [ -f $k8s_apt_key_path ]; then
+		echo "Add $k8s_apt_key_path to apt key store"
+		sudo apt-key add $k8s_apt_key_path
+		successfully_added_k8s_apt_key=true
 	fi
-fi
+done
+
+echo "deb [signed-by=$k8s_apt_key_path] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -63,18 +63,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-get_return_code_from_uri() {
-	return $((curl -s -o /dev/null -w "%{http_code}" $1))
-}
-
 primary_k8s_apt_key_uri="https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 backup_k8s_apt_key_uri="https://dl.k8s.io/apt/doc/apt-key.gpg"
 
-if [ "$(get_return_code_from_uri $primary_k8s_apt_key_uri)" != "200" ]; then
+if [ "$(curl -s -o /dev/null -w '%{http_code}' $primary_k8s_apt_key_uri)" == "200" ]; then
 	echo "Add $primary_k8s_apt_key_uri to apt key store"
 	curl -fsSL $primary_k8s_apt_key_uri | sudo apt-key add -
 else
-	if [ "$(get_return_code_from_uri $backup_k8s_apt_key_uri)" != "200" ]; then
+	if [ "$(curl -s -o /dev/null -w '%{http_code}' $backup_k8s_apt_key_uri)" == "200" ]; then
 		echo "Add $backup_k8s_apt_key_uri to apt key store"
 		curl -fsSL $backup_k8s_apt_key_uri | sudo apt-key add -
 	else

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -49,6 +49,8 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -63,6 +65,8 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
+# make sure that no other update process is running in the background
+lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
@@ -87,7 +87,7 @@ fi
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+update_pid="$(lsof | grep /var/lib/apt/lists/lock || true)"
 if [ ! -z "$update_pid" ]; then
 	# make sure that no other update process is running in the background
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -63,7 +63,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -49,8 +49,12 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
@@ -65,8 +69,12 @@ curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-# make sure that no other update process is running in the background
-lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+update_pid="$(lsof | grep /var/lib/apt/lists/lock)"
+if [ ! -z "$update_pid" ]; then
+	# make sure that no other update process is running in the background
+	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
+fi
+
 sudo apt-get update
 
 kube_ver="1.26.0*"

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -55,7 +55,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
@@ -93,7 +93,7 @@ if [ ! -z "$update_pid" ]; then
 	lsof -t /var/lib/apt/lists/lock | xargs -r sudo kill
 fi
 
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 kube_ver="1.26.0*"
 cni_ver="1.2.0*"
@@ -108,7 +108,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Therefore, we use bionic repo which has all Docker versions.
 echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
-sudo apt-get update
+sudo apt-get -oDebug::pkgAcquire::Worker=1 update
 
 
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes Control-Plane setup issue. 
Sometimes the following issue ocure:
```
[10.10.0.6] Reading package lists...
[10.10.0.6] E: Could not get lock /var/lib/apt/lists/lock. It is held by process 1125 (apt-get)
[10.10.0.6] E: Unable to lock directory /var/lib/apt/lists/
time="11:16:15 UTC" level=error msg="ssh: installing kubeadm\nssh: popen\nProcess exited with status 100" 
```

This happen because any `apt-get update` process is still running in the background and the process is frozen. Even during a retry the `apt-get update` process is on hold.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

