### PR TITLE
Conditional Templating for VCD_USER, VCD_Password, VCD_API_TOKEN

### DIFF
--- a/addons/csi-vmware-cloud-director/vcloud-basic-auth.yaml
+++ b/addons/csi-vmware-cloud-director/vcloud-basic-auth.yaml
@@ -5,6 +5,12 @@ metadata:
   name: vcloud-basic-auth
   namespace: kube-system
 data:
-  username: {{ default "" .Credentials.VCD_USER | b64enc }}
-  password: {{ default "" .Credentials.VCD_PASSWORD | b64enc }}
-  refreshToken: {{ default "" .Credentials.VCD_API_TOKEN | b64enc }}
+{{- with .Credentials.VCD_USER }}
+  username: {{ . | b64enc }}
+{{- end }}
+{{- with .Credentials.VCD_PASSWORD }}
+  password: {{ . | b64enc }}
+{{- end }}
+{{- with .Credentials.VCD_API_TOKEN }}
+  refreshToken: {{ . | b64enc }}
+{{- end }}

--- a/addons/csi-vmware-cloud-director/vcloud-basic-auth.yaml
+++ b/addons/csi-vmware-cloud-director/vcloud-basic-auth.yaml
@@ -5,6 +5,6 @@ metadata:
   name: vcloud-basic-auth
   namespace: kube-system
 data:
-  username: {{ .Credentials.VCD_USER | b64enc }}
-  password: {{ .Credentials.VCD_PASSWORD | b64enc }}
+  username: {{ default "" .Credentials.VCD_USER | b64enc }}
+  password: {{ default "" .Credentials.VCD_PASSWORD | b64enc }}
   refreshToken: {{ default "" .Credentials.VCD_API_TOKEN | b64enc }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
This came in via a support ticket. Without any defaults, the b64enc func fails if username/password are being left empty

```
INFO[10:49:53 CET] Parsing addons manifest 'vcloud-basic-auth.yaml'
WARN[10:49:53 CET] Task failed, error was: runtime: executing addons manifest template "vcloud-basic-auth.yaml"
template: addons-base:8:39: executing "addons-base" at <b64enc>: invalid value; expected string
```

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

I think the requester assumes that leaving username and password empty should be possible. I am not super familiar with vmware vcloud, so I am not sure if that makes sense. It would be good if you could double check this. 
If the two are fields required, then maybe we could make use of the `required` template func in order to avoid confusion?

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
