### PR TITLE
Update backup-restic to etcd 3.5.11 and fix addon documentation

### DIFF
--- a/addons/backups-restic/README.md
+++ b/addons/backups-restic/README.md
@@ -18,7 +18,7 @@ storing backups.
 
 You need to replace the following values with the actual ones:
 * `<<RESTIC_PASSWORD>>` - a password used to encrypt the backups
-* `<<S3_BUCKET>>` - the name of the S3 bucket to be used for backups
+* `<<S3_BUCKET>>` - the restic-style path of the repository to be used for backups (e.g. `s3:s3.amazonaws.com/<backup-bucket-name>`)
 * `<<AWS_DEFAULT_REGION>>` - default AWS region
 
 Credentials are fetched automatically if you are deploying on AWS. If you want to use

--- a/addons/backups-restic/backups-restic.yaml
+++ b/addons/backups-restic/backups-restic.yaml
@@ -52,24 +52,14 @@ spec:
               path: /etc/kubernetes/pki
           initContainers:
           - name: snapshoter
-            image: {{ Registry "gcr.io" }}/etcd-development/etcd:v3.5.6
+            image: {{ Registry "gcr.io" }}/etcd-development/etcd:v3.5.11
             imagePullPolicy: IfNotPresent
             command:
-            - /bin/sh
-            - -c
-            - |-
-              set -euf
-              mkdir -p /backup/pki/kubernetes
-              mkdir -p /backup/pki/etcd
-              cp -a /etc/kubernetes/pki/etcd/ca.crt /backup/pki/etcd/
-              cp -a /etc/kubernetes/pki/etcd/ca.key /backup/pki/etcd/
-              cp -a /etc/kubernetes/pki/ca.crt /backup/pki/kubernetes
-              cp -a /etc/kubernetes/pki/ca.key /backup/pki/kubernetes
-              cp -a /etc/kubernetes/pki/front-proxy-ca.crt /backup/pki/kubernetes
-              cp -a /etc/kubernetes/pki/front-proxy-ca.key /backup/pki/kubernetes
-              cp -a /etc/kubernetes/pki/sa.key /backup/pki/kubernetes
-              cp -a /etc/kubernetes/pki/sa.pub /backup/pki/kubernetes
-              etcdctl snapshot save /backup/etcd-snapshot.db
+              - etcdctl
+            args:
+              - snapshot
+              - save
+              - /backup/etcd-snapshot.db
             env:
             - name: ETCDCTL_API
               value: "3"
@@ -100,6 +90,16 @@ spec:
             - -c
             - |-
               set -euf
+              mkdir -p /backup/pki/kubernetes
+              mkdir -p /backup/pki/etcd
+              cp -a /etc/kubernetes/pki/etcd/ca.crt /backup/pki/etcd/
+              cp -a /etc/kubernetes/pki/etcd/ca.key /backup/pki/etcd/
+              cp -a /etc/kubernetes/pki/ca.crt /backup/pki/kubernetes
+              cp -a /etc/kubernetes/pki/ca.key /backup/pki/kubernetes
+              cp -a /etc/kubernetes/pki/front-proxy-ca.crt /backup/pki/kubernetes
+              cp -a /etc/kubernetes/pki/front-proxy-ca.key /backup/pki/kubernetes
+              cp -a /etc/kubernetes/pki/sa.key /backup/pki/kubernetes
+              cp -a /etc/kubernetes/pki/sa.pub /backup/pki/kubernetes
               restic snapshots -q || restic init -q
               restic backup --tag=etcd --host=${ETCD_HOSTNAME} /backup
               restic forget --prune --keep-last 48
@@ -130,3 +130,6 @@ spec:
             volumeMounts:
             - mountPath: /backup
               name: etcd-backup
+            - mountPath: /etc/kubernetes/pki
+              name: host-pki
+              readOnly: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This updates the `backup-restic` addon to use etcd 3.5.11, the latest available 3.5.x image. Because the images are now using distroless, I have moved the parts that copy the certificates into the backup into the `restic` container before uploading the backup. Given that the container will have access to these files anyway (since its uploading them to s3), I did not see any gain from having another initContainer doing it.

In addition, while trying out the addon, I ran into a documentation issue - The `s3Bucket` param does _not_ do what it's documented to do. If you just put a bucket name as is documented, the backups will be written to a local folder (because `RESTIC_REPOSITORY` is set to the contents of `s3Bucket` verbatim).

Now I had two choices, either fix the way `RESTIC_REPOSITORY` is set from `s3Bucket` or update documentation for the field. I have chosen to go with the latter, because anyone using the addon and validating their backups (which I hope everyone does ... right?) would have figured this out already. I'm afraid that breaking the existing way is going to create more issues (break it for everyone who already sets the `s3:/` part).

I'm open to change this in a follow-up PR, but it wasn't the focus of this one so I just wanted to write down the as-is situation correctly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2980

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update backup-restic addon to use etcd 3.5.11 for creating etcd snapshots
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1591
```
