### PR TITLE
allow credentials without VCD_API_TOKEN for vCloud-CSI and overwrite of vAppName

### DIFF
--- a/addons/csi-vmware-cloud-director/vcloud-basic-auth.yaml
+++ b/addons/csi-vmware-cloud-director/vcloud-basic-auth.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +7,4 @@ metadata:
 data:
   username: {{ .Credentials.VCD_USER | b64enc }}
   password: {{ .Credentials.VCD_PASSWORD | b64enc }}
-  refreshToken: {{ .Credentials.VCD_API_TOKEN | b64enc }}
+  refreshToken: {{ default "" .Credentials.VCD_API_TOKEN | b64enc }}

--- a/addons/csi-vmware-cloud-director/vcloud-csi-config.yaml
+++ b/addons/csi-vmware-cloud-director/vcloud-csi-config.yaml
@@ -11,6 +11,5 @@ data:
       host: {{ required "Please provide VCD_URL" (trimSuffix "/api" .Credentials.VCD_URL) }}
       org: {{ required "Please provide VCD_ORG" .Credentials.VCD_ORG }}
       vdc: {{ required "Please provide VCD_VDC" .Credentials.VCD_VDC }}
-      vAppName: {{ .Config.CloudProvider.VMwareCloudDirector.VApp }}
+      vAppName: {{ default .Config.CloudProvider.VMwareCloudDirector.VApp .Params.vApp }}
     clusterid: {{ default .Config.Name .Params.clusterid }}
----

--- a/addons/csi-vmware-cloud-director/vcloud-csi-config.yaml
+++ b/addons/csi-vmware-cloud-director/vcloud-csi-config.yaml
@@ -11,5 +11,5 @@ data:
       host: {{ required "Please provide VCD_URL" (trimSuffix "/api" .Credentials.VCD_URL) }}
       org: {{ required "Please provide VCD_ORG" .Credentials.VCD_ORG }}
       vdc: {{ required "Please provide VCD_VDC" .Credentials.VCD_VDC }}
-      vAppName: {{ default .Config.CloudProvider.VMwareCloudDirector.VApp .Params.vApp }}
+      vAppName: {{ default .Config.CloudProvider.VMwareCloudDirector.VApp .Params.vAppName }}
     clusterid: {{ default .Config.Name .Params.clusterid }}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This PR fixes a bug which results in failing to apply the embedded [csi-vmware-cloud-director](https://github.com/kubermatic/kubeone/tree/main/addons/csi-vmware-cloud-director) addon if no `VCD_API_TOKEN` is set.

2. This PR allows to overwrite and customize the `vAppName` value in the embedded [csi-vmware-cloud-director](https://github.com/kubermatic/kubeone/tree/main/addons/csi-vmware-cloud-director) addon. vAppName can then be set to different values than what is read from `.Config.CloudProvider.VMwareCloudDirector.VApp`.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Fixes a bug with the VMware Cloud Director CSI driver addon where it would crash if no `VCD_API_TOKEN` is set
- Support for customizing `vAppName` for VMware Cloud Director CSI driver
```

**Documentation**:
```documentation
NONE
```
