### PR TITLE
Update KubeOne container image to Go 1.21.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.21.3 as builder
+FROM docker.io/golang:1.21.5 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY


### PR DESCRIPTION
**What this PR does / why we need it**:

Update KubeOne container image to Go 1.21.5

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 