### PR TITLE
Fix globbing for apt-get install

### DIFF
--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -70,9 +70,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 sudo apt-get update
 {{- end }}
 
-kube_ver="{{ .KUBERNETES_VERSION }}*"
-cni_ver="{{ .KUBERNETES_CNI_VERSION }}*"
-cri_ver="{{ .CRITOOLS_VERSION }}*"
+kube_ver="{{ .KUBERNETES_VERSION }}-*"
+cni_ver="{{ .KUBERNETES_CNI_VERSION }}-*"
+cri_ver="{{ .CRITOOLS_VERSION }}-*"
 
 {{- if or .FORCE .UPGRADE }}
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -68,9 +68,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -65,9 +65,9 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 sudo apt-get update
 
-kube_ver="1.26.0*"
-cni_ver="1.2.0*"
-cri_ver="1.26.0*"
+kube_ver="1.26.0-*"
+cni_ver="1.2.0-*"
+cri_ver="1.26.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We have issue with globbing in `apt-get` install commands used to install Kubernetes. It can happen that `1.x.1*` resolves to `1.x.10-1.1` instead of `1.x.1-1.1`

```shell
sudo DEBIAN_FRONTEND=noninteractive apt-get install --option Dpkg::Options::=--force-confold --no-install-recommends -y 'kubelet=1.26.1*' 'kubeadm=1.26.1*' 'kubectl=1.26.1*' 'kubernetes-cni=1.2.0*' 'cri-tools=1.26.0*'
```

This is fixed by changing the version passed to `apt-get` command to include `-` after version, so the glob only matches the revision part and not the version part.

This problem should only affect users trying to install `1.x.1` after `1.x.10` has been released.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix a globbing issue for `apt-get install` causing KubeOne to install wrong Kubernetes version in some circumstances
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 