### PR TITLE
Update cluster-autoscaler to v1.27.2, v1.26.3, v1.25.2, v1.24.2

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -421,9 +421,10 @@ func optionalResources() map[Resource]map[string]string {
 
 		// Cluster-autoscaler addon
 		ClusterAutoscaler: {
-			"1.24.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0",
-			"1.25.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.0",
-			">= 1.26.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1",
+			"1.24.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.2",
+			"1.25.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.2",
+			"1.26.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.3",
+			">= 1.27.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.2",
 		},
 
 		// CSI Vault Secret Provider


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update cluster-autoscaler to v1.27.2, v1.26.3, v1.25.2, v1.24.2

**Which issue(s) this PR fixes**:
xref #2782 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update cluster-autoscaler to v1.27.2, v1.26.3, v1.25.2, v1.24.2
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 