### PR TITLE
Fix release date for KubeOne 1.7.1

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -1,4 +1,4 @@
-# [v1.7.1](https://github.com/kubermatic/kubeone/releases/tag/v1.7.1) - 2023-11-09
+# [v1.7.1](https://github.com/kubermatic/kubeone/releases/tag/v1.7.1) - 2023-11-10
 
 ## Changelog since v1.7.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeOne 1.7.1 is actually going out today, not yesterday

**What type of PR is this?**

/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 