### PR TITLE
Apply registry override to sandbox (pause) image

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -241,21 +241,23 @@ func (crc ContainerRuntimeConfig) CRISocket() string {
 	return ""
 }
 
-func (v VersionConfig) SandboxImage() (string, error) {
+func (v VersionConfig) SandboxImage(imageRegistry func(string) string) (string, error) {
 	kubeSemVer, err := semver.NewVersion(v.Kubernetes)
 	if err != nil {
 		return "", fail.Config(err, "parsing kubernetes semver")
 	}
 
+	registry := imageRegistry("registry.k8s.io")
+
 	switch {
 	case v124Constraint.Check(kubeSemVer):
-		return "registry.k8s.io/pause:3.7", nil
+		return fmt.Sprintf("%s/pause:3.7", registry), nil
 	case v125Constraint.Check(kubeSemVer):
-		return "registry.k8s.io/pause:3.8", nil
+		return fmt.Sprintf("%s/pause:3.8", registry), nil
 	case v126AndNewerConstraint.Check(kubeSemVer):
 		fallthrough
 	default:
-		return "registry.k8s.io/pause:3.9", nil
+		return fmt.Sprintf("%s/pause:3.9", registry), nil
 	}
 }
 

--- a/pkg/containerruntime/containerd_config.go
+++ b/pkg/containerruntime/containerd_config.go
@@ -81,7 +81,7 @@ type containerdRegistryTLSConfig struct {
 }
 
 func marshalContainerdConfig(cluster *kubeoneapi.KubeOneCluster) (string, error) {
-	sandboxImage, serr := cluster.Versions.SandboxImage()
+	sandboxImage, serr := cluster.Versions.SandboxImage(cluster.RegistryConfiguration.ImageRegistry)
 	if serr != nil {
 		return "", serr
 	}

--- a/pkg/containerruntime/testdata/Test_marshalContainerdConfig-override_insecure_registry.golden
+++ b/pkg/containerruntime/testdata/Test_marshalContainerdConfig-override_insecure_registry.golden
@@ -5,7 +5,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "some.registry/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -106,7 +106,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "127.0.0.1:5000/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -118,7 +118,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "127.0.0.1:5000/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -100,7 +100,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "127.0.0.1:5000/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -79,7 +79,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "127.0.0.1:5000/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
@@ -16,7 +16,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "some.registry/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -27,7 +27,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "127.0.0.1:5000/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
@@ -29,7 +29,7 @@ address = "127.0.0.1:1338"
 
 [plugins]
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "registry.k8s.io/pause:3.9"
+sandbox_image = "127.0.0.1:5000/pause:3.9"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -225,7 +225,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
 		nodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = cluster.AssetConfiguration.Pause.ImageRepository + "/pause:" + cluster.AssetConfiguration.Pause.ImageTag
 	} else {
-		sandboxImage, serr := cluster.Versions.SandboxImage()
+		sandboxImage, serr := cluster.Versions.SandboxImage(cluster.RegistryConfiguration.ImageRegistry)
 		if serr != nil {
 			return nil, serr
 		}
@@ -454,7 +454,7 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
 		nodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = cluster.AssetConfiguration.Pause.ImageRepository + "/pause:" + cluster.AssetConfiguration.Pause.ImageTag
 	} else {
-		sandboxImage, serr := cluster.Versions.SandboxImage()
+		sandboxImage, serr := cluster.Versions.SandboxImage(s.Cluster.RegistryConfiguration.ImageRegistry)
 		if serr != nil {
 			return nil, serr
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
For static nodes provisioned by KubeOne, there is no way to override the sandbox/pause image. This is possible already for MC and OSM, and KubeOne sets the `--pause-image` flags on those correctly (by applying registry overrides), so I believe that this is a bug and should be applied to static nodes as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`registryConfiguration.OverrideRegistry` is correctly applied to the pause image configured in static nodes (control plane and static workers)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
