### PR TITLE
Revert "bug: remove duplicate err print"

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -51,7 +51,11 @@ func Execute() {
 	}
 
 	rootCmd := newRoot()
+
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		exitCode := fail.ExitCode(err)
+
 		debug, _ := rootCmd.PersistentFlags().GetBool(longFlagName(&globalOptions{}, "Debug"))
 		if debug {
 			var formatterErr fmt.Formatter
@@ -62,7 +66,6 @@ func Execute() {
 			}
 		}
 
-		exitCode := fail.ExitCode(err)
 		os.Exit(exitCode)
 	}
 }


### PR DESCRIPTION
Reverts kubermatic/kubeone#2791

This is breaking printing error messages if `SilenceErrors` is disabled for a command (and it's disabled for most commands). I think we should leave this output, but revisit `SilenceErrors` and enable it everywhere.

```release-note
Revert "Fix duplicate CLI print"
```

```documentation
NONE
```