### PR TITLE
[release/v1.6] Migrate to the community-hosted package repositories (`pkgs.k8s.io`) and to `dl.k8s.io`

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 
 	"k8c.io/kubeone/pkg/fail"

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -477,3 +477,10 @@ func (c IPFamily) IsDualstack() bool {
 func (c IPFamily) IsIPv6Primary() bool {
 	return c == IPFamilyIPv6 || c == IPFamilyIPv6IPv4
 }
+
+func (v VersionConfig) KubernetesMajorMinorVersion() string {
+	// Validation passed at this point so we know that version is valid
+	kubeSemVer := semver.MustParse(v.Kubernetes)
+
+	return fmt.Sprintf("v%d.%d", kubeSemVer.Major(), kubeSemVer.Minor())
+}

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -18,7 +18,7 @@ package scripts
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/containerruntime"
@@ -74,7 +74,7 @@ func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
 	// Validation passed at this point so we know that version is valid
 	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)
 
-	switch kubeSemVer.Minor {
+	switch kubeSemVer.Minor() {
 	case 24:
 		fallthrough
 	case 25:

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -18,16 +18,14 @@ package scripts
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/blang/semver/v4"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/containerruntime"
 	"k8c.io/kubeone/pkg/fail"
 )
 
-const (
-	defaultKubernetesCNIVersion = "1.2.0"
-	defaultCriToolsVersion      = "1.26.0"
-)
+const defaultKubernetesCNIVersion = "1.2.0"
 
 var migrateToContainerdScriptTemplate = heredoc.Doc(`
 	sudo systemctl stop kubelet
@@ -70,4 +68,24 @@ func installISCSIAndNFS(cluster *kubeoneapi.KubeOneCluster) bool {
 
 func ciliumCNI(cluster *kubeoneapi.KubeOneCluster) bool {
 	return cluster.ClusterNetwork.CNI != nil && cluster.ClusterNetwork.CNI.Cilium != nil
+}
+
+func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
+	// Validation passed at this point so we know that version is valid
+	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)
+
+	switch kubeSemVer.Minor {
+	case 24:
+		fallthrough
+	case 25:
+		fallthrough
+	case 26:
+		return "1.26.0"
+	case 27:
+		return "1.27.1"
+	case 28:
+		fallthrough
+	default:
+		return "1.28.0"
+	}
 }

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -47,11 +47,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/repodata/repomd.xml.key
 EOF
 {{ end }}
 
@@ -205,8 +204,9 @@ func KubeadmAmazonLinux(cluster *kubeoneapi.KubeOneCluster, force bool) (string,
 		"CNI_URL":                cluster.AssetConfiguration.CNI.URL,
 		"KUBECTL_URL":            cluster.AssetConfiguration.Kubectl.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -243,8 +243,9 @@ func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (string
 		"NODE_BINARIES_URL":      cluster.AssetConfiguration.NodeBinaries.URL,
 		"CNI_URL":                cluster.AssetConfiguration.CNI.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -275,8 +276,9 @@ func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (st
 		"NODE_BINARIES_URL":      cluster.AssetConfiguration.NodeBinaries.URL,
 		"KUBECTL_URL":            cluster.AssetConfiguration.Kubectl.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -44,6 +44,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 {{ if .CONFIGURE_REPOSITORIES }}
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -52,6 +61,11 @@ enabled=1
 gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 {{ end }}
 
 sudo yum install -y \

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -47,11 +47,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -143,8 +142,9 @@ func KubeadmCentOS(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBEADM":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -179,8 +179,9 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"UPGRADE":                true,
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -209,8 +210,9 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBELET":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -44,6 +44,15 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 {{ if .CONFIGURE_REPOSITORIES }}
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -57,6 +66,11 @@ source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 {{ end }}
 

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -61,11 +61,9 @@ sudo systemctl enable --now iscsid
 {{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 {{- end }}
@@ -134,8 +132,9 @@ func KubeadmDebian(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBEADM":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -166,8 +165,9 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"UPGRADE":                true,
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -192,8 +192,9 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBELET":                true,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
+		"KUBERNETES_MAJOR_MINOR": cluster.Versions.KubernetesMajorMinorVersion(),
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,

--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -49,7 +49,7 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 {{ end }}
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary
@@ -125,7 +125,7 @@ RELEASE="v{{ .KUBERNETES_VERSION }}"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
@@ -150,7 +150,7 @@ RELEASE="v{{ .KUBERNETES_VERSION }}"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
 sudo mkdir -p /opt/bin
 cd /opt/bin
 sudo systemctl stop kubelet
@@ -197,7 +197,7 @@ func KubeadmFlatcar(cluster *kubeoneapi.KubeOneCluster) (string, error) {
 	data := Data{
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       defaultCriToolsVersion,
+		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"CILIUM":                 ciliumCNI(cluster),

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -59,15 +59,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -59,20 +59,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -63,11 +63,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -60,11 +60,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -99,7 +99,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -99,7 +99,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -102,7 +102,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -99,7 +99,7 @@ fi
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -75,7 +75,7 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -112,7 +112,7 @@ sudo systemctl restart containerd
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -114,7 +114,7 @@ sudo systemctl restart containerd
 
 
 cd /opt/bin
-k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+k8s_rel_baseurl=https://dl.k8s.io
 for binary in kubeadm kubelet kubectl; do
 	curl -L --output /tmp/$binary \
 		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -72,7 +72,7 @@ RELEASE="v1.26.0"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/kubeadm
 
 sudo mkdir -p /opt/bin
 cd /opt/bin

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -53,15 +53,28 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
+fi
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -53,20 +53,33 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
+# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
+# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
+# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
+repo_migration_needed=false
+
+if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
+  repo_migration_needed=true
+fi
+
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
 if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
+
+if [[ $repo_migration_needed == "true" ]]; then
+  sudo yum clean all
+  sudo yum makecache
 fi
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -57,11 +57,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo apt-key add -
 
-# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
-# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
@@ -67,7 +67,7 @@ RELEASE="v1.26.0"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
+	https://dl.k8s.io/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
 sudo mkdir -p /opt/bin
 cd /opt/bin
 sudo systemctl stop kubelet

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -1420,7 +1420,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1448,7 +1448,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1476,7 +1476,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1504,7 +1504,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1532,7 +1532,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1560,7 +1560,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1588,7 +1588,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1618,7 +1618,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1648,7 +1648,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1678,7 +1678,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1709,7 +1709,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1739,7 +1739,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1767,7 +1767,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1795,7 +1795,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1823,7 +1823,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1851,7 +1851,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1879,7 +1879,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1907,7 +1907,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1935,7 +1935,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1963,7 +1963,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9762,7 +9762,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9790,7 +9790,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9818,7 +9818,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9846,7 +9846,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9874,7 +9874,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9902,7 +9902,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9930,7 +9930,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9960,7 +9960,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9990,7 +9990,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10020,7 +10020,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10051,7 +10051,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10081,7 +10081,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10109,7 +10109,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10137,7 +10137,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10165,7 +10165,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10193,7 +10193,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10221,7 +10221,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10249,7 +10249,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10277,7 +10277,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10305,7 +10305,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10333,7 +10333,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10361,7 +10361,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10389,7 +10389,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10417,7 +10417,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10445,7 +10445,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10473,7 +10473,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10501,7 +10501,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10529,7 +10529,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10557,7 +10557,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.6
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -76,7 +76,7 @@
 - scenario: upgrade_containerd
   initVersion: v1.25.6
   upgradedVersion: v1.26.1
-  initKubeOneVersion: "main"
+  initKubeOneVersion: "release/v1.6"
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -508,7 +508,7 @@
 - scenario: upgrade_containerd_external
   initVersion: v1.25.6
   upgradedVersion: v1.26.1
-  initKubeOneVersion: "main"
+  initKubeOneVersion: "release/v1.6"
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #2873, see the original PR for more details.

**Which issue(s) this PR fixes**:
Fixes #2870 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- [ACTION REQUIRED] Migrate from the Google-hosted package repositories (`apt.kubernetes.io` and `yum.kubernetes.io`) to the community-hosted package repositories. The Google-hosted package repositories are deprecated as of August 15, 2023 and using the community-hosted package repositories is strongly encouraged. For most users, this change shouldn't make a difference. However, if you do IP-based or URL-based allowlisting, you need to allow outgoing traffic to `pkgs.k8s.io` and `prod-cdn.packages.k8s.io`. For more details, see the official announcement: https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/
- [ACTION REQUIRED] Migrate from using the Kubernetes release bucket (`https://storage.googleapis.com/kubernetes-release/release`) to `dl.k8s.io`. This change only affects Flatcar-based clusters. The Kubernetes project is now serving all binary artifacts via `dl.k8s.io` and it's strongly encouraged to use `dl.k8s.io` over accessing the bucket directly. For most users, this change shouldn't make a difference. However, if you do IP-based or URL-based allowlisting, you might need to make changes to your allowlist. See the following announcement for more details: https://kubernetes.io/blog/2023/06/09/dl-adopt-cdn/
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 