### PR TITLE
Update NodeLocalDNSCache to 1.22.23 and metrics-server to v0.6.3

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -220,7 +220,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:          {"*": "docker.io/flannel/flannel:v0.21.3"},
 		// TODO: Switch to semver image before release.
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:8e5884837711fb0fc6b568d734f09a7b809fc28e"},
-		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
+		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.3"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.2"},
 	}
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -216,7 +216,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoCNI:        {"*": "quay.io/calico/cni:v3.26.0"},
 		CalicoController: {"*": "quay.io/calico/kube-controllers:v3.26.0"},
 		CalicoNode:       {"*": "quay.io/calico/node:v3.26.0"},
-		DNSNodeCache:     {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.15"},
+		DNSNodeCache:     {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.23"},
 		Flannel:          {"*": "docker.io/flannel/flannel:v0.21.3"},
 		// TODO: Switch to semver image before release.
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:8e5884837711fb0fc6b568d734f09a7b809fc28e"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update NodeLocalDNSCache to 1.22.23
- Update metrics-server to v0.6.3

**Which issue(s) this PR fixes**:
xref #2782 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update NodeLocalDNSCache to 1.22.23
- Update metrics-server to v0.6.3
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 