### PR TITLE
[release/v1.7] Update metrics-server, cluster-autoscaler, Canal, Calico VXLAN, and Cilium

### DIFF
--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -1,4 +1,4 @@
-# Source: https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico-vxlan.yaml
+# Source: https://raw.githubusercontent.com/projectcalico/calico/v3.26.3/manifests/calico-vxlan.yaml
 ---
 # Source: calico/templates/calico-kube-controllers.yaml
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
@@ -4648,6 +4648,7 @@ spec:
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
           image: {{ .InternalImages.Get "CalicoVXLANCNI" }}
+          imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -4675,6 +4676,7 @@ spec:
         # and CNI network config file on each node.
         - name: install-cni
           image: {{ .InternalImages.Get "CalicoVXLANCNI" }}
+          imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4717,6 +4719,7 @@ spec:
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
           image: {{ .InternalImages.Get "CalicoVXLANNode" }}
+          imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
             - mountPath: /sys/fs
@@ -4742,6 +4745,7 @@ spec:
         # host.
         - name: calico-node
           image: {{ .InternalImages.Get "CalicoVXLANNode" }}
+          imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4969,6 +4973,7 @@ spec:
       containers:
         - name: calico-kube-controllers
           image: {{ .InternalImages.Get "CalicoVXLANController" }}
+          imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/projectcalico/calico/blob/v3.26.1/manifests/canal.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.26.3/manifests/canal.yaml
 ---
 # Source: calico/templates/calico-kube-controllers.yaml
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict

--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -1,12 +1,14 @@
 # Generated from:
-#   helm template cilium cilium/cilium --version 1.14.1 --namespace kube-system --set operator.replicas=1 \
+#   helm template cilium cilium/cilium --version 1.14.3 --namespace kube-system --set operator.replicas=1 \
 #     --set hubble.tls.auto.method=cronJob --set hubble.relay.enabled=true --set hubble.ui.enabled=true \
-#     --set kubeProxyReplacement=strict --set k8sServiceHost=CHANGEME --set k8sServicePort=CHANGEME
+#     --set kubeProxyReplacement=strict --set k8sServiceHost=CHANGEME --set k8sServicePort=CHANGEME \
+#     --set cni.exclusive=false
 #
 # Modifications:
 #   - templated cluster-pool-ipv4-cidr
 #   - templated kube-proxy-replacement parts
 #   - added seccomp profile to cilium-operator
+#   - disable cni.exclusive to allow for Multus CNI use cases
 {{ $hubble_ipv6 := default "true" .Params.HubbleIPv6 }}
 ---
 # Source: cilium/templates/cilium-agent/serviceaccount.yaml
@@ -70,8 +72,6 @@ data:
   cilium-endpoint-gc-interval: "5m0s"
   nodes-gc-interval: "5m0s"
   skip-cnp-status-startup-clean: "false"
-  # Disable the usage of CiliumEndpoint CRD
-  disable-endpoint-crd: "false"
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -297,9 +297,9 @@ data:
 # The only difference between those two configs is that non-IPv6 config
 # doesn't have `listen       [::]:8081;`
 {{ if eq $hubble_ipv6 "true" }}
-  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n\n        location / {\n            try_files $uri $uri/ /index.html;\n        }\n    }\n}"
+  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            # double `/index.html` is required here \n            try_files $uri $uri/ /index.html /index.html;\n        }\n    }\n}"
 {{ else }}
-  nginx.conf: "server {\n    listen       8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n\n        location / {\n            try_files $uri $uri/ /index.html;\n        }\n    }\n}"
+  nginx.conf: "server {\n    listen       8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            # double `/index.html` is required here \n            try_files $uri $uri/ /index.html /index.html;\n        }\n    }\n}"
 {{ end }}
 ---
 {{ end }}
@@ -598,11 +598,11 @@ rules:
   - list
   - watch
 - apiGroups:
-  - cilium.io
+    - cilium.io
   resources:
-  - ciliumpodippools
+    - ciliumpodippools
   verbs:
-  - create
+    - create
 - apiGroups:
   - cilium.io
   resources:
@@ -1214,7 +1214,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - name: cni-path
-            mountPath: /host/opt/cni/bin
+            mountPath: /host/opt/cni/bin # .Values.cni.install
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: "cilium"
@@ -1654,6 +1654,11 @@ spec:
           restartPolicy: OnFailure
       ttlSecondsAfterFinished: 1800
 ---
+# Source: cilium/templates/cilium-secrets-namespace.yaml
+# Only create the namespace if it's different from Ingress secret namespace or Ingress is not enabled.
+
+# Only create the namespace if it's different from Ingress and Gateway API secret namespaces (if enabled).
+---
 # Source: cilium/templates/hubble/tls-cronjob/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -1664,6 +1669,8 @@ metadata:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs
     app.kubernetes.io/part-of: cilium
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
 spec:
   template:
     metadata:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -213,13 +213,13 @@ func FindResource(name string) (Resource, error) {
 
 func baseResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
-		CalicoCNI:              {"*": "quay.io/calico/cni:v3.26.1"},
-		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.26.1"},
-		CalicoNode:             {"*": "quay.io/calico/node:v3.26.1"},
+		CalicoCNI:              {"*": "quay.io/calico/cni:v3.26.3"},
+		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.26.3"},
+		CalicoNode:             {"*": "quay.io/calico/node:v3.26.3"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.23"},
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.57.3"},
-		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.3"},
+		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.4"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.3.3"},
 	}
 }
@@ -404,26 +404,26 @@ func optionalResources() map[Resource]map[string]string {
 		WeaveNetCNINPC:  {"*": "docker.io/weaveworks/weave-npc:2.8.1"},
 
 		// Cilium
-		Cilium:         {"*": "quay.io/cilium/cilium:v1.14.1@sha256:edc1d05ea1365c4a8f6ac6982247d5c145181704894bb698619c3827b6963a72"},
-		CiliumOperator: {"*": "quay.io/cilium/operator-generic:v1.14.1@sha256:e061de0a930534c7e3f8feda8330976367971238ccafff42659f104effd4b5f7"},
+		Cilium:         {"*": "quay.io/cilium/cilium:v1.14.3@sha256:e5ca22526e01469f8d10c14e2339a82a13ad70d9a359b879024715540eef4ace"},
+		CiliumOperator: {"*": "quay.io/cilium/operator-generic:v1.14.3@sha256:c9613277b72103ed36e9c0d16b9a17cafd507461d59340e432e3e9c23468b5e2"},
 
 		// Calico VXLAN
-		CalicoVXLANCNI:        {"*": "quay.io/calico/cni:v3.26.1"},
-		CalicoVXLANController: {"*": "quay.io/calico/kube-controllers:v3.26.1"},
-		CalicoVXLANNode:       {"*": "quay.io/calico/node:v3.26.1"},
+		CalicoVXLANCNI:        {"*": "quay.io/calico/cni:v3.26.3"},
+		CalicoVXLANController: {"*": "quay.io/calico/kube-controllers:v3.26.3"},
+		CalicoVXLANNode:       {"*": "quay.io/calico/node:v3.26.3"},
 
 		// Hubble
-		HubbleRelay:     {"*": "quay.io/cilium/hubble-relay:v1.14.1@sha256:db30e85a7abc10589ce2a97d61ee18696a03dc5ea04d44b4d836d88bd75b59d8"},
-		HubbleUI:        {"*": "quay.io/cilium/hubble-ui:v0.12.0@sha256:1c876cfa1d5e35bc91e1025c9314f922041592a88b03313c22c1f97a5d2ba88f"},
-		HubbleUIBackend: {"*": "quay.io/cilium/hubble-ui-backend:v0.12.0@sha256:8a79a1aad4fc9c2aa2b3e4379af0af872a89fcec9d99e117188190671c66fc2e"},
-		CiliumCertGen:   {"*": "quay.io/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"},
+		HubbleRelay:     {"*": "quay.io/cilium/hubble-relay:v1.14.3@sha256:3f5c425faca4f8a38e29d4f86db2aadd8f33c9f05debd78a2bb2a24dd9e565d8"},
+		HubbleUI:        {"*": "quay.io/cilium/hubble-ui:v0.12.1@sha256:9e5f81ee747866480ea1ac4630eb6975ff9227f9782b7c93919c081c33f38267"},
+		HubbleUIBackend: {"*": "quay.io/cilium/hubble-ui-backend:v0.12.1@sha256:1f86f3400827a0451e6332262467f894eeb7caf0eb8779bd951e2caa9d027cbe"},
+		CiliumCertGen:   {"*": "quay.io/cilium/certgen:v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"},
 
 		// Cluster-autoscaler addon
 		ClusterAutoscaler: {
-			"1.24.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.2",
-			"1.25.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.2",
-			"1.26.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.3",
-			">= 1.27.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.2",
+			"1.24.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.3",
+			"1.25.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.3",
+			"1.26.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.4",
+			">= 1.27.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.3",
 		},
 
 		// CSI Vault Secret Provider


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #2949

- Update metrics-server and cluster-autoscaler
- Update Canal to v3.26.3
- Update Calico VXLAN to v3.26.3
- Update Cilium to v1.14.3

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update metrics-server and cluster-autoscaler
- Update Canal to v3.26.3
- Update Calico VXLAN to v3.26.3
- Update Cilium to v1.14.3
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 