### PR TITLE
vcd: don't fail credential validation when only an API token is passed

### DIFF
--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -642,7 +642,7 @@ func vmwareCloudDirectorValidationFunc(creds map[string]string) error {
 	}
 
 	// Username and password are required when using default credentials i.e. username and password.
-	if !(username && password) {
+	if !apiToken && !(username && password) {
 		return fail.CredentialsError{
 			Op:       "validating",
 			Provider: "VMware Cloud Director",

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -163,3 +163,88 @@ func TestOpenstackValidationFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestVmwareCloudDirectorValidationFunc(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		creds map[string]string
+		err   error
+	}{
+		{
+			name:  "empty",
+			creds: map[string]string{},
+			err:   errors.New("key VCD_ORG is required but is not present"),
+		},
+		{
+			name: "no-credentials",
+			creds: map[string]string{
+				"VCD_ORG": "test",
+				"VCD_URL": "http://localhost:8080",
+				"VCD_VDC": "vdc",
+			},
+			err: errors.New("no valid credentials (either api token or user) found"),
+		},
+		{
+			name: "username-password",
+			creds: map[string]string{
+				"VCD_ORG":      "test",
+				"VCD_URL":      "http://localhost:8080",
+				"VCD_VDC":      "vdc",
+				"VCD_USER":     "user",
+				"VCD_PASSWORD": "password",
+			},
+			err: nil,
+		},
+		{
+			name: "username-no-password",
+			creds: map[string]string{
+				"VCD_ORG":  "test",
+				"VCD_URL":  "http://localhost:8080",
+				"VCD_VDC":  "vdc",
+				"VCD_USER": "user",
+			},
+			err: errors.New("key VCD_USER and VCD_PASSWORD are required but not present"),
+		},
+		{
+			name: "password-no-username",
+			creds: map[string]string{
+				"VCD_ORG":      "test",
+				"VCD_URL":      "http://localhost:8080",
+				"VCD_VDC":      "vdc",
+				"VCD_PASSWORD": "password",
+			},
+			err: errors.New("key VCD_USER and VCD_PASSWORD are required but not present"),
+		},
+		{
+			name: "api-token",
+			creds: map[string]string{
+				"VCD_ORG":       "test",
+				"VCD_URL":       "http://localhost:8080",
+				"VCD_VDC":       "vdc",
+				"VCD_API_TOKEN": "token",
+			},
+			err: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := vmwareCloudDirectorValidationFunc(tt.creds)
+			if tt.err != nil && err != nil {
+				var credsErr fail.CredentialsError
+				if !errors.As(err, &credsErr) {
+					t.Errorf("extected %T error type", credsErr)
+				}
+				if credsErr.Err.Error() != tt.err.Error() {
+					t.Errorf("expected error = '%v', got error = '%v'", tt.err.Error(), err.Error())
+				}
+			} else if !errors.Is(err, tt.err) {
+				t.Errorf("%s: expected error = %v, got error = %v", tt.name, tt.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This is a follow-up to #2751 as reported via INC-6166 to us. The linked PR updates the credential validation for VCD, but runs into the problem that it checks for two things in consecutive if conditions:

1. user credentials (username + password) and API token are mutually exclusive to each other
2. if username and password are not set, fail with them being required

These two conditions stacked on top of each other meant that `VCD_API_TOKEN` was never usable, as using it alongside user credentials was blocked by 1, but using it _without_ user credentials was blocked by 2.

The reporter helpfully pointed out the condition that this PR is updating. In addition, I've added a few simple test cases that should catch such errors in the future.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix incorrect validation that made `VCD_API_TOKEN` unusable for VMware Cloud Director
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
