### PR TITLE
add option to skip local storage for autoscaler addon

### DIFF
--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -100,14 +100,16 @@ kubectl annotate machinedeployment -n kube-system <machinedeployment-name> clust
 
 You need to replace the following values with the actual ones:
 
-* `AUTOSCALER_VERSION` needs to be replaced with the appropriate Cluster
-  Autoscaler version
+* `CLUSTER_AUTOSCALER_IMAGE` can be used to replace the Cluster Autoscaler image
   * The minor versions of Cluster Autoscaler and Kubernetes cluster should
     match, as per
     [Cluster Autoscaler recommendations][recommended-autoscaler-versions]
   * You can find the available Cluster Autoscaler versions by searching for
     Cluster Autoscaler in the
     [autoscaler GitHub repository][autoscaler-releases]
+* `CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE` can be used to define the value of `--skip-nodes-with-local-storage=`.
+  * Possible values are `"true"`or `"false"`
+  * Default is `"false"`, as described in the [FAQ][autoscaler-faq].
 
 You can find more information about deploying addons in the
 [Addons document][using-addons].
@@ -120,3 +122,4 @@ You can find more information about deploying addons in the
 [recommended-autoscaler-versions]: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases
 [autoscaler-releases]: https://github.com/kubernetes/autoscaler/releases
 [using-addons]: https://docs.kubermatic.com/kubeone/v1.6/guides/addons/
+[autoscaler-faq]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -179,6 +179,7 @@ spec:
         args:
         - --cloud-provider=clusterapi
         - --namespace=kube-system
+        - --skip-nodes-with-local-storage={{ default "false" .Params.CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE }}
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4


### PR DESCRIPTION
**What this PR does / why we need it**:

The cluster-autoscaler addon often does not scale down the nodepool if there are pods running which have an `emptyDir` volume, e.g. The default behaviour of keeping these nodes is perfectly OK, but there are also many reasons why someone wouldn't want that. In order to enable KubeOne users to choose the option they prefer, I added another parameter to the addon.

**Which issue(s) this PR fixes**:

None, its a new feature

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Add `CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE` parameter for cluster-autoscaler addon used to skip local storage when downscaling nodes (see https://github.com/kubermatic/kubeone/tree/main/addons/cluster-autoscaler for more details)
```

**Documentation**:
```documentation
TBD
```

I already updated the `addons/cluster-autoscaler/README.md` in my commit :slightly_smiling_face: 
