### PR TITLE
Propagate CA Bundle to vSphere CSI driver

### DIFF
--- a/pkg/certificate/cabundle/ca-bundle.go
+++ b/pkg/certificate/cabundle/ca-bundle.go
@@ -57,11 +57,11 @@ func Inject(caBundle string, podTpl *corev1.PodTemplateSpec) {
 	}
 }
 
-func ConfigMap(caBundle string) *corev1.ConfigMap {
+func ConfigMap(caBundle, namespace string) *corev1.ConfigMap {
 	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ConfigMapName,
-			Namespace: metav1.NamespaceSystem,
+			Namespace: namespace,
 		},
 		Data: map[string]string{
 			FileName: caBundle,

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -287,6 +287,14 @@ func WithResources(t Tasks) Tasks {
 				Predicate:   func(s *state.State) bool { return s.Cluster.Addons != nil && s.Cluster.Addons.Enable },
 			},
 			{
+				Fn:          ensureVsphereCSICABundleConfigMap,
+				Operation:   "ensure vSphere CSI caBundle configMap",
+				Description: "ensure vSphere CSI caBundle configMap",
+				Predicate: func(s *state.State) bool {
+					return s.Cluster.CABundle != "" && s.Cluster.CloudProvider.Vsphere != nil && s.Cluster.CloudProvider.External && !s.Cluster.CloudProvider.DisableBundledCSIDrivers
+				},
+			},
+			{
 				Fn:        joinStaticWorkerNodes,
 				Operation: "joining static worker nodes to the cluster",
 			},

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -94,6 +94,7 @@ const (
 	MetricsServerName      = "metrics-server"
 	MetricsServerNamespace = metav1.NamespaceSystem
 
+	VsphereCSINamespace        = "vmware-system-csi"
 	VsphereCSIWebhookName      = "vsphere-webhook-svc"
 	VsphereCSIWebhookNamespace = "vmware-system-csi"
 	NutanixCSIWebhookName      = "csi-snapshot-webhook"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
With https://github.com/kubermatic/kubeone/pull/2292, we moved the vSphere CSI driver into a dedicated namespace `vmware-system-csi` from `kube-system`. Although the `ca-bundle` configmap was never copied to that namespace which results in broken CSI drivers when a caBundle is explicitly configured for a KubeOne cluster.

```sh
Warning  FailedMount  6s (x15 over 14m)    kubelet            MountVolume.SetUp failed for volume "ca-bundle" : configmap "ca-bundle" not found
pod: vsphere-csi-node-nbktv
```
KubeOne version: v1.6.2

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
KubeOne 1.6 and 1.5 would require manual backports.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Propagate CA Bundle to vSphere CSI driver
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
