### PR TITLE
Drop v1.27 constraint for vSphere, since CCM has been updated

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -321,11 +321,6 @@ func ValidateKubernetesSupport(c kubeoneapi.KubeOneCluster, fldPath *field.Path)
 		return append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, ".versions.kubernetes is not a semver string"))
 	}
 
-	// vSphere CCM v1.25 supports Kubernetes 1.25 and 1.26.
-	if v.Minor() >= 27 && c.CloudProvider.Vsphere != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes versions 1.27.0 and newer are currently not supported for vsphere clusters"))
-	}
-
 	// We require external CCM/CSI on vSphere starting with Kubernetes 1.25
 	// because the in-tree volume plugin requires the CSI driver to be
 	// deployed for Kubernetes 1.25 and newer.

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1021,7 +1021,7 @@ func TestValidateKubernetesSupport(t *testing.T) {
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.27.0",
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 		{
 			name: "OpenStack 1.25.5 cluster with in-tree cloud provider",


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously there was no updated vSphere CCM release to work with kubernetes v1.27, but since that time there update has been integrated so I'm removing the "blocking" code.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drop v1.27 constraint for vSphere, since CCM has been updated
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
