### PR TITLE
Silence output about machine deployments in case it is disabled

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -289,7 +289,7 @@ func runApplyInstall(s *state.State, opts *applyOpts) error { // Print the expec
 		fmt.Println("\t! force-install option provided: force install new binary versions (!dangerous!)")
 	}
 
-	if !s.LiveCluster.IsProvisioned() {
+	if !s.LiveCluster.IsProvisioned() && s.CreateMachineDeployments {
 		for _, node := range s.Cluster.DynamicWorkers {
 			fmt.Printf("\t+ ensure machinedeployment %q with %d replica(s) exists\n", node.Name, resolveInt(node.Replicas))
 		}


### PR DESCRIPTION
- Silence output about machine deployments in case it is disabled

Signed-off-by: Sebastian Schmitt <sebastian.schmitt@sva.de>