### PR TITLE
Migrate PodSelectors for AWS/OpenStack CCM and CSI

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -392,6 +392,9 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 		addonsToDeploy = append(addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIOpenStackCinder,
+				supportFn: func() error {
+					return migrateOpenStackCSIDriver(s)
+				},
 			},
 		)
 	case s.Cluster.CloudProvider.VMwareCloudDirector != nil:
@@ -447,6 +450,9 @@ func ensureCCMAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 		addonsToDeploy = append(addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMOpenStack,
+				supportFn: func() error {
+					return migrateOpenStackCCM(s)
+				},
 			},
 		)
 

--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -18,6 +18,7 @@ package addons
 
 import (
 	"io/fs"
+	"reflect"
 
 	embeddedaddons "k8c.io/kubeone/addons"
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
@@ -26,9 +27,12 @@ import (
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/resources"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -39,6 +43,103 @@ const (
 	vSphereDeploymentName       = "vsphere-cloud-controller-manager"
 )
 
+var (
+	expectedAWSCSIPodSelectors = map[string]string{
+		"app.kubernetes.io/name":     "aws-ebs-csi-driver",
+		"app.kubernetes.io/instance": "aws-ebs-csi-driver",
+	}
+	expectedOpenStackCCMPodSelectors = map[string]string{
+		"component": "controllermanager",
+		"app":       "openstack-cloud-controller-manager",
+		"release":   "openstack-ccm",
+	}
+	expectedOpenStackCSIPodSelectors = map[string]string{
+		"app":     "openstack-cinder-csi",
+		"release": "cinder-csi",
+	}
+)
+
+func migrateAWSCSIDriver(s *state.State) error {
+	if err := migrateAWSCSIController(s); err != nil {
+		return err
+	}
+
+	if err := migrateAWSCSINode(s); err != nil {
+		return err
+	}
+
+	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, awsCSIDriver())
+}
+
+func migrateAWSCSIController(s *state.State) error {
+	key := client.ObjectKey{
+		Name:      "ebs-csi-controller",
+		Namespace: metav1.NamespaceSystem,
+	}
+
+	expectedAWSCSIPodSelectors["app"] = "ebs-csi-controller"
+
+	return migrateDeploymentIfPodSelectorDifferent(s, key, expectedAWSCSIPodSelectors)
+}
+
+func migrateAWSCSINode(s *state.State) error {
+	key := client.ObjectKey{
+		Name:      "ebs-csi-node",
+		Namespace: metav1.NamespaceSystem,
+	}
+
+	expectedAWSCSIPodSelectors["app"] = "ebs-csi-node"
+
+	return migrateDaemonsetIfPodSelectorDifferent(s, key, expectedAWSCSIPodSelectors)
+}
+
+func awsCSIDriver() *storagev1.CSIDriver {
+	return &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: awsCSIDriverName,
+		},
+	}
+}
+
+func migrateOpenStackCCM(s *state.State) error {
+	key := client.ObjectKey{
+		Name:      "openstack-cloud-controller-manager",
+		Namespace: metav1.NamespaceSystem,
+	}
+
+	return migrateDaemonsetIfPodSelectorDifferent(s, key, expectedOpenStackCCMPodSelectors)
+}
+
+func migrateOpenStackCSIDriver(s *state.State) error {
+	if err := migrateOpenStackCSIController(s); err != nil {
+		return err
+	}
+
+	return migrateOpenStackCSINode(s)
+}
+
+func migrateOpenStackCSIController(s *state.State) error {
+	key := client.ObjectKey{
+		Name:      "openstack-cinder-csi-controllerplugin",
+		Namespace: metav1.NamespaceSystem,
+	}
+
+	expectedOpenStackCSIPodSelectors["component"] = "controllerplugin"
+
+	return migrateDeploymentIfPodSelectorDifferent(s, key, expectedOpenStackCSIPodSelectors)
+}
+
+func migrateOpenStackCSINode(s *state.State) error {
+	key := client.ObjectKey{
+		Name:      "openstack-cinder-csi-nodeplugin",
+		Namespace: metav1.NamespaceSystem,
+	}
+
+	expectedOpenStackCSIPodSelectors["component"] = "nodeplugin"
+
+	return migrateDaemonsetIfPodSelectorDifferent(s, key, expectedOpenStackCSIPodSelectors)
+}
+
 func migrateGCEStandardStorageClass(s *state.State) error {
 	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, gceStandardStorageClass())
 }
@@ -47,18 +148,6 @@ func gceStandardStorageClass() *storagev1.StorageClass {
 	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gceStandardStorageClassName,
-		},
-	}
-}
-
-func migrateAWSCSIDriver(s *state.State) error {
-	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, awsCSIDriver())
-}
-
-func awsCSIDriver() *storagev1.CSIDriver {
-	return &storagev1.CSIDriver{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: awsCSIDriverName,
 		},
 	}
 }
@@ -108,6 +197,40 @@ func migratePacketToEquinixCCM(s *state.State) error {
 
 func removeCSIVsphereFromKubeSystem(s *state.State) error {
 	return DeleteAddonByName(s, resources.AddonCSIVsphereKubeSystem)
+}
+
+func migrateDeploymentIfPodSelectorDifferent(s *state.State, key client.ObjectKey, expectedPodSelectors map[string]string) error {
+	deploy := &appsv1.Deployment{}
+	if err := s.DynamicClient.Get(s.Context, key, deploy); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if deploy.Spec.Selector != nil && reflect.DeepEqual(deploy.Spec.Selector.MatchLabels, expectedPodSelectors) {
+		return nil
+	}
+
+	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, deploy)
+}
+
+func migrateDaemonsetIfPodSelectorDifferent(s *state.State, key client.ObjectKey, expectedPodSelectors map[string]string) error {
+	ds := &appsv1.DaemonSet{}
+	if err := s.DynamicClient.Get(s.Context, key, ds); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if ds.Spec.Selector != nil && reflect.DeepEqual(ds.Spec.Selector.MatchLabels, expectedPodSelectors) {
+		return nil
+	}
+
+	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, ds)
 }
 
 // EmbeddedAddonsOnly checks if all specified addons are embedded addons


### PR DESCRIPTION
**What this PR does / why we need it**:

We switched to using Helm for templating manifests for AWS/OpenStack CCM and CSI. However, PodSelector labels are different when using Helm. Because PodSelector labels are immutable, upgrading from an earlier KubeOne version fails.

This PR adds migration logic so that we mitigate this issue.

**Which issue(s) this PR fixes**:
xref #2782 

**What type of PR is this?**

/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Redeploy AWS EBS CSI driver upon upgrading from earlier KubeOne versions to KubeOne 1.7 to update PodSelector labels
- Redeploy OpenStack CCM and Cinder CSI driver upon upgrading from earlier KubeOne versions to KubeOne 1.7 to update PodSelector labels
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 