### PR TITLE
Fix machinecontroller webhook escaping

### DIFF
--- a/addons/machinecontroller/webhook.yaml
+++ b/addons/machinecontroller/webhook.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: kube-system
 data:
 {{ range .RegistryCredentials }}
-  {{ .RegistryName }}: |
+  {{ .RegistryName | quote }}: |
 {{ mustToRawJson .Auth | b64enc | indent 4 }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add escaping of Registry name for the case when registry configured as wildcard.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2926

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add escaping of Registry name for the case when registry configured as wildcard.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
