### PR TITLE
Fix buildx failing to push images

### DIFF
--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -60,22 +60,22 @@ for ARCH in ${ARCHITECTURES}; do
     --build-arg="GOPROXY=${GOPROXY:-}" \
     --build-arg="GOCACHE=/go/src/k8c.io/kubeone/gocaches/${ARCH}" \
     --file="Dockerfile" \
-    --tag "${IMAGE}-${ARCH}:${PRIMARY_TAG}" .
+    --tag "${IMAGE}:${PRIMARY_TAG}-${ARCH}" .
 done
 
 if [ "$NOMOCK" = true ]; then
   for ARCH in ${ARCHITECTURES}; do
-    echodate "Pushing ${IMAGE}-${ARCH}:${PRIMARY_TAG}..."
-    docker push "${IMAGE}-${ARCH}:${PRIMARY_TAG}"
+    echodate "Pushing ${IMAGE}:${PRIMARY_TAG}-${ARCH}..."
+    docker push "${IMAGE}:${PRIMARY_TAG}-${ARCH}"
   done
 
-  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
-  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}:${PRIMARY_TAG}\-&~g")
+  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}:${PRIMARY_TAG}-${ARCH}"; done
   docker manifest push --purge "${IMAGE}:${PRIMARY_TAG}"
 
   for TAG in ${TAGS}; do
-    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
-    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}:${PRIMARY_TAG}\-&~g")
+    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}:${PRIMARY_TAG}-${ARCH}"; done
     docker manifest push --purge "${IMAGE}:${TAG}"
   done
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

We were trying to push images such as `quay.io/kubermatic/kubeone-${arch}`. Unlike GCR, this is not supported on Quay so push fails. Instead, let's append arch to the tag, so we have something like `quay.io/kubermatic/kubeone:tag-arch`. This seems to work well and images are recognized properly by Quay.

![image](https://github.com/kubermatic/kubeone/assets/18719127/fbda6054-445d-4c3f-8d58-39d06aee5e4f)

**What type of PR is this?**

/kind cleanup
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @xrstf 