### PR TITLE
fix: preserve containerd runtime config

### DIFF
--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -156,7 +156,9 @@ func SetDefaults_Versions(obj *KubeOneCluster) {
 }
 
 func SetDefaults_ContainerRuntime(obj *KubeOneCluster) {
-	obj.ContainerRuntime.Containerd = &ContainerRuntimeContainerd{}
+	if obj.ContainerRuntime.Containerd == nil {
+		obj.ContainerRuntime.Containerd = &ContainerRuntimeContainerd{}
+	}
 }
 
 func SetDefaults_ClusterNetwork(obj *KubeOneCluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Currently (after this [commit](https://github.com/kubermatic/kubeone/commit/dcdbbec975976ab19e0ff330118ecd2cb27f7942#diff-ae676061a0bb7ab6e23d55012ec2de5fb7b9315d8c425fb35a07b4470d5af009)) the `containerRuntime.containerd` is ignored and reset to default.

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
fix: preserve containerd runtime config
```

**Documentation**:
```documentation
NONE
```