### PR TITLE
Move vSphere CCM RBAC out of List object to apply resources

### DIFF
--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -196,46 +196,43 @@ spec:
                 operator: Exists
 ---
 # Source: vsphere-cpi/templates/role-binding.yaml
-apiVersion: v1
-kind: List
-metadata: {}
-items:
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: servicecatalog.k8s.io:apiserver-authentication-reader
-    labels:
-      app: vsphere-cpi
-      vsphere-cpi-infra: role-binding
-      component: cloud-controller-manager
-    namespace: kube-system
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: extension-apiserver-authentication-reader
-  subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: cloud-controller-manager
-    namespace: kube-system
-  - apiGroup: ""
-    kind: User
-    name: cloud-controller-manager
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: cloud-controller-manager
-    labels:
-      app: vsphere-cpi
-      vsphere-cpi-infra: cluster-role-binding
-      component: cloud-controller-manager
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: cloud-controller-manager
-  subjects:
-  - kind: ServiceAccount
-    name: cloud-controller-manager
-    namespace: kube-system
-  - kind: User
-    name: cloud-controller-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: servicecatalog.k8s.io:apiserver-authentication-reader
+  labels:
+    app: vsphere-cpi
+    vsphere-cpi-infra: role-binding
+    component: cloud-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+- apiGroup: ""
+  kind: User
+  name: cloud-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-controller-manager
+  labels:
+    app: vsphere-cpi
+    vsphere-cpi-infra: cluster-role-binding
+    component: cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+- kind: User
+  name: cloud-controller-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
#2826 refreshed the vSphere CCM and CSI driver. Unfortunately, the CCM Helm chart is super weird and provides RBAC via a `List` object. This doesn't seem to work well with KubeOne, at least I couldn't see it creating the `RoleBinding` and the `ClusterRoleBinding`. This should make KubeOne apply it again.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
