### PR TITLE
bug: remove duplicate err print

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -51,11 +51,7 @@ func Execute() {
 	}
 
 	rootCmd := newRoot()
-
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		exitCode := fail.ExitCode(err)
-
 		debug, _ := rootCmd.PersistentFlags().GetBool(longFlagName(&globalOptions{}, "Debug"))
 		if debug {
 			var formatterErr fmt.Formatter
@@ -66,6 +62,7 @@ func Execute() {
 			}
 		}
 
+		exitCode := fail.ExitCode(err)
 		os.Exit(exitCode)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Maybe a small thing, but I came across this while I was playing with kubermatic stack and kubeone
This PR removes the second error print as it's already being handled by cobra

before:
```shell
kubeone --version
Error: unknown flag: --version
Error: unknown flag: --version
```
after:
```shell
./dist/kubeone --version
Error: unknown flag: --version
```

```release-note
Fix duplicate CLI print
```

```documentation
NONE
```
