### PR TITLE
add sshCert property to HostConfig

### DIFF
--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -217,6 +217,10 @@ type HostConfig struct {
 	// Default value is "".
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile,omitempty"`
 
+	// SSHCertFile is path to the file with the certificate of the private key.
+	// Default value is "".
+	SSHCertFile string `json:"sshCertFile,omitempty"`
+
 	// SSHHostPublicKey if not empty, will be used to verify remote host public key
 	SSHHostPublicKey []byte `json:"sshHostPublicKey,omitempty"`
 

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -107,6 +107,9 @@ type HostConfig struct {
 	// SSHPrivateKeyFile is path to the file with PRIVATE AND CLEANTEXT ssh key.
 	// Default value is "".
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile,omitempty"`
+	// SSHCertFile is path to the file with the certificate of the private key.
+	// Default value is "".
+	SSHCertFile string `json:"sshCertFile,omitempty"`
 	// SSHAgentSocket path (or reference to the environment) to the SSH agent unix domain socket.
 	// Default value is "env:SSH_AUTH_SOCK".
 	SSHAgentSocket string `json:"sshAgentSocket,omitempty"`

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -223,6 +223,10 @@ type HostConfig struct {
 	// Default value is "".
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile,omitempty"`
 
+	// SSHCertFile is path to the file with the certificate of the private key.
+	// Default value is "".
+	SSHCertFile string `json:"sshCertFile,omitempty"`
+
 	// SSHHostPublicKey if not empty, will be used to verify remote host public key
 	SSHHostPublicKey []byte `json:"sshHostPublicKey,omitempty"`
 

--- a/pkg/ssh/connector.go
+++ b/pkg/ssh/connector.go
@@ -99,17 +99,15 @@ func (c *Connector) forgetConnection(conn *connection) {
 }
 
 func sshOpts(host kubeoneapi.HostConfig) Opts {
-	privateKeyFile := host.SSHPrivateKeyFile
-	// Expand ~/ as path to the home directory
-	if strings.HasPrefix(privateKeyFile, "~/") {
-		privateKeyFile = filepath.Join(homedir.HomeDir(), privateKeyFile[2:])
-	}
+	privateKeyFile := resolveHomeDir(host.SSHPrivateKeyFile)
+	certFile := resolveHomeDir(host.SSHCertFile)
 
 	return Opts{
 		Username:             host.SSHUsername,
 		Port:                 host.SSHPort,
 		Hostname:             host.PublicAddress,
 		KeyFile:              privateKeyFile,
+		SSHCertFile:          certFile,
 		HostPublicKey:        host.SSHHostPublicKey,
 		AgentSocket:          host.SSHAgentSocket,
 		Timeout:              10 * time.Second,
@@ -118,4 +116,12 @@ func sshOpts(host kubeoneapi.HostConfig) Opts {
 		BastionUser:          host.BastionUser,
 		BastionHostPublicKey: host.BastionHostPublicKey,
 	}
+}
+
+func resolveHomeDir(path string) string {
+	// Expand ~/ as path to the home directory
+	if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(homedir.HomeDir(), path[2:])
+	}
+	return path
 }

--- a/pkg/terraform/v1beta1/config.go
+++ b/pkg/terraform/v1beta1/config.go
@@ -74,6 +74,7 @@ type hostsSpec struct {
 	SSHUser           string   `json:"ssh_user"`
 	SSHPort           int      `json:"ssh_port"`
 	SSHPrivateKeyFile string   `json:"ssh_private_key_file"`
+	SSHCertFile       string   `json:"ssh_cert_file"`
 	SSHAgentSocket    string   `json:"ssh_agent_socket"`
 	Bastion           string   `json:"bastion"`
 	BastionPort       int      `json:"bastion_port"`
@@ -289,6 +290,7 @@ func newHostConfig(publicIP, privateIP, hostname string, hs *hostsSpec) kubeonev
 		PublicAddress:     publicIP,
 		SSHAgentSocket:    hs.SSHAgentSocket,
 		SSHPrivateKeyFile: hs.SSHPrivateKeyFile,
+		SSHCertFile:       hs.SSHCertFile,
 		SSHUsername:       hs.SSHUser,
 		SSHPort:           hs.SSHPort,
 	}

--- a/pkg/terraform/v1beta2/config.go
+++ b/pkg/terraform/v1beta2/config.go
@@ -94,6 +94,7 @@ type hostsSpec struct {
 	SSHUser           string            `json:"ssh_user"`
 	SSHPort           int               `json:"ssh_port"`
 	SSHPrivateKeyFile string            `json:"ssh_private_key_file"`
+	SSHCertFile       string            `json:"ssh_cert_file"`
 	SSHAgentSocket    string            `json:"ssh_agent_socket"`
 	SSHHostKeys       [][]byte          `json:"ssh_hosts_keys"`
 	Bastion           string            `json:"bastion"`
@@ -363,6 +364,7 @@ func newHostConfig(publicIP, privateIP string, ipv6addr []string, idx int, spec 
 		IPv6Addresses:        ipv6addr,
 		SSHAgentSocket:       spec.SSHAgentSocket,
 		SSHPrivateKeyFile:    spec.SSHPrivateKeyFile,
+		SSHCertFile:          spec.SSHCertFile,
 		SSHUsername:          spec.SSHUser,
 		SSHPort:              spec.SSHPort,
 		Kubelet:              kubeonev1beta2.KubeletConfig{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
There is currently no way to ssh into the bastion and the control plane with a trusted certificate `ssh -i /path/to/private_key -i /path/to/trusted_cert <user>@<ip_bastion>`. This PR aims to provide this ability to connect to the bastion and the control plan with a (certificate + private key), by adding a new option to the `output.tf` which contains the path to the 
trusted certificate

**Which issue(s) this PR fixes**:
None
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
SSH configuration of bastion and control plan must be adjusted so that **TrustedUserCAKeys** is set to the public key of the CA.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
No
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
SSH into the bastion and control plane with trusted certificates

-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
