### PR TITLE
Fix: Use containerd binary from path in Flatcar

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -122,7 +122,7 @@ var containerRuntimeTemplates = map[string]string{
 			Restart=always
 			Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 			ExecStart=
-			ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+			ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 			EOF
 		`),
 }

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -122,7 +122,7 @@ var containerRuntimeTemplates = map[string]string{
 			Restart=always
 			Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 			ExecStart=
-			ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+			ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 			EOF
 		`),
 }

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -100,7 +100,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -102,7 +102,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -102,7 +102,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
@@ -39,7 +39,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
@@ -39,7 +39,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -52,7 +52,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -52,7 +52,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
@@ -54,7 +54,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
@@ -54,7 +54,7 @@ cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/env containerd --config \${CONTAINERD_CONFIG}
 EOF
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
With the latest stable release of flatcar(https://www.flatcar.org/releases#release-3815.2.0), they removed the old containerd installation with torcx and moved to the upstream gentoo builds. This results in a broken containerd.service, because the kubeone dropin refers to the torcx path. Both old(LTS) and new versions PATH var contains the binary, so we are safe to just use the binary from PATH.

**Which issue(s) this PR fixes**:
NONE

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
fixed support for flatcar stable channel 3815.2.0
```

**Documentation**:
```documentation
NONE
```
