### PR TITLE
fix default value for autoscaler addon option

### DIFF
--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -109,7 +109,7 @@ You need to replace the following values with the actual ones:
     [autoscaler GitHub repository][autoscaler-releases]
 * `CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE` can be used to define the value of `--skip-nodes-with-local-storage=`.
   * Possible values are `"true"`or `"false"`
-  * Default is `"false"`, as described in the [FAQ][autoscaler-faq].
+  * Default is `"true"`, as described in the [FAQ][autoscaler-faq].
 
 You can find more information about deploying addons in the
 [Addons document][using-addons].

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -179,7 +179,7 @@ spec:
         args:
         - --cloud-provider=clusterapi
         - --namespace=kube-system
-        - --skip-nodes-with-local-storage={{ default "false" .Params.CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE }}
+        - --skip-nodes-with-local-storage={{ default "true" .Params.CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE }}
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4


### PR DESCRIPTION
See https://github.com/kubermatic/kubeone/pull/2872#issuecomment-1696950915 for details.

```release-note
NONE
```

```documentation
NONE
```