### PR TITLE
[release/v1.6] Update operating-system-manager (OSM) to v1.2.3

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -220,7 +220,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.56.4"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.2"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.3"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update operating-system-manager (OSM) to v1.2.3.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 