### PR TITLE
Migrate AzureDisk CSI Node CRB if subject is csi-azuredisk-node-sa

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -354,7 +354,7 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			addonAction{
 				name: resources.AddonCSIAzureDisk,
 				supportFn: func() error {
-					return migrateAzureDiskCSIDriver(s)
+					return migrateAzureDiskCSI(s)
 				},
 			},
 			addonAction{


### PR DESCRIPTION
**What this PR does / why we need it**:

Delete AzureDisk's `csi-azuredisk-node-secret-binding` ClusterRoleBinding if RoleRef's name is `csi-azuredisk-node-sa` to allow upgrading KubeOne from 1.6 to 1.7.

**Which issue(s) this PR fixes**:
Fixes #2971

**What type of PR is this?**

/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Delete AzureDisk's `csi-azuredisk-node-secret-binding` ClusterRoleBinding if RoleRef's name is `csi-azuredisk-node-sa` to allow upgrading KubeOne from 1.6 to 1.7
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/1581
```

/assign @kron4eg @ahmedwaleedmalik 