### PR TITLE
Add release note for updating MC to v1.6.3 changelog

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -18,6 +18,10 @@
 
 ### Updates
 
+#### machine-controller
+
+- Update machine-controller to v1.56.4 ([#2889](https://github.com/kubermatic/kubeone/pull/2889), [@xmudrii](https://github.com/xmudrii))
+
 #### Equinix Metal
 
 - Update the Equinix Metal CCM to v3.6.2 ([#2871](https://github.com/kubermatic/kubeone/pull/2871), [@kubermatic-bot](https://github.com/kubermatic-bot))


### PR DESCRIPTION
**What this PR does / why we need it**:

I updated machine-controller in #2889 on release/v1.6 branch. This PR adds a release note for that change to the changelog.

**Which issue(s) this PR fixes**:
xref #2886 

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 