### PR TITLE
Update AWS EBS CSI driver to v1.22.0

### DIFF
--- a/addons/csi-aws-ebs/README.md
+++ b/addons/csi-aws-ebs/README.md
@@ -3,14 +3,14 @@
 The AWS EBS CSI manifest is generated from the [official Helm chart][helm-chart].
 
 ```shell
-helm repo add aws-cloud-controller-manager https://kubernetes.github.io/cloud-provider-aws
+helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
 helm repo update
 
 helm template \
     --namespace="kube-system" \
     --values="generated-values-csi" \
     --skip-tests \
-    aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver
+    aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver > csi-aws-ebs.yaml
 ```
 
 Required manual modifications include:

--- a/addons/csi-aws-ebs/csi-aws-ebs.yaml
+++ b/addons/csi-aws-ebs/csi-aws-ebs.yaml
@@ -8,8 +8,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,8 +29,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -44,8 +44,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -58,8 +58,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -87,8 +87,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -104,8 +104,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -145,8 +145,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -182,8 +182,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -215,8 +215,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -236,8 +236,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -257,8 +257,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -278,8 +278,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -299,8 +299,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -332,8 +332,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -355,8 +355,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -375,8 +375,8 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.20.0
-        app.kubernetes.io/version: "1.20.0"
+        helm.sh/chart: aws-ebs-csi-driver-2.22.0
+        app.kubernetes.io/version: "1.22.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -529,8 +529,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -550,8 +550,8 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.20.0
-        app.kubernetes.io/version: "1.20.0"
+        helm.sh/chart: aws-ebs-csi-driver-2.22.0
+        app.kubernetes.io/version: "1.22.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -615,6 +615,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: AWS_EC2_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: aws-meta
+                  key: endpoint
+                  optional: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -768,8 +774,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.20.0
-    app.kubernetes.io/version: "1.20.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.22.0
+    app.kubernetes.io/version: "1.22.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -235,14 +235,14 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// AWS EBS CSI driver
-		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.20.0"},
-		AwsEbsCSIAttacher:            {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.3.0-eks-1-27-3"},
-		AwsEbsCSILivenessProbe:       {"*": "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-27-3"},
-		AwsEbsCSINodeDriverRegistrar: {"*": "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.8.0-eks-1-27-3"},
-		AwsEbsCSIProvisioner:         {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-27-3"},
-		AwsEbsCSIResizer:             {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.8.0-eks-1-27-3"},
-		AwsEbsCSISnapshotter:         {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v6.2.1-eks-1-27-3"},
+		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.22.0"},
+		AwsEbsCSIAttacher:            {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.3.0-eks-1-27-9"},
+		AwsEbsCSILivenessProbe:       {"*": "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-27-9"},
+		AwsEbsCSINodeDriverRegistrar: {"*": "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.8.0-eks-1-27-9"},
+		AwsEbsCSIProvisioner:         {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-27-9"},
+		AwsEbsCSIResizer:             {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.8.0-eks-1-27-9"},
 		AwsEbsCSISnapshotController:  {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.2.1"},
+		AwsEbsCSISnapshotter:         {"*": "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v6.2.2-eks-1-27-9"},
 
 		// Azure CCM
 		AzureCCM: {


### PR DESCRIPTION
**What this PR does / why we need it**:
Flatcar has been failing with:
```
Warning  FailedAttachVolume  25s   attachdetach-controller  AttachVolume.Attach failed for volume "pvc-264e0b7f-4da3-4662-bc95-ef3f12e484bc" : rpc error: code = Internal desc = Could not attach volume "vol-0cf2618dadfc26acb" to node "i-09c3735e4b047c3b4": could not attach volume "vol-0cf2618dadfc26acb" to node "i-09c3735e4b047c3b4": 
  
  InvalidParameterValue: Invalid value '/dev/xvdb' for unixDevice. Attachment point /dev/xvdb is already in use
           status code: 400, request id: 386d703c-f34c-4fce-ab3b-0dde01a80e80
```

This update addresses the issues.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update AWS EBS CSI driver to v1.22.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
