### PR TITLE
Ignore some kubeadm preflight checks when validating cluster requirements

### DIFF
--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -50,6 +50,7 @@ func kubeadmPreflightChecks(s *state.State) error {
 			ctx.Logger.Info("	preflight...")
 			_, _, err := ctx.Runner.Run(heredoc.Docf(`
 				sudo kubeadm init phase preflight \
+					--ignore-preflight-errors=DirAvailable--var-lib-etcd,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-6443,Port-10259,Port-10257,Port-10250,Port-2379,Port-2380 \
 					--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 			`), runner.TemplateVariables{
 				"NODE_ID":  node.ID,


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore some `kubeadm` preflight checks when validating cluster requirements to account for adding new static worker nodes. For more details about this, see #2802

**Which issue(s) this PR fixes**:
xref #2802

**What type of PR is this?**

/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Ignore some `kubeadm` preflight checks when validating cluster requirements to account for adding new static worker nodes
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 