### PR TITLE
Drop containerRuntimeEndpoint field from KubeletConfiguration

### DIFF
--- a/pkg/templates/kubernetesconfigs/kubelet.go
+++ b/pkg/templates/kubernetesconfigs/kubelet.go
@@ -79,5 +79,5 @@ func NewKubeletConfiguration(cluster *kubeoneapi.KubeOneCluster, featureGates ma
 		kubeletConfig.ClusterDNS = []string{resources.NodeLocalDNSVirtualIP}
 	}
 
-	return dropFields(kubeletConfig, []string{"logging"})
+	return dropFields(kubeletConfig, []string{"logging"}, []string{"containerRuntimeEndpoint"})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The `containerRuntimeEndpoint` field has been introduced in Kubernetes v1.27. This is causing the following error when running `kubeadm init` and `kubeadm join` on Kubernetes versions prior to 1.27:

```
[172.31.120.97] W1030 16:39:28.325293   11979 initconfiguration.go:305] error unmarshaling configuration schema.GroupVersionKind{Group:"kubelet.config.k8s.io", Version:"v1beta1", Kind:"KubeletConfiguration"}: strict decoding error: unknown field "containerRuntimeEndpoint"
```

Given that we don't use this field at this time, we can just drop it for now.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Drop `containerRuntimeEndpoint` field from KubeletConfiguration to fix warning from `kubeadm init` and `kubeadm join` for clusters running Kubernetes prior to 1.27
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 