### PR TITLE
[release/v1.7] Update Go to 1.21.5 and machine-controller to v1.57.4

### DIFF
--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -330,7 +330,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -355,7 +355,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -380,7 +380,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -405,7 +405,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -428,7 +428,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -451,7 +451,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -475,7 +475,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -498,7 +498,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -521,7 +521,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -544,7 +544,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -569,7 +569,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -594,7 +594,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -619,7 +619,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -645,7 +645,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -670,7 +670,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -693,7 +693,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -718,7 +718,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -743,7 +743,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -768,7 +768,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -794,7 +794,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -819,7 +819,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -842,7 +842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -872,7 +872,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -902,7 +902,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -932,7 +932,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -963,7 +963,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -993,7 +993,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1021,7 +1021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1049,7 +1049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1077,7 +1077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1105,7 +1105,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1133,7 +1133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1161,7 +1161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1189,7 +1189,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1219,7 +1219,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1249,7 +1249,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1279,7 +1279,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1310,7 +1310,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1340,7 +1340,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1368,7 +1368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1396,7 +1396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1424,7 +1424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1452,7 +1452,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1480,7 +1480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1508,7 +1508,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1536,7 +1536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1566,7 +1566,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1596,7 +1596,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1626,7 +1626,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1657,7 +1657,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1687,7 +1687,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1715,7 +1715,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1745,7 +1745,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1775,7 +1775,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1805,7 +1805,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1835,7 +1835,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1865,7 +1865,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1890,7 +1890,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1915,7 +1915,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1940,7 +1940,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1966,7 +1966,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1991,7 +1991,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2014,7 +2014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2037,7 +2037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2060,7 +2060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2083,7 +2083,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2106,7 +2106,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2129,7 +2129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2152,7 +2152,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2177,7 +2177,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2202,7 +2202,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2227,7 +2227,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2253,7 +2253,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2278,7 +2278,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2301,7 +2301,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2326,7 +2326,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2351,7 +2351,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2376,7 +2376,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2401,7 +2401,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2424,7 +2424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2447,7 +2447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2470,7 +2470,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2495,7 +2495,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2520,7 +2520,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2545,7 +2545,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2571,7 +2571,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2596,7 +2596,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2619,7 +2619,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2644,7 +2644,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2669,7 +2669,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2694,7 +2694,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2720,7 +2720,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2745,7 +2745,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2768,7 +2768,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2791,7 +2791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2814,7 +2814,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2837,7 +2837,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2860,7 +2860,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2883,7 +2883,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2906,7 +2906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2931,7 +2931,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2956,7 +2956,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2981,7 +2981,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3007,7 +3007,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3032,7 +3032,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3055,7 +3055,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3080,7 +3080,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3105,7 +3105,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3130,7 +3130,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3155,7 +3155,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3178,7 +3178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3201,7 +3201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3224,7 +3224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3254,7 +3254,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3284,7 +3284,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3314,7 +3314,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3345,7 +3345,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3375,7 +3375,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3403,7 +3403,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3431,7 +3431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3459,7 +3459,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3487,7 +3487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3515,7 +3515,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3543,7 +3543,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3571,7 +3571,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3601,7 +3601,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3631,7 +3631,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3661,7 +3661,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3692,7 +3692,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3722,7 +3722,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3750,7 +3750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3780,7 +3780,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3810,7 +3810,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3840,7 +3840,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3870,7 +3870,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3898,7 +3898,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3926,7 +3926,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3954,7 +3954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3979,7 +3979,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4004,7 +4004,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4029,7 +4029,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4054,7 +4054,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4079,7 +4079,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4102,7 +4102,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4125,7 +4125,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4148,7 +4148,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4171,7 +4171,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4194,7 +4194,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4217,7 +4217,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4240,7 +4240,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4265,7 +4265,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4290,7 +4290,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4315,7 +4315,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4341,7 +4341,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4366,7 +4366,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4389,7 +4389,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4412,7 +4412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4437,7 +4437,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4462,7 +4462,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4487,7 +4487,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4512,7 +4512,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4535,7 +4535,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4558,7 +4558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4581,7 +4581,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4604,7 +4604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4627,7 +4627,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4650,7 +4650,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4675,7 +4675,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4700,7 +4700,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4725,7 +4725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4751,7 +4751,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4776,7 +4776,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4799,7 +4799,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4824,7 +4824,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4849,7 +4849,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4874,7 +4874,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4900,7 +4900,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4925,7 +4925,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4948,7 +4948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4971,7 +4971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4994,7 +4994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5017,7 +5017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5040,7 +5040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5063,7 +5063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5086,7 +5086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5109,7 +5109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5134,7 +5134,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5159,7 +5159,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5184,7 +5184,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5209,7 +5209,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5234,7 +5234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5259,7 +5259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5284,7 +5284,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5310,7 +5310,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5335,7 +5335,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5358,7 +5358,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5381,7 +5381,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5404,7 +5404,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5427,7 +5427,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5450,7 +5450,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5473,7 +5473,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5498,7 +5498,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5523,7 +5523,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5548,7 +5548,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5574,7 +5574,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5599,7 +5599,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5624,7 +5624,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5649,7 +5649,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5674,7 +5674,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5700,7 +5700,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5725,7 +5725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5748,7 +5748,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5771,7 +5771,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5794,7 +5794,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5817,7 +5817,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5840,7 +5840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5863,7 +5863,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5888,7 +5888,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5913,7 +5913,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5938,7 +5938,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5964,7 +5964,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5989,7 +5989,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6012,7 +6012,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6035,7 +6035,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6058,7 +6058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6081,7 +6081,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6104,7 +6104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6127,7 +6127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6150,7 +6150,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6173,7 +6173,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6196,7 +6196,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6219,7 +6219,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6242,7 +6242,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6267,7 +6267,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6292,7 +6292,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6317,7 +6317,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6342,7 +6342,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6365,7 +6365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6388,7 +6388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6411,7 +6411,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6434,7 +6434,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6457,7 +6457,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6480,7 +6480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6503,7 +6503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6526,7 +6526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6549,7 +6549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6574,7 +6574,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6599,7 +6599,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6624,7 +6624,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6650,7 +6650,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6675,7 +6675,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6698,7 +6698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6721,7 +6721,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6744,7 +6744,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6767,7 +6767,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6790,7 +6790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6813,7 +6813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6836,7 +6836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6859,7 +6859,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6882,7 +6882,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6905,7 +6905,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6928,7 +6928,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6953,7 +6953,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6978,7 +6978,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7003,7 +7003,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7028,7 +7028,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7051,7 +7051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7074,7 +7074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7097,7 +7097,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7120,7 +7120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7143,7 +7143,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7167,7 +7167,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7190,7 +7190,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7213,7 +7213,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7236,7 +7236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7261,7 +7261,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7286,7 +7286,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7311,7 +7311,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7337,7 +7337,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7362,7 +7362,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7385,7 +7385,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7408,7 +7408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7431,7 +7431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7454,7 +7454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7477,7 +7477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7500,7 +7500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7523,7 +7523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7546,7 +7546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7569,7 +7569,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7592,7 +7592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7615,7 +7615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7640,7 +7640,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7665,7 +7665,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7690,7 +7690,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7715,7 +7715,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7738,7 +7738,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7761,7 +7761,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7784,7 +7784,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7812,7 +7812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7840,7 +7840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7868,7 +7868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7896,7 +7896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7924,7 +7924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7952,7 +7952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7982,7 +7982,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8012,7 +8012,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8042,7 +8042,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8073,7 +8073,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8103,7 +8103,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8131,7 +8131,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8159,7 +8159,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8187,7 +8187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8215,7 +8215,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8243,7 +8243,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8271,7 +8271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8299,7 +8299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8327,7 +8327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8355,7 +8355,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8383,7 +8383,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8413,7 +8413,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8443,7 +8443,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8473,7 +8473,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8503,7 +8503,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8533,7 +8533,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8561,7 +8561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8589,7 +8589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8617,7 +8617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8645,7 +8645,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8673,7 +8673,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8701,7 +8701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8729,7 +8729,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8757,7 +8757,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8785,7 +8785,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8815,7 +8815,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8845,7 +8845,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8875,7 +8875,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8906,7 +8906,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8936,7 +8936,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8964,7 +8964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8992,7 +8992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9020,7 +9020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9048,7 +9048,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9076,7 +9076,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9104,7 +9104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9132,7 +9132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9160,7 +9160,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9188,7 +9188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9216,7 +9216,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9246,7 +9246,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9276,7 +9276,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9306,7 +9306,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9336,7 +9336,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9366,7 +9366,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9394,7 +9394,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9422,7 +9422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9450,7 +9450,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9478,7 +9478,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9506,7 +9506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9534,7 +9534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9562,7 +9562,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9590,7 +9590,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9618,7 +9618,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9648,7 +9648,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9678,7 +9678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9708,7 +9708,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9739,7 +9739,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9769,7 +9769,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9797,7 +9797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9825,7 +9825,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9853,7 +9853,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9881,7 +9881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9909,7 +9909,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9937,7 +9937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9965,7 +9965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9993,7 +9993,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10021,7 +10021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10049,7 +10049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10079,7 +10079,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10109,7 +10109,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10139,7 +10139,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10169,7 +10169,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10199,7 +10199,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10227,7 +10227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10255,7 +10255,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10283,7 +10283,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10306,7 +10306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10329,7 +10329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10352,7 +10352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10375,7 +10375,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10398,7 +10398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10421,7 +10421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10446,7 +10446,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10471,7 +10471,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10496,7 +10496,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10522,7 +10522,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10547,7 +10547,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10570,7 +10570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10593,7 +10593,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10616,7 +10616,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10639,7 +10639,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10662,7 +10662,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10685,7 +10685,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10708,7 +10708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10731,7 +10731,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10754,7 +10754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10777,7 +10777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10800,7 +10800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10825,7 +10825,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10850,7 +10850,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10875,7 +10875,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10900,7 +10900,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10923,7 +10923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10946,7 +10946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10969,7 +10969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10992,7 +10992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11015,7 +11015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11038,7 +11038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11061,7 +11061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11084,7 +11084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11107,7 +11107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11132,7 +11132,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11157,7 +11157,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11182,7 +11182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11208,7 +11208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11233,7 +11233,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11256,7 +11256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11279,7 +11279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11302,7 +11302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11325,7 +11325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11348,7 +11348,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11371,7 +11371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11394,7 +11394,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11417,7 +11417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11440,7 +11440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11463,7 +11463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11486,7 +11486,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11511,7 +11511,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11536,7 +11536,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11561,7 +11561,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11586,7 +11586,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11609,7 +11609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11632,7 +11632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11655,7 +11655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11678,7 +11678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11701,7 +11701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11724,7 +11724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11747,7 +11747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11770,7 +11770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11793,7 +11793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11818,7 +11818,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11843,7 +11843,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11868,7 +11868,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11894,7 +11894,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11919,7 +11919,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11942,7 +11942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11965,7 +11965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11988,7 +11988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12011,7 +12011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12034,7 +12034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12057,7 +12057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12080,7 +12080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12103,7 +12103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12126,7 +12126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12149,7 +12149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12172,7 +12172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12197,7 +12197,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12222,7 +12222,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12247,7 +12247,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12272,7 +12272,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12295,7 +12295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12318,7 +12318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12341,7 +12341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - /bin/bash
             - -c
@@ -38,7 +38,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.21-node-18-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-9
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -57,7 +57,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.21-node-18-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-9
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-9
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.55.1
+        - image: golangci/golangci-lint:v1.55.2
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - /bin/bash
             - -c

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -218,7 +218,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:             {"*": "quay.io/calico/node:v3.26.3"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.23"},
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
-		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.57.3"},
+		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.57.4"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.4"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.3.3"},
 	}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/build:go-1.21-node-18-6"
+	prowImage             = "quay.io/kubermatic/build:go-1.21-node-18-9"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -330,7 +330,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -355,7 +355,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -380,7 +380,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -405,7 +405,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -428,7 +428,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -451,7 +451,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -475,7 +475,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -498,7 +498,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -521,7 +521,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -544,7 +544,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -569,7 +569,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -594,7 +594,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -619,7 +619,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -645,7 +645,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -670,7 +670,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -693,7 +693,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -718,7 +718,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -743,7 +743,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -768,7 +768,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -794,7 +794,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -819,7 +819,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -842,7 +842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -872,7 +872,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -902,7 +902,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -932,7 +932,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -963,7 +963,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -993,7 +993,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1021,7 +1021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1049,7 +1049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1077,7 +1077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1105,7 +1105,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1133,7 +1133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1161,7 +1161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1189,7 +1189,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1219,7 +1219,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1249,7 +1249,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1279,7 +1279,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1310,7 +1310,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1340,7 +1340,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1368,7 +1368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1396,7 +1396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1424,7 +1424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1452,7 +1452,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1480,7 +1480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1508,7 +1508,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1536,7 +1536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1566,7 +1566,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1596,7 +1596,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1626,7 +1626,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1657,7 +1657,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1687,7 +1687,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1715,7 +1715,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1745,7 +1745,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1775,7 +1775,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1805,7 +1805,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1835,7 +1835,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1865,7 +1865,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1890,7 +1890,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1915,7 +1915,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1940,7 +1940,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1966,7 +1966,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1991,7 +1991,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2014,7 +2014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2037,7 +2037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2060,7 +2060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2083,7 +2083,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2106,7 +2106,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2129,7 +2129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2152,7 +2152,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2177,7 +2177,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2202,7 +2202,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2227,7 +2227,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2253,7 +2253,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2278,7 +2278,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2301,7 +2301,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2326,7 +2326,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2351,7 +2351,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2376,7 +2376,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2401,7 +2401,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2424,7 +2424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2447,7 +2447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2470,7 +2470,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2495,7 +2495,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2520,7 +2520,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2545,7 +2545,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2571,7 +2571,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2596,7 +2596,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2619,7 +2619,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2644,7 +2644,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2669,7 +2669,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2694,7 +2694,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2720,7 +2720,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2745,7 +2745,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2768,7 +2768,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2791,7 +2791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2814,7 +2814,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2837,7 +2837,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2860,7 +2860,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2883,7 +2883,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2906,7 +2906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2931,7 +2931,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2956,7 +2956,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2981,7 +2981,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3007,7 +3007,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3032,7 +3032,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3055,7 +3055,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3080,7 +3080,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3105,7 +3105,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3130,7 +3130,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3155,7 +3155,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3178,7 +3178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3201,7 +3201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3224,7 +3224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3254,7 +3254,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3284,7 +3284,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3314,7 +3314,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3345,7 +3345,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3375,7 +3375,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3403,7 +3403,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3431,7 +3431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3459,7 +3459,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3487,7 +3487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3515,7 +3515,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3543,7 +3543,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3571,7 +3571,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3601,7 +3601,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3631,7 +3631,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3661,7 +3661,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3692,7 +3692,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3722,7 +3722,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3750,7 +3750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3780,7 +3780,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3810,7 +3810,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3840,7 +3840,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3870,7 +3870,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3898,7 +3898,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3926,7 +3926,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3954,7 +3954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3979,7 +3979,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4004,7 +4004,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4029,7 +4029,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4054,7 +4054,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4079,7 +4079,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4102,7 +4102,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4125,7 +4125,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4148,7 +4148,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4171,7 +4171,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4194,7 +4194,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4217,7 +4217,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4240,7 +4240,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4265,7 +4265,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4290,7 +4290,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4315,7 +4315,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4341,7 +4341,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4366,7 +4366,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4389,7 +4389,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4412,7 +4412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4437,7 +4437,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4462,7 +4462,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4487,7 +4487,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4512,7 +4512,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4535,7 +4535,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4558,7 +4558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4581,7 +4581,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4604,7 +4604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4627,7 +4627,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4650,7 +4650,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4675,7 +4675,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4700,7 +4700,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4725,7 +4725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4751,7 +4751,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4776,7 +4776,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4799,7 +4799,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4824,7 +4824,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4849,7 +4849,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4874,7 +4874,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4900,7 +4900,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4925,7 +4925,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4948,7 +4948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4971,7 +4971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4994,7 +4994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5017,7 +5017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5040,7 +5040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5063,7 +5063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5086,7 +5086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5109,7 +5109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5134,7 +5134,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5159,7 +5159,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5184,7 +5184,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5209,7 +5209,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5234,7 +5234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5259,7 +5259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5284,7 +5284,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5310,7 +5310,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5335,7 +5335,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5358,7 +5358,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5381,7 +5381,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5404,7 +5404,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5427,7 +5427,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5450,7 +5450,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5473,7 +5473,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5498,7 +5498,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5523,7 +5523,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5548,7 +5548,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5574,7 +5574,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5599,7 +5599,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5624,7 +5624,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5649,7 +5649,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5674,7 +5674,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5700,7 +5700,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5725,7 +5725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5748,7 +5748,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5771,7 +5771,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5794,7 +5794,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5817,7 +5817,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5840,7 +5840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5863,7 +5863,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5888,7 +5888,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5913,7 +5913,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5938,7 +5938,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5964,7 +5964,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5989,7 +5989,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6012,7 +6012,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6035,7 +6035,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6058,7 +6058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6081,7 +6081,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6104,7 +6104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6127,7 +6127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6150,7 +6150,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6173,7 +6173,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6196,7 +6196,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6219,7 +6219,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6242,7 +6242,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6267,7 +6267,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6292,7 +6292,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6317,7 +6317,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6342,7 +6342,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6365,7 +6365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6388,7 +6388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6411,7 +6411,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6434,7 +6434,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6457,7 +6457,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6480,7 +6480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6503,7 +6503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6526,7 +6526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6549,7 +6549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6574,7 +6574,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6599,7 +6599,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6624,7 +6624,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6650,7 +6650,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6675,7 +6675,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6698,7 +6698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6721,7 +6721,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6744,7 +6744,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6767,7 +6767,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6790,7 +6790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6813,7 +6813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6836,7 +6836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6859,7 +6859,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6882,7 +6882,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6905,7 +6905,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6928,7 +6928,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6953,7 +6953,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6978,7 +6978,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7003,7 +7003,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7028,7 +7028,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7051,7 +7051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7074,7 +7074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7097,7 +7097,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7120,7 +7120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7143,7 +7143,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7167,7 +7167,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7190,7 +7190,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7213,7 +7213,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7236,7 +7236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7261,7 +7261,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7286,7 +7286,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7311,7 +7311,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7337,7 +7337,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7362,7 +7362,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7385,7 +7385,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7408,7 +7408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7431,7 +7431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7454,7 +7454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7477,7 +7477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7500,7 +7500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7523,7 +7523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7546,7 +7546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7569,7 +7569,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7592,7 +7592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7615,7 +7615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7640,7 +7640,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7665,7 +7665,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7690,7 +7690,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7715,7 +7715,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7738,7 +7738,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7761,7 +7761,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7784,7 +7784,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7812,7 +7812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7840,7 +7840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7868,7 +7868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7896,7 +7896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7924,7 +7924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7952,7 +7952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7982,7 +7982,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8012,7 +8012,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8042,7 +8042,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8073,7 +8073,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8103,7 +8103,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8131,7 +8131,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8159,7 +8159,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8187,7 +8187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8215,7 +8215,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8243,7 +8243,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8271,7 +8271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8299,7 +8299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8327,7 +8327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8355,7 +8355,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8383,7 +8383,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8413,7 +8413,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8443,7 +8443,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8473,7 +8473,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8503,7 +8503,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8533,7 +8533,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8561,7 +8561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8589,7 +8589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8617,7 +8617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8645,7 +8645,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8673,7 +8673,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8701,7 +8701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8729,7 +8729,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8757,7 +8757,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8785,7 +8785,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8815,7 +8815,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8845,7 +8845,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8875,7 +8875,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8906,7 +8906,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8936,7 +8936,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8964,7 +8964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8992,7 +8992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9020,7 +9020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9048,7 +9048,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9076,7 +9076,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9104,7 +9104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9132,7 +9132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9160,7 +9160,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9188,7 +9188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9216,7 +9216,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9246,7 +9246,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9276,7 +9276,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9306,7 +9306,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9336,7 +9336,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9366,7 +9366,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9394,7 +9394,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9422,7 +9422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9450,7 +9450,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9478,7 +9478,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9506,7 +9506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9534,7 +9534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9562,7 +9562,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9590,7 +9590,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9618,7 +9618,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9648,7 +9648,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9678,7 +9678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9708,7 +9708,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9739,7 +9739,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9769,7 +9769,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9797,7 +9797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9825,7 +9825,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9853,7 +9853,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9881,7 +9881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9909,7 +9909,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9937,7 +9937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9965,7 +9965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9993,7 +9993,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10021,7 +10021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10049,7 +10049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10079,7 +10079,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10109,7 +10109,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10139,7 +10139,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10169,7 +10169,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10199,7 +10199,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10227,7 +10227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10255,7 +10255,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10283,7 +10283,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10306,7 +10306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10329,7 +10329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10352,7 +10352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10375,7 +10375,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10398,7 +10398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10421,7 +10421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10446,7 +10446,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10471,7 +10471,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10496,7 +10496,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10522,7 +10522,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10547,7 +10547,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10570,7 +10570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10593,7 +10593,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10616,7 +10616,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10639,7 +10639,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10662,7 +10662,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10685,7 +10685,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10708,7 +10708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10731,7 +10731,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10754,7 +10754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10777,7 +10777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10800,7 +10800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10825,7 +10825,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10850,7 +10850,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10875,7 +10875,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10900,7 +10900,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10923,7 +10923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10946,7 +10946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10969,7 +10969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10992,7 +10992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11015,7 +11015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11038,7 +11038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11061,7 +11061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11084,7 +11084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11107,7 +11107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11132,7 +11132,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11157,7 +11157,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11182,7 +11182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11208,7 +11208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11233,7 +11233,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11256,7 +11256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11279,7 +11279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11302,7 +11302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11325,7 +11325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11348,7 +11348,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11371,7 +11371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11394,7 +11394,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11417,7 +11417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11440,7 +11440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11463,7 +11463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11486,7 +11486,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11511,7 +11511,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11536,7 +11536,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11561,7 +11561,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11586,7 +11586,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11609,7 +11609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11632,7 +11632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11655,7 +11655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11678,7 +11678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11701,7 +11701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11724,7 +11724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11747,7 +11747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11770,7 +11770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11793,7 +11793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11818,7 +11818,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11843,7 +11843,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11868,7 +11868,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11894,7 +11894,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11919,7 +11919,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11942,7 +11942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11965,7 +11965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11988,7 +11988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12011,7 +12011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12034,7 +12034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12057,7 +12057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12080,7 +12080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12103,7 +12103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12126,7 +12126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12149,7 +12149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12172,7 +12172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12197,7 +12197,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12222,7 +12222,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12247,7 +12247,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12272,7 +12272,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12295,7 +12295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12318,7 +12318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12341,7 +12341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.21-node-18-6
+      image: quay.io/kubermatic/build:go-1.21-node-18-9
       imagePullPolicy: Always
       name: ""
       resources:

--- a/test/e2e/sonobuoy.go
+++ b/test/e2e/sonobuoy.go
@@ -60,7 +60,7 @@ func (sbb *sonobuoyBin) Run(ctx context.Context, mode sonobuoyMode) error {
 }
 
 func (sbb *sonobuoyBin) Wait(ctx context.Context) error {
-	return sbb.run(ctx, "wait")
+	return sbb.run(ctx, "wait", "--wait=120")
 }
 
 func (sbb *sonobuoyBin) Retrieve(ctx context.Context) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Go to 1.21.5 and machine-controller to v1.57.4 on the `release/v1.7` branch (cherry-pick of #2988).

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- KubeOne is now built with Go 1.21.5
- Update machine-controller to v1.57.4
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 