### PR TITLE
fix strictArp field usage

### DIFF
--- a/pkg/apis/kubeone/config/testdata/config-full-v1beta1.yaml
+++ b/pkg/apis/kubeone/config/testdata/config-full-v1beta1.yaml
@@ -26,7 +26,7 @@ clusterNetwork:
       # * sed: shortest expected delay
       # * nq: never queue
       scheduler: rr
-      strictArp: false
+      strictARP: false
       tcpTimeout: "0"
       tcpFinTimeout: "0"
       udpTimeout: "0"

--- a/pkg/apis/kubeone/config/testdata/config-full-v1beta2.golden
+++ b/pkg/apis/kubeone/config/testdata/config-full-v1beta2.golden
@@ -11,7 +11,7 @@ clusterNetwork:
   kubeProxy:
     ipvs:
       scheduler: rr
-      strictArp: false
+      strictARP: false
       tcpTimeout: "0"
       tcpFinTimeout: "0"
       udpTimeout: "0"

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -544,7 +544,7 @@ clusterNetwork:
       # * sed: shortest expected delay
       # * nq: never queue
       scheduler: rr
-      strictArp: false
+      strictARP: false
       tcpTimeout: "0"
       tcpFinTimeout: "0"
       udpTimeout: "0"


### PR DESCRIPTION
The strictArp does not match the schema that sets this field as strictARP

Documentation changes are not required:
```documentation
NONE
```