### PR TITLE
[release/v1.5] Migrate from buildah to buildx

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push-kubermatic: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+        - image: quay.io/kubermatic/build:go-1.19-node-18-16
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+        - image: quay.io/kubermatic/build:go-1.19-node-18-16
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -135,7 +135,7 @@ presubmits:
               memory: 1Gi
               cpu: 4
             limits:
-              memory: 2Gi
+              memory: 3Gi
   - name: pull-kubeone-build-image
     always_run: true
     decorate: true

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.8
+        - image: golang:1.19.10
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-9
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-16
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.8 as builder
+FROM docker.io/golang:1.19.10 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -27,55 +27,56 @@ set -o monitor
 
 source $(dirname $0)/../lib.sh
 
-DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
+IMAGE="${IMAGE:-quay.io/kubermatic/kubeone}"
 ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
 NOMOCK=${NOMOCK:-false}
 
 PRIMARY_TAG="$(git rev-parse HEAD | tr -d '\n')"
 TAGS=${TAGS:-}
 
-gocaches="$(mktemp -d)"
+gocaches="./gocaches"
 for ARCH in ${ARCHITECTURES}; do
   cacheDir="$gocaches/$ARCH"
   mkdir -p "$cacheDir"
  
   # try to get a gocache for this arch; this can "fail" but still exit with 0
-  echodate "Attempting to fetch gocache for $ARCH..."
-  TARGET_DIRECTORY="$cacheDir" GOARCH="$ARCH" ./hack/ci/download-gocache.sh
+  echodate "Attempting to fetch gocache for ${ARCH}..."
+  TARGET_DIRECTORY="$cacheDir" GOARCH="${ARCH}" ./hack/ci/download-gocache.sh
 done
 
-echodate "Building ${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+echodate "Building ${IMAGE}:${PRIMARY_TAG}"
 
 # build multi-arch images
-buildah manifest create "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
-for ARCH in ${ARCHITECTURES}; do
-  echodate "Building a KubeOne image for $ARCH..."
+docker buildx rm k8c-k1-release || true
+docker buildx create --use --name=k8c-k1-release
 
-  # Building via buildah does not use the gocache, but that's okay, because we
-  # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
-  # cache size and force every e2e test to download gigabytes worth of unneeded
-  # arm64 stuff. We might need to change this once we run e2e tests on arm64.
-  buildah bud \
-    --tag="${DOCKER_REPO}/kubeone-${ARCH}:${PRIMARY_TAG}" \
+for ARCH in ${ARCHITECTURES}; do
+  echodate "Building a KubeOne image for ${ARCH}..."
+
+  docker buildx build \
+    --load \
+    --progress=plain \
+    --platform="linux/${ARCH}" \
     --build-arg="GOPROXY=${GOPROXY:-}" \
-    --build-arg="GOCACHE=/gocache" \
-    --arch="$ARCH" \
-    --override-arch="$ARCH" \
-    --format=docker \
-    --file Dockerfile \
-    --volume "$gocaches/$ARCH:/gocache" \
-    .
-  buildah manifest add "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeone-${ARCH}:${PRIMARY_TAG}"
+    --build-arg="GOCACHE=/go/src/k8c.io/kubeone/gocaches/${ARCH}" \
+    --file="Dockerfile" \
+    --tag "${IMAGE}-${ARCH}:${PRIMARY_TAG}" .
 done
 
 if [ "$NOMOCK" = true ]; then
-  echodate "Pushing ${DOCKER_REPO}/kubeone:${PRIMARY_TAG}..."
-  buildah manifest push --all "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "docker://${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+  for ARCH in ${ARCHITECTURES}; do
+    echodate "Pushing ${IMAGE}-${ARCH}:${PRIMARY_TAG}..."
+    docker push "${IMAGE}-${ARCH}:${PRIMARY_TAG}"
+  done
+
+  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
+  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+  docker manifest push --purge "${IMAGE}:${PRIMARY_TAG}"
 
   for TAG in ${TAGS}; do
-    echodate "Pushing ${DOCKER_REPO}/kubeone:${TAG}..."
-    buildah tag "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeone:${TAG}"
-    buildah manifest push --all "${DOCKER_REPO}/kubeone:${TAG}" "docker://${DOCKER_REPO}/kubeone:${TAG}"
+    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
+    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+    docker manifest push --purge "${IMAGE}:${TAG}"
   done
 fi
 

--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -60,22 +60,22 @@ for ARCH in ${ARCHITECTURES}; do
     --build-arg="GOPROXY=${GOPROXY:-}" \
     --build-arg="GOCACHE=/go/src/k8c.io/kubeone/gocaches/${ARCH}" \
     --file="Dockerfile" \
-    --tag "${IMAGE}-${ARCH}:${PRIMARY_TAG}" .
+    --tag "${IMAGE}:${PRIMARY_TAG}-${ARCH}" .
 done
 
 if [ "$NOMOCK" = true ]; then
   for ARCH in ${ARCHITECTURES}; do
-    echodate "Pushing ${IMAGE}-${ARCH}:${PRIMARY_TAG}..."
-    docker push "${IMAGE}-${ARCH}:${PRIMARY_TAG}"
+    echodate "Pushing ${IMAGE}:${PRIMARY_TAG}-${ARCH}..."
+    docker push "${IMAGE}:${PRIMARY_TAG}-${ARCH}"
   done
 
-  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
-  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+  docker manifest create --amend "${IMAGE}:${PRIMARY_TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}:${PRIMARY_TAG}\-&~g")
+  for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${PRIMARY_TAG}" "${IMAGE}:${PRIMARY_TAG}-${ARCH}"; done
   docker manifest push --purge "${IMAGE}:${PRIMARY_TAG}"
 
   for TAG in ${TAGS}; do
-    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}\-&:${PRIMARY_TAG}~g")
-    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}-${ARCH}:${PRIMARY_TAG}"; done
+    docker manifest create --amend "${IMAGE}:${TAG}" $(echo "${ARCHITECTURES}" | sed -e "s~[^ ]*~${IMAGE}:${PRIMARY_TAG}\-&~g")
+    for ARCH in ${ARCHITECTURES}; do docker manifest annotate --arch "${ARCH}" "${IMAGE}:${TAG}" "${IMAGE}:${PRIMARY_TAG}-${ARCH}"; done
     docker manifest push --purge "${IMAGE}:${TAG}"
   done
 fi

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -169,11 +169,7 @@ func Ensure(s *state.State) error {
 		}
 	}
 
-	if err := cleanupAddons(s); err != nil {
-		return err
-	}
-
-	return nil
+	return cleanupAddons(s)
 }
 
 // EnsureUserAddons deploys addons that are provided by the user and that are
@@ -270,11 +266,7 @@ func EnsureAddonByName(s *state.State, addonName string) error {
 				continue
 			}
 			if a.Name() == addonName {
-				if err := applier.loadAndApplyAddon(s, applier.LocalFS, a.Name()); err != nil {
-					return err
-				}
-
-				return nil
+				return applier.loadAndApplyAddon(s, applier.LocalFS, a.Name())
 			}
 		}
 	}
@@ -289,11 +281,7 @@ func EnsureAddonByName(s *state.State, addonName string) error {
 			continue
 		}
 		if a.Name() == addonName {
-			if err := applier.loadAndApplyAddon(s, applier.EmbeddedFS, a.Name()); err != nil {
-				return err
-			}
-
-			return nil
+			return applier.loadAndApplyAddon(s, applier.EmbeddedFS, a.Name())
 		}
 	}
 
@@ -325,11 +313,7 @@ func DeleteAddonByName(s *state.State, addonName string) error {
 				continue
 			}
 			if a.Name() == addonName {
-				if err := applier.loadAndDeleteAddon(s, applier.LocalFS, a.Name()); err != nil {
-					return err
-				}
-
-				return nil
+				return applier.loadAndDeleteAddon(s, applier.LocalFS, a.Name())
 			}
 		}
 	}
@@ -344,11 +328,7 @@ func DeleteAddonByName(s *state.State, addonName string) error {
 			continue
 		}
 		if a.Name() == addonName {
-			if err := applier.loadAndDeleteAddon(s, applier.EmbeddedFS, a.Name()); err != nil {
-				return err
-			}
-
-			return nil
+			return applier.loadAndDeleteAddon(s, applier.EmbeddedFS, a.Name())
 		}
 	}
 

--- a/pkg/apis/kubeone/v1beta2/conversion.go
+++ b/pkg/apis/kubeone/v1beta2/conversion.go
@@ -24,9 +24,5 @@ import (
 
 func Convert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in *kubeoneapi.KubeOneCluster, out *KubeOneCluster, scope conversion.Scope) error {
 	// AssetsConfiguration has been removed in the v1beta2 API
-	if err := autoConvert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in, out, scope); err != nil {
-		return err
-	}
-
-	return nil
+	return autoConvert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in, out, scope)
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -72,7 +72,7 @@ func ValidateKubeOneCluster(c kubeoneapi.KubeOneCluster) field.ErrorList {
 	}
 
 	allErrs = append(allErrs, ValidateCABundle(c.CABundle, field.NewPath("caBundle"))...)
-	allErrs = append(allErrs, ValidateFeatures(c.Features, c.Versions, field.NewPath("features"))...)
+	allErrs = append(allErrs, ValidateFeatures(c.Features, field.NewPath("features"))...)
 	allErrs = append(allErrs, ValidateAddons(c.Addons, field.NewPath("addons"))...)
 	allErrs = append(allErrs, ValidateRegistryConfiguration(c.RegistryConfiguration, field.NewPath("registryConfiguration"))...)
 	allErrs = append(allErrs,
@@ -161,9 +161,8 @@ func ValidateAPIEndpoint(a kubeoneapi.APIEndpoint, fldPath *field.Path) field.Er
 			allErrs = append(allErrs, field.Invalid(fldPath, altName, "duplicates are not allowed in alternative names"))
 
 			break
-		} else {
-			visited[altName] = true
 		}
+		visited[altName] = true
 	}
 
 	return allErrs
@@ -480,7 +479,7 @@ func ValidateCABundle(caBundle string, fldPath *field.Path) field.ErrorList {
 }
 
 // ValidateFeatures validates the Features structure
-func ValidateFeatures(f kubeoneapi.Features, versions kubeoneapi.VersionConfig, fldPath *field.Path) field.ErrorList {
+func ValidateFeatures(f kubeoneapi.Features, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if f.CoreDNS != nil && f.CoreDNS.Replicas != nil && *f.CoreDNS.Replicas < 0 {

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1518,7 +1518,7 @@ func TestValidateFeatures(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			errs := ValidateFeatures(tc.features, tc.versions, nil)
+			errs := ValidateFeatures(tc.features, nil)
 			if (len(errs) == 0) == tc.expectedError {
 				t.Errorf("test case failed: expected %v, but got %v", tc.expectedError, (len(errs) != 0))
 			}

--- a/pkg/certificate/ca.go
+++ b/pkg/certificate/ca.go
@@ -46,7 +46,7 @@ func kubernetesPKIFiles() []string {
 	}
 }
 
-func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Interface) error {
+func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	sshfs := s.Runner.NewFS()
 
 	for _, fname := range kubernetesPKIFiles() {
@@ -71,7 +71,7 @@ func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Int
 	return nil
 }
 
-func UploadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Interface) error {
+func UploadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	sshfs := s.Runner.NewFS()
 
 	for _, fname := range kubernetesPKIFiles() {

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -145,6 +145,7 @@ func TestOpenstackValidationFunc(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := openstackValidationFunc(tt.creds)

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -37,13 +37,13 @@ type localAdapter struct {
 	ctx context.Context
 }
 
-func (la *localAdapter) Open(host kubeoneapi.HostConfig) (Interface, error) {
+func (la *localAdapter) Open(_ kubeoneapi.HostConfig) (Interface, error) {
 	ctx, cancel := context.WithCancel(la.ctx)
 
 	return &localExec{ctx: ctx, cancelFn: cancel}, nil
 }
 
-func (la *localAdapter) Tunnel(host kubeoneapi.HostConfig) (Tunneler, error) {
+func (la *localAdapter) Tunnel(_ kubeoneapi.HostConfig) (Tunneler, error) {
 	ctx, cancel := context.WithCancel(la.ctx)
 
 	return &localExec{ctx: ctx, cancelFn: cancel}, nil

--- a/pkg/features/activate.go
+++ b/pkg/features/activate.go
@@ -40,11 +40,7 @@ func Activate(s *state.State) error {
 		return err
 	}
 
-	if err := installPodNodeSelector(s.Context, s.DynamicClient, s.Cluster.Features.PodNodeSelector); err != nil {
-		return err
-	}
-
-	return nil
+	return installPodNodeSelector(s.Context, s.DynamicClient, s.Cluster.Features.PodNodeSelector)
 }
 
 // UpdateKubeadmClusterConfiguration update additional config options in the kubeadm's

--- a/pkg/scripts/configs.go
+++ b/pkg/scripts/configs.go
@@ -102,7 +102,7 @@ func SaveEncryptionProvidersConfig(workdir, fileName string) (string, error) {
 	return result, fail.Runtime(err, "rendering encryptionProvidersConfigTemplate script")
 }
 
-func DeleteEncryptionProvidersConfig(fileName string) string {
+func DeleteEncryptionProvidersConfig() string {
 	return deleteEncryptionProvidersConfigTemplate
 }
 

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -151,11 +151,8 @@ func ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfigInternal(s *stat
 	}
 
 	logger.Infoln("Uncordoning node...")
-	if err := drainer.Cordon(s.Context, node.Hostname, false); err != nil {
-		return err
-	}
 
-	return nil
+	return drainer.Cordon(s.Context, node.Hostname, false)
 }
 
 func ccmMigrationUpdateStaticWorkersKubeletConfig(s *state.State) error {
@@ -201,11 +198,8 @@ func ccmMigrationUpdateStaticWorkersKubeletConfigInternal(s *state.State, node *
 	}
 
 	logger.Infoln("Uncordoning node...")
-	if err := drainer.Cordon(s.Context, node.Hostname, false); err != nil {
-		return err
-	}
 
-	return nil
+	return drainer.Cordon(s.Context, node.Hostname, false)
 }
 
 func ccmMigrationUpdateKubeletConfigFile(s *state.State) error {

--- a/pkg/tasks/certs.go
+++ b/pkg/tasks/certs.go
@@ -179,7 +179,7 @@ func saveCABundleOnControlPlane(s *state.State, _ *kubeoneapi.HostConfig, conn e
 	return fail.SSH(err, "save CABundle")
 }
 
-func restartKubelet(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func restartKubelet(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.WithField("node", node.PublicAddress).Debug("Restarting Kubelet to force regenerating CSRs...")
 
 	_, _, err := s.Runner.RunRaw(scripts.RestartKubelet())
@@ -205,7 +205,7 @@ func restartKubeletOnControlPlane(s *state.State) error {
 	return nil
 }
 
-func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	var csrFound bool
 	sleepTime := 20 * time.Second
 	s.Logger.Infof("Waiting %s for CSRs to approve...", sleepTime)

--- a/pkg/tasks/containerd.go
+++ b/pkg/tasks/containerd.go
@@ -82,7 +82,7 @@ func migrateToContainerd(s *state.State) error {
 	return s.RunTaskOnAllNodes(migrateToContainerdTask, state.RunSequentially)
 }
 
-func migrateToContainerdTask(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func migrateToContainerdTask(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Info("Migrating container runtime to containerd")
 
 	err := updateRemoteFile(s, kubeadmEnvFlagsFile, func(content []byte) ([]byte, error) {

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -55,7 +55,7 @@ func joinControlPlaneNodeInternal(s *state.State, node *kubeoneapi.HostConfig, c
 	return approvePendingCSR(s, node, conn)
 }
 
-func kubeadmCertsExecutor(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func kubeadmCertsExecutor(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Ensuring Certificates...")
 	cmd, err := scripts.KubeadmCert(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
 	if err != nil {

--- a/pkg/tasks/encryption_providers.go
+++ b/pkg/tasks/encryption_providers.go
@@ -147,7 +147,7 @@ func uploadEncryptionConfigurationWithoutOldKey(s *state.State) error {
 	return s.RunTaskOnControlPlane(pushEncryptionConfigurationOnNode, state.RunParallel)
 }
 
-func pushEncryptionConfigurationOnNode(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func pushEncryptionConfigurationOnNode(s *state.State, _ *kubeoneapi.HostConfig, conn executor.Interface) error {
 	err := s.Configuration.UploadTo(conn, s.WorkDir)
 	if err != nil {
 		return err
@@ -193,9 +193,7 @@ func removeEncryptionProviderFile(s *state.State) error {
 	s.Logger.Infof("Removing EncryptionProviders configuration file...")
 
 	return s.RunTaskOnControlPlane(func(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
-		cmd := scripts.DeleteEncryptionProvidersConfig(s.GetEncryptionProviderConfigName())
-
-		_, _, err := s.Runner.RunRaw(cmd)
+		_, _, err := s.Runner.RunRaw(scripts.DeleteEncryptionProvidersConfig())
 
 		return fail.SSH(err, "deleting encryption providers config")
 	}, state.RunParallel)

--- a/pkg/tasks/kubeadm_config.go
+++ b/pkg/tasks/kubeadm_config.go
@@ -35,7 +35,7 @@ func determinePauseImage(s *state.State) error {
 	})
 }
 
-func determinePauseImageExecutor(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func determinePauseImageExecutor(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	cmd, err := scripts.KubeadmPauseImageVersion(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return err

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -122,11 +122,8 @@ func setupProxy(logger *logrus.Entry, s *state.State) error {
 	}
 
 	logger.Infoln("Configuring proxy...")
-	if err := containerRuntimeEnvironment(s); err != nil {
-		return err
-	}
 
-	return nil
+	return containerRuntimeEnvironment(s)
 }
 
 func createEnvironmentFile(s *state.State) error {

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -152,11 +152,7 @@ func safeguard(s *state.State) error {
 		return err
 	}
 
-	if err := safeguardFlatcarMachineDeployments(s); err != nil {
-		return err
-	}
-
-	return nil
+	return safeguardFlatcarMachineDeployments(s)
 }
 
 // safeguardNodeSelectorsAndTolerations ensures that there are no pods that have:

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -103,7 +103,7 @@ func resetAllNodes(s *state.State) error {
 	return s.RunTaskOnAllNodes(resetNode, state.RunSequentially)
 }
 
-func resetNode(s *state.State, host *kubeoneapi.HostConfig, conn executor.Interface) error {
+func resetNode(s *state.State, host *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Resetting node...")
 
 	cmd, err := scripts.KubeadmReset(s.KubeadmVerboseFlag(), s.WorkDir)
@@ -126,7 +126,7 @@ func removeBinariesAllNodes(s *state.State) error {
 	return s.RunTaskOnAllNodes(removeBinaries, state.RunParallel)
 }
 
-func removeBinaries(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func removeBinaries(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Removing Kubernetes binaries")
 	var err error
 

--- a/pkg/templates/encryptionproviders/encryption_providers.go
+++ b/pkg/templates/encryptionproviders/encryption_providers.go
@@ -39,7 +39,7 @@ func generateAESCBCSecret() (string, error) {
 	return base64.StdEncoding.EncodeToString(buf), nil
 }
 
-func NewEncryptionProvidersConfig(s *state.State) (*apiserverconfigv1.EncryptionConfiguration, error) {
+func NewEncryptionProvidersConfig(_ *state.State) (*apiserverconfigv1.EncryptionConfiguration, error) {
 	secret, err := generateAESCBCSecret()
 	if err != nil {
 		return nil, err

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -59,11 +59,7 @@ func WaitReady(s *state.State) error {
 		return err
 	}
 
-	if err := waitForCRDs(s); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForCRDs(s)
 }
 
 // waitForCRDs waits for machine-controller CRDs to be created and become established

--- a/pkg/templates/operatingsystemmanager/helper.go
+++ b/pkg/templates/operatingsystemmanager/helper.go
@@ -48,11 +48,7 @@ func WaitReady(s *state.State) error {
 		return err
 	}
 
-	if err := waitForCRDs(s); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForCRDs(s)
 }
 
 // waitForCRDs waits for operating-system-manager CRDs to be created and become established

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8"
+	prowImage             = "quay.io/kubermatic/build:go-1.19-node-18-16"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -328,7 +328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -351,7 +351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -374,7 +374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -397,7 +397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -420,7 +420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -443,7 +443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -466,7 +466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -489,7 +489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -512,7 +512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -536,7 +536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -559,7 +559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -582,7 +582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -605,7 +605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -630,7 +630,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -655,7 +655,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -680,7 +680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -706,7 +706,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -731,7 +731,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -754,7 +754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -777,7 +777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -800,7 +800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -823,7 +823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -846,7 +846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -869,7 +869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -892,7 +892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -915,7 +915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -938,7 +938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -961,7 +961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -984,7 +984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1008,7 +1008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1031,7 +1031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1054,7 +1054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1077,7 +1077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1102,7 +1102,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1127,7 +1127,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1152,7 +1152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1178,7 +1178,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1203,7 +1203,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1226,7 +1226,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1249,7 +1249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1272,7 +1272,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1295,7 +1295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1318,7 +1318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1341,7 +1341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1364,7 +1364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1387,7 +1387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1410,7 +1410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1433,7 +1433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1456,7 +1456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1479,7 +1479,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1502,7 +1502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1525,7 +1525,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1548,7 +1548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1573,7 +1573,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1598,7 +1598,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1623,7 +1623,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1649,7 +1649,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1674,7 +1674,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1697,7 +1697,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1720,7 +1720,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1743,7 +1743,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1766,7 +1766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1789,7 +1789,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1812,7 +1812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1835,7 +1835,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1858,7 +1858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1881,7 +1881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1904,7 +1904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1927,7 +1927,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1950,7 +1950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1973,7 +1973,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1996,7 +1996,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2019,7 +2019,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2044,7 +2044,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2069,7 +2069,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2094,7 +2094,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2120,7 +2120,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2145,7 +2145,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2168,7 +2168,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2191,7 +2191,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2214,7 +2214,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2237,7 +2237,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2260,7 +2260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2283,7 +2283,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2306,7 +2306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2329,7 +2329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2352,7 +2352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2380,7 +2380,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2408,7 +2408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2436,7 +2436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2464,7 +2464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2492,7 +2492,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2520,7 +2520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2550,7 +2550,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2580,7 +2580,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2610,7 +2610,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2641,7 +2641,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2671,7 +2671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2699,7 +2699,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2727,7 +2727,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2755,7 +2755,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2783,7 +2783,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2811,7 +2811,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2839,7 +2839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2867,7 +2867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2895,7 +2895,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2923,7 +2923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2951,7 +2951,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2979,7 +2979,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3007,7 +3007,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3035,7 +3035,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3063,7 +3063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3093,7 +3093,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3123,7 +3123,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3153,7 +3153,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3184,7 +3184,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3214,7 +3214,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3242,7 +3242,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3270,7 +3270,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3298,7 +3298,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3326,7 +3326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3354,7 +3354,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3382,7 +3382,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3410,7 +3410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3438,7 +3438,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3466,7 +3466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3494,7 +3494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3522,7 +3522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3550,7 +3550,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3578,7 +3578,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3606,7 +3606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3636,7 +3636,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3666,7 +3666,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3696,7 +3696,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3727,7 +3727,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3757,7 +3757,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3785,7 +3785,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3813,7 +3813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3841,7 +3841,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3869,7 +3869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3897,7 +3897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3925,7 +3925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3953,7 +3953,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3981,7 +3981,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4009,7 +4009,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4037,7 +4037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4065,7 +4065,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4093,7 +4093,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4121,7 +4121,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4149,7 +4149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4179,7 +4179,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4209,7 +4209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4239,7 +4239,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4270,7 +4270,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4300,7 +4300,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4328,7 +4328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4356,7 +4356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4384,7 +4384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4412,7 +4412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4440,7 +4440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4468,7 +4468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4496,7 +4496,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4524,7 +4524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4552,7 +4552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4580,7 +4580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4608,7 +4608,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4636,7 +4636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4664,7 +4664,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4692,7 +4692,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4722,7 +4722,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4752,7 +4752,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4782,7 +4782,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4813,7 +4813,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4843,7 +4843,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4871,7 +4871,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4899,7 +4899,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4927,7 +4927,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4955,7 +4955,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4983,7 +4983,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5011,7 +5011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5039,7 +5039,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5067,7 +5067,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5090,7 +5090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5113,7 +5113,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5136,7 +5136,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5159,7 +5159,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5182,7 +5182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5205,7 +5205,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5230,7 +5230,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5255,7 +5255,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5280,7 +5280,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5306,7 +5306,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5331,7 +5331,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5354,7 +5354,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5377,7 +5377,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5400,7 +5400,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5423,7 +5423,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5446,7 +5446,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5469,7 +5469,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5492,7 +5492,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5515,7 +5515,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5538,7 +5538,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5561,7 +5561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5584,7 +5584,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5607,7 +5607,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5630,7 +5630,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5653,7 +5653,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5676,7 +5676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5701,7 +5701,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5726,7 +5726,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5751,7 +5751,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5777,7 +5777,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5802,7 +5802,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5825,7 +5825,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5848,7 +5848,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5871,7 +5871,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5894,7 +5894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5917,7 +5917,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5940,7 +5940,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5963,7 +5963,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5986,7 +5986,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6009,7 +6009,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6032,7 +6032,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6055,7 +6055,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6078,7 +6078,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6101,7 +6101,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6124,7 +6124,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6147,7 +6147,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6172,7 +6172,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6197,7 +6197,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6222,7 +6222,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6248,7 +6248,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6273,7 +6273,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6296,7 +6296,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6319,7 +6319,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6342,7 +6342,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6365,7 +6365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6388,7 +6388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6411,7 +6411,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6434,7 +6434,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6457,7 +6457,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6480,7 +6480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6503,7 +6503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6526,7 +6526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6549,7 +6549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6572,7 +6572,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6595,7 +6595,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6618,7 +6618,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6643,7 +6643,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6668,7 +6668,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6693,7 +6693,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6719,7 +6719,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6744,7 +6744,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6767,7 +6767,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6790,7 +6790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6813,7 +6813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6836,7 +6836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6859,7 +6859,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6882,7 +6882,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6905,7 +6905,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6928,7 +6928,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6951,7 +6951,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6974,7 +6974,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6997,7 +6997,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7020,7 +7020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7043,7 +7043,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7066,7 +7066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7089,7 +7089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7114,7 +7114,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7139,7 +7139,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7164,7 +7164,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7190,7 +7190,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7215,7 +7215,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7238,7 +7238,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7261,7 +7261,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7284,7 +7284,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7307,7 +7307,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7330,7 +7330,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7353,7 +7353,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7376,7 +7376,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7399,7 +7399,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7422,7 +7422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7445,7 +7445,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7468,7 +7468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7491,7 +7491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7514,7 +7514,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7537,7 +7537,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7560,7 +7560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7585,7 +7585,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7610,7 +7610,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7635,7 +7635,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7661,7 +7661,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7686,7 +7686,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7709,7 +7709,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7732,7 +7732,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7755,7 +7755,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7778,7 +7778,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7801,7 +7801,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7824,7 +7824,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7847,7 +7847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7870,7 +7870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7893,7 +7893,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7918,7 +7918,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7943,7 +7943,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7968,7 +7968,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7993,7 +7993,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8018,7 +8018,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8043,7 +8043,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8066,7 +8066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8089,7 +8089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8112,7 +8112,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8135,7 +8135,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8158,7 +8158,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8181,7 +8181,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8204,7 +8204,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8227,7 +8227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8252,7 +8252,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8277,7 +8277,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8302,7 +8302,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8328,7 +8328,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8353,7 +8353,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8376,7 +8376,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8399,7 +8399,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8422,7 +8422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8445,7 +8445,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8468,7 +8468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8491,7 +8491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8514,7 +8514,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8537,7 +8537,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8560,7 +8560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8583,7 +8583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8606,7 +8606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8629,7 +8629,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8652,7 +8652,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8675,7 +8675,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8698,7 +8698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8723,7 +8723,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8748,7 +8748,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8773,7 +8773,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8799,7 +8799,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8824,7 +8824,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8847,7 +8847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8870,7 +8870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8893,7 +8893,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8916,7 +8916,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8939,7 +8939,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8962,7 +8962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8985,7 +8985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9008,7 +9008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9031,7 +9031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9054,7 +9054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9077,7 +9077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9100,7 +9100,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9123,7 +9123,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9146,7 +9146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9169,7 +9169,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9194,7 +9194,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9219,7 +9219,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9244,7 +9244,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9270,7 +9270,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9295,7 +9295,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9318,7 +9318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9341,7 +9341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9364,7 +9364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9387,7 +9387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9410,7 +9410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9433,7 +9433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9456,7 +9456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9479,7 +9479,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9502,7 +9502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9525,7 +9525,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9548,7 +9548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9571,7 +9571,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9594,7 +9594,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9617,7 +9617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9640,7 +9640,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9665,7 +9665,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9690,7 +9690,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9715,7 +9715,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9741,7 +9741,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9766,7 +9766,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9789,7 +9789,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9812,7 +9812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9835,7 +9835,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9858,7 +9858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9881,7 +9881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9904,7 +9904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9927,7 +9927,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9950,7 +9950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9973,7 +9973,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9996,7 +9996,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10019,7 +10019,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10042,7 +10042,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10065,7 +10065,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10088,7 +10088,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10111,7 +10111,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10136,7 +10136,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10161,7 +10161,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10186,7 +10186,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10212,7 +10212,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10237,7 +10237,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10260,7 +10260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10283,7 +10283,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10306,7 +10306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10329,7 +10329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10352,7 +10352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10375,7 +10375,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10398,7 +10398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10421,7 +10421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10444,7 +10444,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10467,7 +10467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10490,7 +10490,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10513,7 +10513,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10536,7 +10536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10559,7 +10559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10582,7 +10582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10605,7 +10605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10630,7 +10630,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10655,7 +10655,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10680,7 +10680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10706,7 +10706,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10731,7 +10731,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10754,7 +10754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10777,7 +10777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10800,7 +10800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10823,7 +10823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10846,7 +10846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10869,7 +10869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10892,7 +10892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10915,7 +10915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10938,7 +10938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10963,7 +10963,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10988,7 +10988,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11013,7 +11013,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11039,7 +11039,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11064,7 +11064,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11087,7 +11087,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11110,7 +11110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11133,7 +11133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11156,7 +11156,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11179,7 +11179,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11202,7 +11202,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11225,7 +11225,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11248,7 +11248,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11271,7 +11271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11296,7 +11296,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11321,7 +11321,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11346,7 +11346,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11372,7 +11372,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11397,7 +11397,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11420,7 +11420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11443,7 +11443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11466,7 +11466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11489,7 +11489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11512,7 +11512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11535,7 +11535,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11558,7 +11558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11581,7 +11581,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11604,7 +11604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11629,7 +11629,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11654,7 +11654,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11679,7 +11679,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11705,7 +11705,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11730,7 +11730,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11753,7 +11753,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11776,7 +11776,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11799,7 +11799,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11822,7 +11822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11845,7 +11845,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11868,7 +11868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11891,7 +11891,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11914,7 +11914,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11937,7 +11937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11960,7 +11960,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11983,7 +11983,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12006,7 +12006,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12029,7 +12029,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12052,7 +12052,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12075,7 +12075,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12098,7 +12098,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12121,7 +12121,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12144,7 +12144,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12167,7 +12167,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12190,7 +12190,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12213,7 +12213,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12236,7 +12236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12259,7 +12259,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12282,7 +12282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12307,7 +12307,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12332,7 +12332,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12357,7 +12357,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12383,7 +12383,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12408,7 +12408,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12431,7 +12431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12454,7 +12454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12477,7 +12477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12500,7 +12500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12523,7 +12523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12546,7 +12546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12569,7 +12569,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12592,7 +12592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12615,7 +12615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12638,7 +12638,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12661,7 +12661,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12684,7 +12684,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12707,7 +12707,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12730,7 +12730,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12753,7 +12753,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12776,7 +12776,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12799,7 +12799,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12822,7 +12822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12845,7 +12845,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12868,7 +12868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12891,7 +12891,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12914,7 +12914,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12937,7 +12937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12960,7 +12960,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12985,7 +12985,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13010,7 +13010,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13035,7 +13035,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13061,7 +13061,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13086,7 +13086,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13109,7 +13109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13132,7 +13132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13155,7 +13155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13178,7 +13178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13201,7 +13201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13224,7 +13224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13247,7 +13247,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13270,7 +13270,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13293,7 +13293,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13316,7 +13316,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13339,7 +13339,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13362,7 +13362,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13385,7 +13385,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13408,7 +13408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13431,7 +13431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13454,7 +13454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13477,7 +13477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13500,7 +13500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13523,7 +13523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13546,7 +13546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13569,7 +13569,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13592,7 +13592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13615,7 +13615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13638,7 +13638,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13663,7 +13663,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13688,7 +13688,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13713,7 +13713,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13739,7 +13739,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13764,7 +13764,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13787,7 +13787,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13810,7 +13810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13833,7 +13833,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13856,7 +13856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13879,7 +13879,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13902,7 +13902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13925,7 +13925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13948,7 +13948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13971,7 +13971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13994,7 +13994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14017,7 +14017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14040,7 +14040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14063,7 +14063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14086,7 +14086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14109,7 +14109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14132,7 +14132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14155,7 +14155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14178,7 +14178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14201,7 +14201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14224,7 +14224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14247,7 +14247,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14270,7 +14270,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14293,7 +14293,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14316,7 +14316,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14341,7 +14341,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14366,7 +14366,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14391,7 +14391,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14417,7 +14417,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14442,7 +14442,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14465,7 +14465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14488,7 +14488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14511,7 +14511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14534,7 +14534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14557,7 +14557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14580,7 +14580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14603,7 +14603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14626,7 +14626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14649,7 +14649,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14672,7 +14672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14695,7 +14695,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14718,7 +14718,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14741,7 +14741,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14764,7 +14764,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14787,7 +14787,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14810,7 +14810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14833,7 +14833,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14856,7 +14856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14884,7 +14884,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14912,7 +14912,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14940,7 +14940,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14968,7 +14968,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14996,7 +14996,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15024,7 +15024,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15054,7 +15054,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15084,7 +15084,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15114,7 +15114,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15145,7 +15145,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15175,7 +15175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15203,7 +15203,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15231,7 +15231,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15259,7 +15259,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15287,7 +15287,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15315,7 +15315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15343,7 +15343,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15371,7 +15371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15399,7 +15399,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15427,7 +15427,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15455,7 +15455,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15483,7 +15483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15511,7 +15511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15539,7 +15539,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15567,7 +15567,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15595,7 +15595,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15623,7 +15623,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15651,7 +15651,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15679,7 +15679,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15707,7 +15707,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15735,7 +15735,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15763,7 +15763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15791,7 +15791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15819,7 +15819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15849,7 +15849,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15879,7 +15879,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15909,7 +15909,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15940,7 +15940,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15970,7 +15970,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15998,7 +15998,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16026,7 +16026,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16054,7 +16054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16082,7 +16082,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16110,7 +16110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16138,7 +16138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16166,7 +16166,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16194,7 +16194,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16222,7 +16222,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16250,7 +16250,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16278,7 +16278,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16306,7 +16306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16334,7 +16334,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16362,7 +16362,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16390,7 +16390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16418,7 +16418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16446,7 +16446,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16474,7 +16474,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16502,7 +16502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16530,7 +16530,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16558,7 +16558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16586,7 +16586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16614,7 +16614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16644,7 +16644,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16674,7 +16674,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16704,7 +16704,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16735,7 +16735,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16765,7 +16765,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16793,7 +16793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16821,7 +16821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16849,7 +16849,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16877,7 +16877,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16905,7 +16905,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16933,7 +16933,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16961,7 +16961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16989,7 +16989,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17017,7 +17017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17045,7 +17045,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17073,7 +17073,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17101,7 +17101,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17129,7 +17129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17157,7 +17157,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17185,7 +17185,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17213,7 +17213,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17241,7 +17241,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17269,7 +17269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17297,7 +17297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17325,7 +17325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17353,7 +17353,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17381,7 +17381,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17409,7 +17409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17439,7 +17439,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17469,7 +17469,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17499,7 +17499,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17530,7 +17530,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17560,7 +17560,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17588,7 +17588,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17616,7 +17616,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17644,7 +17644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17672,7 +17672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17700,7 +17700,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17728,7 +17728,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17756,7 +17756,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17784,7 +17784,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17812,7 +17812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17840,7 +17840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17868,7 +17868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17896,7 +17896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17924,7 +17924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17952,7 +17952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17980,7 +17980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18008,7 +18008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18036,7 +18036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18064,7 +18064,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18092,7 +18092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18120,7 +18120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18148,7 +18148,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18176,7 +18176,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18204,7 +18204,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18234,7 +18234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18264,7 +18264,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18294,7 +18294,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18325,7 +18325,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18355,7 +18355,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18383,7 +18383,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18411,7 +18411,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18439,7 +18439,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18467,7 +18467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18495,7 +18495,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18523,7 +18523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18551,7 +18551,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18579,7 +18579,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18607,7 +18607,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18635,7 +18635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18663,7 +18663,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18691,7 +18691,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18719,7 +18719,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18747,7 +18747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18775,7 +18775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18803,7 +18803,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18831,7 +18831,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18854,7 +18854,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18877,7 +18877,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18900,7 +18900,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18923,7 +18923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18946,7 +18946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18969,7 +18969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18994,7 +18994,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19019,7 +19019,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19044,7 +19044,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19070,7 +19070,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19095,7 +19095,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19118,7 +19118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19141,7 +19141,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19164,7 +19164,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19187,7 +19187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19210,7 +19210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19233,7 +19233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19256,7 +19256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19279,7 +19279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19302,7 +19302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19325,7 +19325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19348,7 +19348,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19371,7 +19371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19394,7 +19394,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19417,7 +19417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19440,7 +19440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19463,7 +19463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19486,7 +19486,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19509,7 +19509,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19532,7 +19532,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19555,7 +19555,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19578,7 +19578,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19601,7 +19601,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19624,7 +19624,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19647,7 +19647,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19672,7 +19672,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19697,7 +19697,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19722,7 +19722,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19748,7 +19748,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19773,7 +19773,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19796,7 +19796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19819,7 +19819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19842,7 +19842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19865,7 +19865,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19888,7 +19888,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19911,7 +19911,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19934,7 +19934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19957,7 +19957,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19980,7 +19980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20003,7 +20003,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20026,7 +20026,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20049,7 +20049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20072,7 +20072,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20095,7 +20095,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20118,7 +20118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20141,7 +20141,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20164,7 +20164,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20187,7 +20187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20210,7 +20210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20233,7 +20233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20256,7 +20256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20279,7 +20279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20302,7 +20302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20325,7 +20325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20350,7 +20350,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20375,7 +20375,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20400,7 +20400,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20426,7 +20426,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20451,7 +20451,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20474,7 +20474,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20497,7 +20497,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20520,7 +20520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20543,7 +20543,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20566,7 +20566,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20589,7 +20589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20612,7 +20612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20635,7 +20635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20658,7 +20658,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20681,7 +20681,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20704,7 +20704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20727,7 +20727,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20750,7 +20750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20773,7 +20773,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20796,7 +20796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20819,7 +20819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20842,7 +20842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20865,7 +20865,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20888,7 +20888,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20911,7 +20911,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20934,7 +20934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20957,7 +20957,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20980,7 +20980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21003,7 +21003,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21026,7 +21026,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21049,7 +21049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21072,7 +21072,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21095,7 +21095,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21118,7 +21118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21141,7 +21141,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21164,7 +21164,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21187,7 +21187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21210,7 +21210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21233,7 +21233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21256,7 +21256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21279,7 +21279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21302,7 +21302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21325,7 +21325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.31-go-1.19.8
+      image: quay.io/kubermatic/build:go-1.19-node-18-16
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is combined backport of #2807 and #2808 to the `release/v1.5` branch.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use buildx instead of Buildah to create multi-architecture KubeOne container images.
```

**Documentation**:
```documentation
NONE
```