### PR TITLE
Fix azure SKU in e2e

### DIFF
--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -145,6 +145,7 @@ resource "azurerm_public_ip" "lbip" {
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Dynamic"
+  sku                 = "Basic"
 
   tags = {
     environment = "kubeone"
@@ -159,6 +160,7 @@ resource "azurerm_public_ip" "control_plane" {
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Dynamic"
+  sku                 = "Basic"
 
   tags = {
     environment = "kubeone"

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -87,10 +87,10 @@ output "kubeone_workers" {
           location      = var.location
           resourceGroup = azurerm_resource_group.rg.name
           # vnetResourceGroup     = ""
-          vmSize     = var.worker_vm_size
-          vnetName   = azurerm_virtual_network.vpc.name
-          subnetName = azurerm_subnet.subnet.name
-          # loadBalancerSku       = ""
+          vmSize          = var.worker_vm_size
+          vnetName        = azurerm_virtual_network.vpc.name
+          subnetName      = azurerm_subnet.subnet.name
+          loadBalancerSku = "Basic"
           routeTableName  = azurerm_route_table.rt.name
           availabilitySet = azurerm_availability_set.avset_workers.name
           # assignAvailabilitySet = true/false

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -122,6 +122,8 @@ func Ensure(s *state.State) error {
 			return err
 		}
 
+		s.Cluster.CloudProvider.CloudConfig = cloudConfig
+
 		cloudCfgSecret := cloudConfigSecret(cloudConfig)
 		if err := clientutil.CreateOrReplace(context.Background(), s.DynamicClient, cloudCfgSecret); err != nil {
 			return err

--- a/test/e2e/cloudprovider.go
+++ b/test/e2e/cloudprovider.go
@@ -199,7 +199,7 @@ func (c *cloudProviderTests) createStatefulSetWithStorage(t *testing.T) {
 func (c *cloudProviderTests) validateStatefulSetReadiness(t *testing.T) {
 	t.Log("Waiting until the StatefulSet is ready...")
 
-	err := wait.PollUntilContextTimeout(context.TODO(), cpTestPollPeriod, cpTestTimeout, false, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(c.ctx, cpTestPollPeriod, cpTestTimeout, false, func(ctx context.Context) (done bool, err error) {
 		currentSet := &appsv1.StatefulSet{}
 		name := types.NamespacedName{Namespace: cpTestNamespaceName, Name: cpTestStatefulSetName}
 

--- a/test/go-test-e2e.sh
+++ b/test/go-test-e2e.sh
@@ -89,6 +89,7 @@ cloudConfig: |
     "location": "westeurope",
     "subnetName": "${TF_VAR_cluster_name}-subnet",
     "routeTableName": "",
+    "loadBalancerSku": "Basic",
     "securityGroupName": "${TF_VAR_cluster_name}-sg",
     "vnetName": "${TF_VAR_cluster_name}-vpc",
     "primaryAvailabilitySetName": "${TF_VAR_cluster_name}-avset-workers",


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like new CCM version defaulting SKU to Standard (from former Basic). This introduces explicit SKU to unblock LoadBalancer creation.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix azure SKU in e2e
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
