### PR TITLE
Use env to determine cluster name used by OpenStack CCM and CSI, increase memory limits and requests for cluster-autoscaler

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -189,10 +189,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 300Mi
+            memory: 600Mi
           requests:
             cpu: 100m
-            memory: 300Mi
+            memory: 600Mi
       serviceAccountName: cluster-autoscaler
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -941,7 +941,14 @@ func detectClusterName(s *state.State) (string, error) {
 		}
 		for _, flag := range container.Command {
 			if strings.HasPrefix(flag, "--cluster-name") {
-				return strings.Split(flag, "=")[1], nil
+				if val := strings.Split(flag, "=")[1]; val != "$(CLUSTER_NAME)" {
+					return val, nil
+				}
+			}
+		}
+		for _, env := range container.Env {
+			if env.Name == "CLUSTER_NAME" {
+				return env.Value, nil
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We are using the `CLUSTER_NAME` environment variable instead of the `--cluster-name` flag on the OpenStack CCM since KubeOne 1.7. This broke determining the cluster name used by the CCM, so if you upgrade from KubeOne 1.6 to 1.7 and run `kubeone apply` two or more times, the cluster name will be changed to `kubernetes` (default value).

This PR also increases the memory requests and limits for cluster-autoscaler from 300Mi to 600Mi given that we received reports that cluster-autoscaler is getting OOMKilled.

**Which issue(s) this PR fixes**:

Fixes #2976
Fixes #2975 

**What type of PR is this?**

/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- [ACTION REQUIRED] Use the `CLUSTER_NAME` environment variable from the OpenStack CCM pods to determine the current cluster name used by the OpenStack CCM. Fixes a regression where cluster name was changed to `kubernetes` upon running `kubeone apply` two or more times after upgrading from KubeOne 1.6 to KubeOne 1.7. Please check the known issues document to find if you're affected by this issue and what steps you need to take if you're affected
- Increase the memory requests and limits from 300Mi to 600Mi for cluster-autoscaler
```

**Documentation**:
```documentation
TBD
```

/assign @kron4eg 