### PR TITLE
Remove rp_filter sysctl config

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -70,13 +70,6 @@ var (
 		net.netfilter.nf_conntrack_max      = 1000000
 		vm.overcommit_memory                = 1
 		EOF
-		{{- if .CILIUM }}
-		cat <<EOF | sudo tee /etc/sysctl.d/99-zzz-override_cilium.conf
-		# Disable rp_filter on ALL interfaces since it may cause mangled packets to be dropped
-		# https://github.com/cilium/cilium/blob/v1.11.1/pkg/datapath/loader/base.go#L244
-		net.ipv4.conf.all.rp_filter = 0
-		EOF
-		{{ end }}
 		sudo sysctl --system
 		{{ end }}
 

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -66,10 +66,6 @@ func installISCSIAndNFS(cluster *kubeoneapi.KubeOneCluster) bool {
 	return cluster.CloudProvider.Nutanix != nil
 }
 
-func ciliumCNI(cluster *kubeoneapi.KubeOneCluster) bool {
-	return cluster.ClusterNetwork.CNI != nil && cluster.ClusterNetwork.CNI.Cilium != nil
-}
-
 func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
 	// Validation passed at this point so we know that version is valid
 	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -227,7 +227,6 @@ func KubeadmAmazonLinux(cluster *kubeoneapi.KubeOneCluster, force bool) (string,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"USE_KUBERNETES_REPO":    cluster.AssetConfiguration.NodeBinaries.URL == "",
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 
@@ -266,7 +265,6 @@ func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (string
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"USE_KUBERNETES_REPO":    cluster.AssetConfiguration.NodeBinaries.URL == "",
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 
@@ -300,7 +298,6 @@ func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (st
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"USE_KUBERNETES_REPO":    cluster.AssetConfiguration.NodeBinaries.URL == "",
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -165,7 +165,6 @@ func KubeadmCentOS(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 
@@ -202,7 +201,6 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 
@@ -234,7 +232,6 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeoneapi.KubeOneCluster) (string,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -142,7 +142,6 @@ func KubeadmDebian(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 
@@ -175,7 +174,6 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 
@@ -203,7 +201,6 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeoneapi.KubeOneCluster) (string,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 

--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -200,7 +200,6 @@ func KubeadmFlatcar(cluster *kubeoneapi.KubeOneCluster) (string, error) {
 		"CRITOOLS_VERSION":       criToolsVersion(cluster),
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
-		"CILIUM":                 ciliumCNI(cluster),
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
 	}
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -34,12 +34,6 @@ net.ipv4.ip_forward                 = 1
 net.netfilter.nf_conntrack_max      = 1000000
 vm.overcommit_memory                = 1
 EOF
-cat <<EOF | sudo tee /etc/sysctl.d/99-zzz-override_cilium.conf
-# Disable rp_filter on ALL interfaces since it may cause mangled packets to be dropped
-# https://github.com/cilium/cilium/blob/v1.11.1/pkg/datapath/loader/base.go#L244
-net.ipv4.conf.all.rp_filter = 0
-EOF
-
 sudo sysctl --system
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -34,12 +34,6 @@ net.ipv4.ip_forward                 = 1
 net.netfilter.nf_conntrack_max      = 1000000
 vm.overcommit_memory                = 1
 EOF
-cat <<EOF | sudo tee /etc/sysctl.d/99-zzz-override_cilium.conf
-# Disable rp_filter on ALL interfaces since it may cause mangled packets to be dropped
-# https://github.com/cilium/cilium/blob/v1.11.1/pkg/datapath/loader/base.go#L244
-net.ipv4.conf.all.rp_filter = 0
-EOF
-
 sudo sysctl --system
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -32,12 +32,6 @@ net.ipv4.ip_forward                 = 1
 net.netfilter.nf_conntrack_max      = 1000000
 vm.overcommit_memory                = 1
 EOF
-cat <<EOF | sudo tee /etc/sysctl.d/99-zzz-override_cilium.conf
-# Disable rp_filter on ALL interfaces since it may cause mangled packets to be dropped
-# https://github.com/cilium/cilium/blob/v1.11.1/pkg/datapath/loader/base.go#L244
-net.ipv4.conf.all.rp_filter = 0
-EOF
-
 sudo sysctl --system
 
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -43,12 +43,6 @@ net.ipv4.ip_forward                 = 1
 net.netfilter.nf_conntrack_max      = 1000000
 vm.overcommit_memory                = 1
 EOF
-cat <<EOF | sudo tee /etc/sysctl.d/99-zzz-override_cilium.conf
-# Disable rp_filter on ALL interfaces since it may cause mangled packets to be dropped
-# https://github.com/cilium/cilium/blob/v1.11.1/pkg/datapath/loader/base.go#L244
-net.ipv4.conf.all.rp_filter = 0
-EOF
-
 sudo sysctl --system
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We started setting `net.ipv4.conf.all.rp_filter` to `0` with #2089 to mitigate some issues with Cilium. Now Cilium is managing that rule on its own and we're running into conflicts when upgrading from Cilium v1.12 to v1.14. These conflicts are causing #2021 to happen again upon upgrading the cluster.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
`net.ipv4.conf.all.rp_filter` sysctl config is now managed by Cilium instead of KubeOne
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 