### PR TITLE
[release/v1.6] Migrate from buildah to buildx

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push-kubermatic: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+        - image: quay.io/kubermatic/build:go-1.19-node-18-16
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+        - image: quay.io/kubermatic/build:go-1.19-node-18-16
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.50.1
+        - image: golangci/golangci-lint:v1.53.3
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - /bin/bash
             - -c

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -135,7 +135,7 @@ presubmits:
               memory: 1Gi
               cpu: 4
             limits:
-              memory: 2Gi
+              memory: 3Gi
   - name: pull-kubeone-build-image
     always_run: true
     decorate: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.8 as builder
+FROM docker.io/golang:1.19.10 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY
@@ -24,7 +24,7 @@ WORKDIR /go/src/k8c.io/kubeone
 COPY . .
 RUN make build
 
-FROM docker.io/alpine:3.15
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 # openssh-client is required for the ssh binary and for ssh-agent

--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -27,55 +27,56 @@ set -o monitor
 
 source $(dirname $0)/../lib.sh
 
-DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
+IMAGE="${IMAGE:-quay.io/kubermatic/kubeone}"
 ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
 NOMOCK=${NOMOCK:-false}
 
 PRIMARY_TAG="$(git rev-parse HEAD | tr -d '\n')"
 TAGS=${TAGS:-}
 
-gocaches="$(mktemp -d)"
+gocaches="./gocaches"
 for ARCH in ${ARCHITECTURES}; do
   cacheDir="$gocaches/$ARCH"
   mkdir -p "$cacheDir"
  
   # try to get a gocache for this arch; this can "fail" but still exit with 0
-  echodate "Attempting to fetch gocache for $ARCH..."
-  TARGET_DIRECTORY="$cacheDir" GOARCH="$ARCH" ./hack/ci/download-gocache.sh
+  echodate "Attempting to fetch gocache for ${ARCH}..."
+  TARGET_DIRECTORY="$cacheDir" GOARCH="${ARCH}" ./hack/ci/download-gocache.sh
 done
 
-echodate "Building ${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+echodate "Building ${IMAGE}:${PRIMARY_TAG}"
 
 # build multi-arch images
-buildah manifest create "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
-for ARCH in ${ARCHITECTURES}; do
-  echodate "Building a KubeOne image for $ARCH..."
+docker buildx rm k8c-k1-release || true
+docker buildx create --use --name=k8c-k1-release
 
-  # Building via buildah does not use the gocache, but that's okay, because we
-  # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
-  # cache size and force every e2e test to download gigabytes worth of unneeded
-  # arm64 stuff. We might need to change this once we run e2e tests on arm64.
-  buildah bud \
-    --tag="${DOCKER_REPO}/kubeone-${ARCH}:${PRIMARY_TAG}" \
+for ARCH in ${ARCHITECTURES}; do
+  echodate "Building a KubeOne image for ${ARCH}..."
+
+  docker buildx build \
+    --load \
+    --progress=plain \
+    --platform="linux/${ARCH}" \
     --build-arg="GOPROXY=${GOPROXY:-}" \
-    --build-arg="GOCACHE=/gocache" \
-    --arch="$ARCH" \
-    --override-arch="$ARCH" \
-    --format=docker \
-    --file Dockerfile \
-    --volume "$gocaches/$ARCH:/gocache" \
-    .
-  buildah manifest add "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeone-${ARCH}:${PRIMARY_TAG}"
+    --build-arg="GOCACHE=/go/src/k8c.io/kubeone/gocaches/${ARCH}" \
+    --file="Dockerfile" \
+    --tag "${IMAGE}-${ARCH}:${PRIMARY_TAG}" .
 done
 
 if [ "$NOMOCK" = true ]; then
-  echodate "Pushing ${DOCKER_REPO}/kubeone:${PRIMARY_TAG}..."
-  buildah manifest push --all "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "docker://${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+  for ARCH in ${ARCHITECTURES}; do
+    echodate "Pushing ${IMAGE}-${ARCH}:${PRIMARY_TAG}..."
+    docker push "${IMAGE}-${ARCH}:${PRIMARY_TAG}"
+  done
+
+  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
+  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+  docker manifest push --purge "${IMAGE}:${PRIMARY_TAG}"
 
   for TAG in ${TAGS}; do
-    echodate "Pushing ${DOCKER_REPO}/kubeone:${TAG}..."
-    buildah tag "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeone:${TAG}"
-    buildah manifest push --all "${DOCKER_REPO}/kubeone:${TAG}" "docker://${DOCKER_REPO}/kubeone:${TAG}"
+    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
+    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+    docker manifest push --purge "${IMAGE}:${TAG}"
   done
 fi
 

--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -60,22 +60,22 @@ for ARCH in ${ARCHITECTURES}; do
     --build-arg="GOPROXY=${GOPROXY:-}" \
     --build-arg="GOCACHE=/go/src/k8c.io/kubeone/gocaches/${ARCH}" \
     --file="Dockerfile" \
-    --tag "${IMAGE}-${ARCH}:${PRIMARY_TAG}" .
+    --tag "${IMAGE}:${PRIMARY_TAG}-${ARCH}" .
 done
 
 if [ "$NOMOCK" = true ]; then
   for ARCH in ${ARCHITECTURES}; do
-    echodate "Pushing ${IMAGE}-${ARCH}:${PRIMARY_TAG}..."
-    docker push "${IMAGE}-${ARCH}:${PRIMARY_TAG}"
+    echodate "Pushing ${IMAGE}:${PRIMARY_TAG}-${ARCH}..."
+    docker push "${IMAGE}:${PRIMARY_TAG}-${ARCH}"
   done
 
-  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
-  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}:${PRIMARY_TAG}\-&~g")
+  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}:${PRIMARY_TAG}-${ARCH}"; done
   docker manifest push --purge "${IMAGE}:${PRIMARY_TAG}"
 
   for TAG in ${TAGS}; do
-    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
-    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}:${PRIMARY_TAG}\-&~g")
+    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}:${PRIMARY_TAG}-${ARCH}"; done
     docker manifest push --purge "${IMAGE}:${TAG}"
   done
 fi

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -163,11 +163,7 @@ func Ensure(s *state.State) error {
 		}
 	}
 
-	if err := cleanupAddons(s); err != nil {
-		return err
-	}
-
-	return nil
+	return cleanupAddons(s)
 }
 
 // EnsureUserAddons deploys addons that are provided by the user and that are
@@ -264,11 +260,7 @@ func EnsureAddonByName(s *state.State, addonName string) error {
 				continue
 			}
 			if a.Name() == addonName {
-				if err := applier.loadAndApplyAddon(s, applier.LocalFS, a.Name()); err != nil {
-					return err
-				}
-
-				return nil
+				return applier.loadAndApplyAddon(s, applier.LocalFS, a.Name())
 			}
 		}
 	}
@@ -283,11 +275,7 @@ func EnsureAddonByName(s *state.State, addonName string) error {
 			continue
 		}
 		if a.Name() == addonName {
-			if err := applier.loadAndApplyAddon(s, applier.EmbeddedFS, a.Name()); err != nil {
-				return err
-			}
-
-			return nil
+			return applier.loadAndApplyAddon(s, applier.EmbeddedFS, a.Name())
 		}
 	}
 
@@ -319,11 +307,7 @@ func DeleteAddonByName(s *state.State, addonName string) error {
 				continue
 			}
 			if a.Name() == addonName {
-				if err := applier.loadAndDeleteAddon(s, applier.LocalFS, a.Name()); err != nil {
-					return err
-				}
-
-				return nil
+				return applier.loadAndDeleteAddon(s, applier.LocalFS, a.Name())
 			}
 		}
 	}
@@ -338,11 +322,7 @@ func DeleteAddonByName(s *state.State, addonName string) error {
 			continue
 		}
 		if a.Name() == addonName {
-			if err := applier.loadAndDeleteAddon(s, applier.EmbeddedFS, a.Name()); err != nil {
-				return err
-			}
-
-			return nil
+			return applier.loadAndDeleteAddon(s, applier.EmbeddedFS, a.Name())
 		}
 	}
 

--- a/pkg/apis/kubeone/v1beta2/conversion.go
+++ b/pkg/apis/kubeone/v1beta2/conversion.go
@@ -24,9 +24,5 @@ import (
 
 func Convert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in *kubeoneapi.KubeOneCluster, out *KubeOneCluster, scope conversion.Scope) error {
 	// AssetsConfiguration has been removed in the v1beta2 API
-	if err := autoConvert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in, out, scope); err != nil {
-		return err
-	}
-
-	return nil
+	return autoConvert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in, out, scope)
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -168,9 +168,8 @@ func ValidateAPIEndpoint(a kubeoneapi.APIEndpoint, fldPath *field.Path) field.Er
 			allErrs = append(allErrs, field.Invalid(fldPath, altName, "duplicates are not allowed in alternative names"))
 
 			break
-		} else {
-			visited[altName] = true
 		}
+		visited[altName] = true
 	}
 
 	return allErrs

--- a/pkg/certificate/ca.go
+++ b/pkg/certificate/ca.go
@@ -46,7 +46,7 @@ func kubernetesPKIFiles() []string {
 	}
 }
 
-func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Interface) error {
+func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	sshfs := s.Runner.NewFS()
 
 	for _, fname := range kubernetesPKIFiles() {
@@ -71,7 +71,7 @@ func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Int
 	return nil
 }
 
-func UploadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Interface) error {
+func UploadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	sshfs := s.Runner.NewFS()
 
 	for _, fname := range kubernetesPKIFiles() {

--- a/pkg/cmd/initcmd/generate.go
+++ b/pkg/cmd/initcmd/generate.go
@@ -122,11 +122,8 @@ func GenerateConfigs(opts *GenerateOpts) error {
 	}
 
 	prov := ValidProviders[opts.providerName]
-	if err := createTerraformVars(opts, prov); err != nil {
-		return err
-	}
 
-	return nil
+	return createTerraformVars(opts, prov)
 }
 
 var (

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -37,13 +37,13 @@ type localAdapter struct {
 	ctx context.Context
 }
 
-func (la *localAdapter) Open(host kubeoneapi.HostConfig) (Interface, error) {
+func (la *localAdapter) Open(_ kubeoneapi.HostConfig) (Interface, error) {
 	ctx, cancel := context.WithCancel(la.ctx)
 
 	return &localExec{ctx: ctx, cancelFn: cancel}, nil
 }
 
-func (la *localAdapter) Tunnel(host kubeoneapi.HostConfig) (Tunneler, error) {
+func (la *localAdapter) Tunnel(_ kubeoneapi.HostConfig) (Tunneler, error) {
 	ctx, cancel := context.WithCancel(la.ctx)
 
 	return &localExec{ctx: ctx, cancelFn: cancel}, nil

--- a/pkg/features/activate.go
+++ b/pkg/features/activate.go
@@ -40,11 +40,7 @@ func Activate(s *state.State) error {
 		return err
 	}
 
-	if err := installPodNodeSelector(s.Context, s.DynamicClient, s.Cluster.Features.PodNodeSelector); err != nil {
-		return err
-	}
-
-	return nil
+	return installPodNodeSelector(s.Context, s.DynamicClient, s.Cluster.Features.PodNodeSelector)
 }
 
 // UpdateKubeadmClusterConfiguration update additional config options in the kubeadm's

--- a/pkg/scripts/configs.go
+++ b/pkg/scripts/configs.go
@@ -102,7 +102,7 @@ func SaveEncryptionProvidersConfig(workdir, fileName string) (string, error) {
 	return result, fail.Runtime(err, "rendering encryptionProvidersConfigTemplate script")
 }
 
-func DeleteEncryptionProvidersConfig(fileName string) string {
+func DeleteEncryptionProvidersConfig() string {
 	return deleteEncryptionProvidersConfigTemplate
 }
 

--- a/pkg/tabwriter/tabwriter.go
+++ b/pkg/tabwriter/tabwriter.go
@@ -32,10 +32,10 @@ const (
 
 // New returns a tabwriter that translates tabbed columns in input into properly aligned text.
 func New(output io.Writer) *tabwriter.Writer {
-	return tabwriter.NewWriter(output, tabwriterMinWidth, tabwriterWidth, tabwriterPadding, tabwriterPadChar, tabwriterFlags)
+	return NewWithPadding(output, tabwriterPadding)
 }
 
 // New returns a tabwriter that translates tabbed columns in input into properly aligned text.
 func NewWithPadding(output io.Writer, padding int) *tabwriter.Writer {
-	return tabwriter.NewWriter(output, tabwriterMinWidth, tabwriterWidth, 1, tabwriterPadChar, tabwriterFlags)
+	return tabwriter.NewWriter(output, tabwriterMinWidth, tabwriterWidth, padding, tabwriterPadChar, tabwriterFlags)
 }

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -151,11 +151,8 @@ func ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfigInternal(s *stat
 	}
 
 	logger.Infoln("Uncordoning node...")
-	if err := drainer.Cordon(s.Context, node.Hostname, false); err != nil {
-		return err
-	}
 
-	return nil
+	return drainer.Cordon(s.Context, node.Hostname, false)
 }
 
 func ccmMigrationUpdateStaticWorkersKubeletConfig(s *state.State) error {
@@ -201,11 +198,8 @@ func ccmMigrationUpdateStaticWorkersKubeletConfigInternal(s *state.State, node *
 	}
 
 	logger.Infoln("Uncordoning node...")
-	if err := drainer.Cordon(s.Context, node.Hostname, false); err != nil {
-		return err
-	}
 
-	return nil
+	return drainer.Cordon(s.Context, node.Hostname, false)
 }
 
 func ccmMigrationUpdateKubeletConfigFile(s *state.State) error {

--- a/pkg/tasks/certs.go
+++ b/pkg/tasks/certs.go
@@ -179,7 +179,7 @@ func saveCABundleOnControlPlane(s *state.State, _ *kubeoneapi.HostConfig, conn e
 	return fail.SSH(err, "save CABundle")
 }
 
-func restartKubelet(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func restartKubelet(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.WithField("node", node.PublicAddress).Debug("Restarting Kubelet to force regenerating CSRs...")
 
 	_, _, err := s.Runner.RunRaw(scripts.RestartKubelet())
@@ -205,7 +205,7 @@ func restartKubeletOnControlPlane(s *state.State) error {
 	return nil
 }
 
-func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	var csrFound bool
 	sleepTime := 20 * time.Second
 	s.Logger.Infof("Waiting %s for CSRs to approve...", sleepTime)

--- a/pkg/tasks/containerd.go
+++ b/pkg/tasks/containerd.go
@@ -82,7 +82,7 @@ func migrateToContainerd(s *state.State) error {
 	return s.RunTaskOnAllNodes(migrateToContainerdTask, state.RunSequentially)
 }
 
-func migrateToContainerdTask(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func migrateToContainerdTask(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Info("Migrating container runtime to containerd")
 
 	err := updateRemoteFile(s, kubeadmEnvFlagsFile, func(content []byte) ([]byte, error) {

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -55,7 +55,7 @@ func joinControlPlaneNodeInternal(s *state.State, node *kubeoneapi.HostConfig, c
 	return approvePendingCSR(s, node, conn)
 }
 
-func kubeadmCertsExecutor(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func kubeadmCertsExecutor(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Ensuring Certificates...")
 	cmd, err := scripts.KubeadmCert(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
 	if err != nil {

--- a/pkg/tasks/encryption_providers.go
+++ b/pkg/tasks/encryption_providers.go
@@ -147,7 +147,7 @@ func uploadEncryptionConfigurationWithoutOldKey(s *state.State) error {
 	return s.RunTaskOnControlPlane(pushEncryptionConfigurationOnNode, state.RunParallel)
 }
 
-func pushEncryptionConfigurationOnNode(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func pushEncryptionConfigurationOnNode(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Interface) error {
 	err := s.Configuration.UploadTo(conn, s.WorkDir)
 	if err != nil {
 		return err
@@ -193,9 +193,7 @@ func removeEncryptionProviderFile(s *state.State) error {
 	s.Logger.Infof("Removing EncryptionProviders configuration file...")
 
 	return s.RunTaskOnControlPlane(func(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
-		cmd := scripts.DeleteEncryptionProvidersConfig(s.GetEncryptionProviderConfigName())
-
-		_, _, err := s.Runner.RunRaw(cmd)
+		_, _, err := s.Runner.RunRaw(scripts.DeleteEncryptionProvidersConfig())
 
 		return fail.SSH(err, "deleting encryption providers config")
 	}, state.RunParallel)

--- a/pkg/tasks/kubeadm_config.go
+++ b/pkg/tasks/kubeadm_config.go
@@ -35,7 +35,7 @@ func determinePauseImage(s *state.State) error {
 	})
 }
 
-func determinePauseImageExecutor(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func determinePauseImageExecutor(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	cmd, err := scripts.KubeadmPauseImageVersion(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return err

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -122,11 +122,8 @@ func setupProxy(logger *logrus.Entry, s *state.State) error {
 	}
 
 	logger.Infoln("Configuring proxy...")
-	if err := containerRuntimeEnvironment(s); err != nil {
-		return err
-	}
 
-	return nil
+	return containerRuntimeEnvironment(s)
 }
 
 func createEnvironmentFile(s *state.State) error {

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -156,11 +156,7 @@ func safeguard(s *state.State) error {
 		return err
 	}
 
-	if err := safeguardFlatcarMachineDeployments(s); err != nil {
-		return err
-	}
-
-	return nil
+	return safeguardFlatcarMachineDeployments(s)
 }
 
 // safeguardNodeTaints ensures that there are no Nodes running Kubernetes 1.25

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -103,7 +103,7 @@ func resetAllNodes(s *state.State) error {
 	return s.RunTaskOnAllNodes(resetNode, state.RunSequentially)
 }
 
-func resetNode(s *state.State, host *kubeoneapi.HostConfig, conn executor.Interface) error {
+func resetNode(s *state.State, host *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Resetting node...")
 
 	cmd, err := scripts.KubeadmReset(s.KubeadmVerboseFlag(), s.WorkDir)
@@ -126,7 +126,7 @@ func removeBinariesAllNodes(s *state.State) error {
 	return s.RunTaskOnAllNodes(removeBinaries, state.RunParallel)
 }
 
-func removeBinaries(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func removeBinaries(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Removing Kubernetes binaries")
 	var err error
 

--- a/pkg/templates/encryptionproviders/encryption_providers.go
+++ b/pkg/templates/encryptionproviders/encryption_providers.go
@@ -39,7 +39,7 @@ func generateAESCBCSecret() (string, error) {
 	return base64.StdEncoding.EncodeToString(buf), nil
 }
 
-func NewEncryptionProvidersConfig(s *state.State) (*apiserverconfigv1.EncryptionConfiguration, error) {
+func NewEncryptionProvidersConfig(_ *state.State) (*apiserverconfigv1.EncryptionConfiguration, error) {
 	secret, err := generateAESCBCSecret()
 	if err != nil {
 		return nil, err

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -59,11 +59,7 @@ func WaitReady(s *state.State) error {
 		return err
 	}
 
-	if err := waitForCRDs(s); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForCRDs(s)
 }
 
 // waitForCRDs waits for machine-controller CRDs to be created and become established

--- a/pkg/templates/operatingsystemmanager/helper.go
+++ b/pkg/templates/operatingsystemmanager/helper.go
@@ -48,11 +48,7 @@ func WaitReady(s *state.State) error {
 		return err
 	}
 
-	if err := waitForCRDs(s); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForCRDs(s)
 }
 
 // waitForCRDs waits for operating-system-manager CRDs to be created and become established

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8"
+	prowImage             = "quay.io/kubermatic/build:go-1.19-node-18-16"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -328,7 +328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -351,7 +351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -374,7 +374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -397,7 +397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -420,7 +420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -443,7 +443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -466,7 +466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -489,7 +489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -512,7 +512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -536,7 +536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -559,7 +559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -582,7 +582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -605,7 +605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -630,7 +630,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -655,7 +655,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -680,7 +680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -706,7 +706,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -731,7 +731,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -754,7 +754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -777,7 +777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -800,7 +800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -823,7 +823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -846,7 +846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -869,7 +869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -892,7 +892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -915,7 +915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -938,7 +938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -961,7 +961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -984,7 +984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1008,7 +1008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1031,7 +1031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1054,7 +1054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1077,7 +1077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1102,7 +1102,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1127,7 +1127,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1152,7 +1152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1178,7 +1178,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1203,7 +1203,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1226,7 +1226,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1249,7 +1249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1272,7 +1272,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1295,7 +1295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1318,7 +1318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1341,7 +1341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1364,7 +1364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1387,7 +1387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1410,7 +1410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1438,7 +1438,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1466,7 +1466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1494,7 +1494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1522,7 +1522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1550,7 +1550,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1578,7 +1578,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1608,7 +1608,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1638,7 +1638,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1668,7 +1668,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1699,7 +1699,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1729,7 +1729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1757,7 +1757,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1785,7 +1785,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1813,7 +1813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1841,7 +1841,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1869,7 +1869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1897,7 +1897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1925,7 +1925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1953,7 +1953,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1981,7 +1981,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2009,7 +2009,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2037,7 +2037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2065,7 +2065,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2093,7 +2093,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2121,7 +2121,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2149,7 +2149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2179,7 +2179,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2209,7 +2209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2239,7 +2239,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2270,7 +2270,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2300,7 +2300,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2328,7 +2328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2356,7 +2356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2384,7 +2384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2412,7 +2412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2440,7 +2440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2468,7 +2468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2496,7 +2496,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2524,7 +2524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2552,7 +2552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2575,7 +2575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2598,7 +2598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2621,7 +2621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2644,7 +2644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2667,7 +2667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2690,7 +2690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2715,7 +2715,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2740,7 +2740,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2765,7 +2765,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2791,7 +2791,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2816,7 +2816,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2839,7 +2839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2862,7 +2862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2885,7 +2885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2908,7 +2908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2931,7 +2931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2954,7 +2954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2977,7 +2977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3000,7 +3000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3023,7 +3023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3046,7 +3046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3069,7 +3069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3092,7 +3092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3115,7 +3115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3138,7 +3138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3161,7 +3161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3186,7 +3186,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3211,7 +3211,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3236,7 +3236,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3262,7 +3262,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3287,7 +3287,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3310,7 +3310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3333,7 +3333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3356,7 +3356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3379,7 +3379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3402,7 +3402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3425,7 +3425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3448,7 +3448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3471,7 +3471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3494,7 +3494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3517,7 +3517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3540,7 +3540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3563,7 +3563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3586,7 +3586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3609,7 +3609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3632,7 +3632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3657,7 +3657,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3682,7 +3682,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3707,7 +3707,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3733,7 +3733,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3758,7 +3758,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3781,7 +3781,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3804,7 +3804,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3827,7 +3827,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3850,7 +3850,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3873,7 +3873,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3896,7 +3896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3919,7 +3919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3942,7 +3942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3965,7 +3965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3990,7 +3990,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4015,7 +4015,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4040,7 +4040,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4065,7 +4065,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4090,7 +4090,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4115,7 +4115,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4138,7 +4138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4161,7 +4161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4184,7 +4184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4207,7 +4207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4230,7 +4230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4253,7 +4253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4276,7 +4276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4301,7 +4301,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4326,7 +4326,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4351,7 +4351,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4377,7 +4377,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4402,7 +4402,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4425,7 +4425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4448,7 +4448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4471,7 +4471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4494,7 +4494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4517,7 +4517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4540,7 +4540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4563,7 +4563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4586,7 +4586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4609,7 +4609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4632,7 +4632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4655,7 +4655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4678,7 +4678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4701,7 +4701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4724,7 +4724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4747,7 +4747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4772,7 +4772,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4797,7 +4797,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4822,7 +4822,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4848,7 +4848,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4873,7 +4873,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4896,7 +4896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4919,7 +4919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4942,7 +4942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4965,7 +4965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4988,7 +4988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5011,7 +5011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5034,7 +5034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5057,7 +5057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5080,7 +5080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5103,7 +5103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5126,7 +5126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5149,7 +5149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5172,7 +5172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5195,7 +5195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5218,7 +5218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5243,7 +5243,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5268,7 +5268,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5293,7 +5293,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5319,7 +5319,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5344,7 +5344,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5367,7 +5367,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5390,7 +5390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5413,7 +5413,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5436,7 +5436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5459,7 +5459,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5482,7 +5482,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5505,7 +5505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5528,7 +5528,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5551,7 +5551,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5574,7 +5574,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5597,7 +5597,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5620,7 +5620,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5643,7 +5643,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5666,7 +5666,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5689,7 +5689,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5712,7 +5712,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5735,7 +5735,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5758,7 +5758,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5781,7 +5781,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5804,7 +5804,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5829,7 +5829,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5854,7 +5854,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5879,7 +5879,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5905,7 +5905,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5930,7 +5930,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5953,7 +5953,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5976,7 +5976,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5999,7 +5999,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6022,7 +6022,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6045,7 +6045,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6068,7 +6068,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6091,7 +6091,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6114,7 +6114,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6137,7 +6137,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6160,7 +6160,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6183,7 +6183,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6206,7 +6206,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6229,7 +6229,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6252,7 +6252,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6277,7 +6277,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6302,7 +6302,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6327,7 +6327,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6353,7 +6353,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6378,7 +6378,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6401,7 +6401,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6424,7 +6424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6447,7 +6447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6470,7 +6470,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6493,7 +6493,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6516,7 +6516,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6539,7 +6539,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6562,7 +6562,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6585,7 +6585,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6608,7 +6608,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6631,7 +6631,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6654,7 +6654,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6677,7 +6677,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6700,7 +6700,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6725,7 +6725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6750,7 +6750,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6775,7 +6775,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6801,7 +6801,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6826,7 +6826,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6849,7 +6849,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6872,7 +6872,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6895,7 +6895,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6918,7 +6918,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6941,7 +6941,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6964,7 +6964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6987,7 +6987,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7010,7 +7010,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7033,7 +7033,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7058,7 +7058,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7083,7 +7083,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7108,7 +7108,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7134,7 +7134,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7159,7 +7159,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7182,7 +7182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7205,7 +7205,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7228,7 +7228,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7251,7 +7251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7274,7 +7274,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7297,7 +7297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7320,7 +7320,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7343,7 +7343,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7366,7 +7366,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7389,7 +7389,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7412,7 +7412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7435,7 +7435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7458,7 +7458,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7481,7 +7481,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7504,7 +7504,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7527,7 +7527,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7550,7 +7550,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7573,7 +7573,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7596,7 +7596,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7619,7 +7619,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7642,7 +7642,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7665,7 +7665,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7688,7 +7688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7711,7 +7711,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7736,7 +7736,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7761,7 +7761,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7786,7 +7786,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7812,7 +7812,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7837,7 +7837,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7860,7 +7860,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7883,7 +7883,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7906,7 +7906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7929,7 +7929,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7952,7 +7952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7975,7 +7975,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7998,7 +7998,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8021,7 +8021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8044,7 +8044,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8067,7 +8067,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8090,7 +8090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8113,7 +8113,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8136,7 +8136,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8159,7 +8159,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8182,7 +8182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8205,7 +8205,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8228,7 +8228,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8251,7 +8251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8274,7 +8274,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8297,7 +8297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8320,7 +8320,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8343,7 +8343,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8366,7 +8366,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8389,7 +8389,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8414,7 +8414,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8439,7 +8439,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8464,7 +8464,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8490,7 +8490,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8515,7 +8515,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8538,7 +8538,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8561,7 +8561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8584,7 +8584,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8607,7 +8607,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8630,7 +8630,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8653,7 +8653,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8676,7 +8676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8699,7 +8699,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8722,7 +8722,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8745,7 +8745,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8768,7 +8768,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8791,7 +8791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8814,7 +8814,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8837,7 +8837,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8860,7 +8860,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8883,7 +8883,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8906,7 +8906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8929,7 +8929,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8957,7 +8957,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8985,7 +8985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9013,7 +9013,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9041,7 +9041,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9069,7 +9069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9097,7 +9097,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9127,7 +9127,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9157,7 +9157,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9187,7 +9187,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9218,7 +9218,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9248,7 +9248,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9276,7 +9276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9304,7 +9304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9332,7 +9332,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9360,7 +9360,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9388,7 +9388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9416,7 +9416,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9444,7 +9444,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9472,7 +9472,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9500,7 +9500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9528,7 +9528,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9556,7 +9556,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9584,7 +9584,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9612,7 +9612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9640,7 +9640,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9668,7 +9668,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9696,7 +9696,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9724,7 +9724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9752,7 +9752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9780,7 +9780,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9808,7 +9808,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9836,7 +9836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9864,7 +9864,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9892,7 +9892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9920,7 +9920,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9950,7 +9950,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9980,7 +9980,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10010,7 +10010,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10041,7 +10041,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10071,7 +10071,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10099,7 +10099,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10127,7 +10127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10155,7 +10155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10183,7 +10183,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10211,7 +10211,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10239,7 +10239,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10267,7 +10267,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10295,7 +10295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10323,7 +10323,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10351,7 +10351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10379,7 +10379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10407,7 +10407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10435,7 +10435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10463,7 +10463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10491,7 +10491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10519,7 +10519,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10547,7 +10547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10575,7 +10575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10598,7 +10598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10621,7 +10621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10644,7 +10644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10667,7 +10667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10690,7 +10690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10713,7 +10713,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10738,7 +10738,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10763,7 +10763,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10788,7 +10788,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10814,7 +10814,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10839,7 +10839,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10862,7 +10862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10885,7 +10885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10908,7 +10908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10931,7 +10931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10954,7 +10954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10977,7 +10977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11000,7 +11000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11023,7 +11023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11046,7 +11046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11069,7 +11069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11092,7 +11092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11115,7 +11115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11138,7 +11138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11161,7 +11161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11184,7 +11184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11207,7 +11207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11230,7 +11230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11253,7 +11253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11276,7 +11276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11299,7 +11299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11322,7 +11322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11345,7 +11345,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11368,7 +11368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11391,7 +11391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11416,7 +11416,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11441,7 +11441,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11466,7 +11466,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11492,7 +11492,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11517,7 +11517,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11540,7 +11540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11563,7 +11563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11586,7 +11586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11609,7 +11609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11632,7 +11632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11655,7 +11655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11678,7 +11678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11701,7 +11701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11724,7 +11724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11747,7 +11747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11770,7 +11770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11793,7 +11793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11816,7 +11816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11839,7 +11839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11862,7 +11862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11885,7 +11885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11908,7 +11908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11931,7 +11931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11954,7 +11954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11977,7 +11977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12000,7 +12000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12023,7 +12023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12046,7 +12046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12069,7 +12069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12094,7 +12094,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12119,7 +12119,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12144,7 +12144,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12170,7 +12170,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12195,7 +12195,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12218,7 +12218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12241,7 +12241,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12264,7 +12264,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12287,7 +12287,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12310,7 +12310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12333,7 +12333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12356,7 +12356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12379,7 +12379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12402,7 +12402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12425,7 +12425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12448,7 +12448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12471,7 +12471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12494,7 +12494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12517,7 +12517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12540,7 +12540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12563,7 +12563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12586,7 +12586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12609,7 +12609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is combined backport of #2807 and #2808 to the `release/v1.6` branch.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use buildx instead of Buildah to create multi-architecture KubeOne container images.
```

**Documentation**:
```documentation
NONE
```