### PR TITLE
Migrate to the community-hosted package repositories (`pkgs.k8s.io`) and to `dl.k8s.io`

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -500,3 +500,10 @@ func (c IPFamily) IsDualstack() bool {
 func (c IPFamily) IsIPv6Primary() bool {
 	return c == IPFamilyIPv6 || c == IPFamilyIPv6IPv4
 }
+
+func (v VersionConfig) KubernetesMajorMinorVersion() string {
+	// Validation passed at this point so we know that version is valid
+	kubeSemVer := semver.MustParse(v.Kubernetes)
+
+	return fmt.Sprintf("v%d.%d", kubeSemVer.Major(), kubeSemVer.Minor())
+}

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -18,7 +18,7 @@ package scripts
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/containerruntime"
@@ -74,7 +74,7 @@ func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
 	// Validation passed at this point so we know that version is valid
 	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)
 
-	switch kubeSemVer.Minor {
+	switch kubeSemVer.Minor() {
 	case 24:
 		fallthrough
 	case 25:

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -18,16 +18,14 @@ package scripts
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/blang/semver/v4"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/containerruntime"
 	"k8c.io/kubeone/pkg/fail"
 )
 
-const (
-	defaultKubernetesCNIVersion = "1.2.0"
-	defaultCriToolsVersion      = "1.26.0"
-)
+const defaultKubernetesCNIVersion = "1.2.0"
 
 var migrateToContainerdScriptTemplate = heredoc.Doc(`
 	sudo systemctl stop kubelet
@@ -70,4 +68,24 @@ func installISCSIAndNFS(cluster *kubeoneapi.KubeOneCluster) bool {
 
 func ciliumCNI(cluster *kubeoneapi.KubeOneCluster) bool {
 	return cluster.ClusterNetwork.CNI != nil && cluster.ClusterNetwork.CNI.Cilium != nil
+}
+
+func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
+	// Validation passed at this point so we know that version is valid
+	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)
+
+	switch kubeSemVer.Minor {
+	case 24:
+		fallthrough
+	case 25:
+		fallthrough
+	case 26:
+		return "1.26.0"
+	case 27:
+		return "1.27.1"
+	case 28:
+		fallthrough
+	default:
+		return "1.28.0"
+	}
 }

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -44,6 +44,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 {{ if .CONFIGURE_REPOSITORIES }}
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -52,6 +61,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 {{ end }}
 
 sudo yum install -y \

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -47,11 +47,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/repodata/repomd.xml.key
 EOF
 {{ end }}
 
@@ -205,8 +204,9 @@ func KubeadmAmazonLinux(cluster *kubeoneapi.KubeOneCluster, force bool) (string,
 		"CNI_URL":                cluster.AssetConfiguration.CNI.URL,
 		"KUBECTL_URL":            cluster.AssetConfiguration.Kubectl.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -244,8 +244,9 @@ func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (string
 		"NODE_BINARIES_URL":      cluster.AssetConfiguration.NodeBinaries.URL,
 		"CNI_URL":                cluster.AssetConfiguration.CNI.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -277,8 +278,9 @@ func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (st
 		"NODE_BINARIES_URL":      cluster.AssetConfiguration.NodeBinaries.URL,
 		"KUBECTL_URL":            cluster.AssetConfiguration.Kubectl.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -47,11 +47,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -143,8 +142,9 @@ func KubeadmCentOS(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBEADM":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -180,8 +180,9 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"UPGRADE":                true,
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -211,8 +212,9 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBELET":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -44,6 +44,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 {{ if .CONFIGURE_REPOSITORIES }}
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -57,6 +66,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 {{ end }}
 

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -61,11 +61,9 @@ sudo systemctl enable --now iscsid
 {{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 {{- end }}
@@ -134,8 +132,9 @@ func KubeadmDebian(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBEADM":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -167,8 +166,9 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"UPGRADE":                true,
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -194,8 +194,9 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBELET":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,

--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -49,7 +49,7 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 {{ end }}
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary
@@ -125,7 +125,7 @@ RELEASE="v{{ .KUBERNETES_VERSION }}"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
@@ -150,7 +150,7 @@ RELEASE="v{{ .KUBERNETES_VERSION }}"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
 sudo mkdir -p /opt/bin
 cd /opt/bin
 sudo systemctl stop kubelet
@@ -197,7 +197,7 @@ func KubeadmFlatcar(cluster *kubeoneapi.KubeOneCluster) (string, error) {
 	data := Data{
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"CILIUM":                 ciliumCNI(cluster),

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -59,6 +59,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -67,6 +76,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -62,11 +62,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -59,6 +59,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -72,6 +81,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -62,11 +62,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -63,11 +63,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -60,11 +60,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -99,7 +99,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -99,7 +99,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -102,7 +102,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -99,7 +99,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -75,7 +75,7 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -113,7 +113,7 @@ sudo systemctl restart containerd
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -115,7 +115,7 @@ sudo systemctl restart containerd
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -73,7 +73,7 @@ RELEASE="v1.26.0"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
 
 sudo mkdir -p /opt/bin
 cd /opt/bin

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -61,6 +70,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -53,6 +53,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -66,6 +75,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -56,11 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
@@ -68,7 +68,7 @@ RELEASE="v1.26.0"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
 sudo mkdir -p /opt/bin
 cd /opt/bin
 sudo systemctl stop kubelet

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -1316,7 +1316,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1346,7 +1346,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1376,7 +1376,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1406,7 +1406,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1437,7 +1437,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1467,7 +1467,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1495,7 +1495,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1523,7 +1523,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1551,7 +1551,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1579,7 +1579,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1607,7 +1607,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1635,7 +1635,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1663,7 +1663,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1693,7 +1693,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1723,7 +1723,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1753,7 +1753,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1784,7 +1784,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1814,7 +1814,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1842,7 +1842,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1870,7 +1870,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1898,7 +1898,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1926,7 +1926,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1954,7 +1954,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1982,7 +1982,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2010,7 +2010,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2040,7 +2040,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2070,7 +2070,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2100,7 +2100,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2131,7 +2131,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2161,7 +2161,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2189,7 +2189,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2217,7 +2217,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2245,7 +2245,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2273,7 +2273,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2301,7 +2301,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9109,7 +9109,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9137,7 +9137,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9165,7 +9165,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9193,7 +9193,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9221,7 +9221,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9249,7 +9249,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9277,7 +9277,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9307,7 +9307,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9337,7 +9337,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9367,7 +9367,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9398,7 +9398,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9428,7 +9428,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9456,7 +9456,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9484,7 +9484,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9512,7 +9512,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9540,7 +9540,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9568,7 +9568,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9596,7 +9596,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9624,7 +9624,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9652,7 +9652,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9680,7 +9680,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9708,7 +9708,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9736,7 +9736,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9764,7 +9764,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9792,7 +9792,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9820,7 +9820,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9848,7 +9848,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9876,7 +9876,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9904,7 +9904,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone

--- a/test/e2e/scenario_upgrade.go
+++ b/test/e2e/scenario_upgrade.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	kubeoneStableBaseRef = "release/v1.5"
+	kubeoneStableBaseRef = "release/v1.6"
 )
 
 type scenarioUpgrade struct {

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -75,7 +75,6 @@
 - scenario: upgrade_containerd
   initVersion: v1.26.6
   upgradedVersion: v1.27.3
-  initKubeOneVersion: "main"
   infrastructures:
     - name: azure_default_stable
     - name: azure_centos_stable
@@ -87,7 +86,6 @@
 - scenario: upgrade_containerd
   initVersion: v1.25.11
   upgradedVersion: v1.26.6
-  initKubeOneVersion: "main"
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable


### PR DESCRIPTION
**What this PR does / why we need it**:

There are three changes introduced in this PR:

- Migrate to the community-hosted package repositories (`pkgs.k8s.io`) from the deprecated Google-hosted package repository (`apt.kubernetes.io` and `yum.kubernetes.io`)
  - The Kubernetes project strongly encourages and recommends migrating to the new package repositories as soon as possible
  - Given that the Google-hosted repository is deprecated, I decided to do unconditional migration, i.e. without giving an option to opt-out from this change. This is going to make it easier for us to maintain and support this release branch in the long term. Moreover, most users are not going to notice this change at all. This change might only affect users allowlisting traffic based on IP addresses or URLs, in which case they need to update their allowlists (this is explained in the release note)
-  Migrate to `dl.k8s.io` instead of pulling binaries from the release bucket directly
  - The `kubernetes-release` bucket might get deprecated and frozen in the future as part of efforts to migrate to the community-owned infrastructure. The Kubernetes project strongly recommends using `dl.k8s.io` going forward
  - Same as the previous change, this change shouldn't affect many users. Additionally, this only affects Flatcar-based clusters. Users using allowlisting might need to update their configuration and this is explained in the release note
- cri-tools is updated to v1.27.1 for clusters running Kubernetes 1.27. Kubernetes 1.28 clusters will use cri-tools v1.28.0

Additionally, tests are updated to use KubeOne 1.6 as the stable version for initially provisioning the cluster. 

**Which issue(s) this PR fixes**:
Fixes #2870 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- [ACTION REQUIRED] Migrate from the Google-hosted package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`) to the community-hosted package repositories. The Google-hosted package repositories are deprecated as of August 15, 2023 and using the community-hosted package repositories is strongly encouraged. For most users, this change shouldn't make a difference. However, if you do IP-based or URL-based allowlisting, you need to allow outgoing traffic to `pkgs.k8s.io` and `prod-cdn.packages.k8s.io`. For more details, see the official announcement: https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/
- [ACTION REQUIRED] Migrate from using the Kubernetes release bucket (`https://storage.googleapis.com/kubernetes-release/release`) to `dl.k8s.io`. This change only affects Flatcar-based clusters. The Kubernetes project is now serving all binary artifacts via `dl.k8s.io` and it's strongly encouraged to use `dl.k8s.io` over accessing the bucket directly. For most users, this change shouldn't make a difference. However, if you do IP-based or URL-based allowlisting, you might need to make changes to your allowlist. See the following announcement for more details: https://kubernetes.io/blog/2023/06/09/dl-adopt-cdn/
- Upgrade cri-tools to v1.27.1 for clusters running Kubernetes 1.27
```

**Documentation**:
```documentation
TBD
```
(this should be mentioned in the upgrade guide)