### PR TITLE
Fix indentation for vsphere-csi-node webhook

### DIFF
--- a/addons/csi-vsphere-ks/validatingwebhook.yaml
+++ b/addons/csi-vsphere-ks/validatingwebhook.yaml
@@ -135,23 +135,23 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-  {{ if .Config.CABundle }}
-  {{ caBundleEnvVar | indent 12 }}
-  {{ end }}
-volumeMounts:
-  - mountPath: /run/secrets/tls
-    name: webhook-certs
-    readOnly: true
-  {{ if .Config.CABundle }}
-  {{ caBundleVolumeMount | indent 12 }}
-  {{ end }}
-volumes:
-  - name: socket-dir
-    emptyDir: {}
-  - name: webhook-certs
-    secret:
-      secretName: vsphere-webhook-certs
-  {{ if .Config.CABundle }}
-  {{ caBundleVolume | indent 8 }}
-  {{ end }}
-  {{ end }}
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
+          volumeMounts:
+            - mountPath: /run/secrets/tls
+              name: webhook-certs
+              readOnly: true
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: webhook-certs
+          secret:
+            secretName: vsphere-webhook-certs
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
The addon `csi-vsphere-ks` is used for clean-up purposes; used to remove vSphere resources from kube-system namespace since they have been moved into a dedicated `vmware-system-csi` namespace, for reference https://github.com/kubermatic/kubeone/pull/2327.

This PR fixes the indentation issues in the `validatingWebhook` resource.

```
INFO[08:44:42 UTC] Deleting addon "csi-vsphere-ks"...
INFO[08:44:42 UTC] Parsing addons manifest 'validatingwebhook.yaml'
WARN[08:44:42 UTC] Task failed, error was: runtime: unmarshalling manifest "validatingwebhook.yaml"
error converting YAML to JSON: yaml: line 55: did not find expected key
```

KubeOne version: v1.6.2

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix indentation for manifests of csi-vsphere-ks addon
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
