### PR TITLE
Download cri-tools from Kubernetes repos instead of AL2 repos

### DIFF
--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -157,7 +157,14 @@ rm /tmp/k8s-binaries/kubectl
 sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 {{- end }}
 
-sudo yum install -y \
+# Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
+# priority over the Kubernetes repos, so it's not possible to install cri-tools
+# from the Kubenretes repos at all, even if the cri-tools version in the
+# Kubernetes repos is newer. This is a problem because recent Kubernetes
+# versions require cri-tools versions that are newer than the latest available
+# cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
+# to install cri-tools from the Kubernetes repos.
+sudo yum install -y --disableplugin=priorities \
 {{- if .KUBELET }}
 	kubelet-{{ .KUBERNETES_VERSION }} \
 {{- end }}

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -99,7 +99,14 @@ cd /tmp/k8s-binaries
 
 
 
-sudo yum install -y \
+# Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
+# priority over the Kubernetes repos, so it's not possible to install cri-tools
+# from the Kubenretes repos at all, even if the cri-tools version in the
+# Kubernetes repos is newer. This is a problem because recent Kubernetes
+# versions require cri-tools versions that are newer than the latest available
+# cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
+# to install cri-tools from the Kubernetes repos.
+sudo yum install -y --disableplugin=priorities \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -137,7 +137,14 @@ cd /tmp/k8s-binaries
 
 
 
-sudo yum install -y \
+# Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
+# priority over the Kubernetes repos, so it's not possible to install cri-tools
+# from the Kubenretes repos at all, even if the cri-tools version in the
+# Kubernetes repos is newer. This is a problem because recent Kubernetes
+# versions require cri-tools versions that are newer than the latest available
+# cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
+# to install cri-tools from the Kubernetes repos.
+sudo yum install -y --disableplugin=priorities \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -139,7 +139,14 @@ cd /tmp/k8s-binaries
 
 
 
-sudo yum install -y \
+# Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
+# priority over the Kubernetes repos, so it's not possible to install cri-tools
+# from the Kubenretes repos at all, even if the cri-tools version in the
+# Kubernetes repos is newer. This is a problem because recent Kubernetes
+# versions require cri-tools versions that are newer than the latest available
+# cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
+# to install cri-tools from the Kubernetes repos.
+sudo yum install -y --disableplugin=priorities \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeOne is failing to provision a Kubernetes 1.28 cluster on Amazon Linux 2:

```
[172.31.97.42] 1 packages excluded due to repository priority protections
[172.31.96.130] --> Finished Dependency Resolution
[172.31.96.130]  You could try using --skip-broken to work around the problem
[172.31.96.130] Error: Package: kubeadm-1.28.3-150500.1.1.x86_64 (kubernetes)
[172.31.96.130]            Requires: cri-tools >= 1.28.0
[172.31.96.130]            Available: cri-tools-1.25.0-1.amzn2.0.1.x86_64 (amzn2-core)
[172.31.96.130]                cri-tools = 1.25.0-1.amzn2.0.1
[172.31.96.130]            Available: cri-tools-1.26.1-1.amzn2.0.1.x86_64 (amzn2-core)
[172.31.96.130]                cri-tools = 1.26.1-1.amzn2.0.1
[172.31.96.130]            Available: cri-tools-1.26.1-1.amzn2.0.2.x86_64 (amzn2-core)
[172.31.96.130]                cri-tools = 1.26.1-1.amzn2.0.2
[172.31.96.130]            Available: cri-tools-1.26.1-1.amzn2.0.3.x86_64 (amzn2-core)
[172.31.96.130]                cri-tools = 1.26.1-1.amzn2.0.3
[172.31.96.130]  You could try running: rpm -Va --nofiles --nodigest
```

Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher priority over the Kubernetes repos, so it's not possible to install cri-tools from the Kubenretes repos at all, even if the cri-tools version in the Kubernetes repos is newer.

This is a problem because recent Kubernetes versions require cri-tools versions that are newer than the latest available cri-tools in the AL2 repos. We disable the priorities plugin to allow yum to install cri-tools from the Kubernetes repos.

**Which issue(s) this PR fixes**:
xref #2834 

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Download cri-tools from the Kubernetes repos instead of the Amazon Linux 2 repos on instances running Amazon Linux 2
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 