### PR TITLE
Add changelogs for v1.7.3 and v1.6.5, and fix the changelog generation script

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -1,3 +1,32 @@
+# [v1.6.5](https://github.com/kubermatic/kubeone/releases/tag/v1.6.5) - 2024-03-01
+
+## Changelog since v1.6.4
+
+## Changes by Kind
+
+### Feature
+
+- Enforce etcd v3.5.10 for Kubernetes versions that use an older etcd version. This etcd version includes some important stability, reliability, and security fixes ([#3003](https://github.com/kubermatic/kubeone/pull/3003), [@kubermatic-bot](https://github.com/kubermatic-bot))
+
+### Bug or Regression
+
+- Fix KubeOne failing to provision and upgrade Flatcar control plane and static worker nodes due to `torcx` removal ([#3042](https://github.com/kubermatic/kubeone/pull/3042), [@kron4eg](https://github.com/kron4eg))
+- Improve error messages when working with remote files over SSH ([#3053](https://github.com/kubermatic/kubeone/pull/3053), [@kubermatic-bot](https://github.com/kubermatic-bot))
+
+### Updates
+
+#### machine-controller
+
+- Update machine-controller to v1.56.6 ([#3058](https://github.com/kubermatic/kubeone/pull/3058), [@xmudrii](https://github.com/xmudrii))
+
+#### operating-system-manager
+
+- Update operating-system-manager to v1.2.4 ([#3042](https://github.com/kubermatic/kubeone/pull/3042), [@kron4eg](https://github.com/kron4eg))
+
+#### Addons
+
+- Update backup-restic addon to use etcd 3.5.11 for creating etcd snapshots ([#2983](https://github.com/kubermatic/kubeone/pull/2983), [@kubermatic-bot](https://github.com/kubermatic-bot))
+
 # [v1.6.4](https://github.com/kubermatic/kubeone/releases/tag/v1.6.4) - 2023-11-10
 
 ## Changelog since v1.6.3

--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -1,3 +1,33 @@
+# [v1.7.3](https://github.com/kubermatic/kubeone/releases/tag/v1.7.3) - 2024-03-01
+
+## Changelog since v1.7.2
+
+## Changes by Kind
+
+### Feature
+
+- Enforce etcd v3.5.10 for Kubernetes versions that use an older etcd version. This etcd version includes some important stability, reliability, and security fixes ([#3004](https://github.com/kubermatic/kubeone/pull/3004), [@kubermatic-bot](https://github.com/kubermatic-bot))
+
+### Bug or Regression
+
+- Fix KubeOne failing to provision and upgrade Flatcar control plane and static worker nodes due to `torcx` removal ([#3041](https://github.com/kubermatic/kubeone/pull/3041), [@kron4eg](https://github.com/kron4eg))
+- Fix Helm deploying resources in the wrong namespace ([#3001](https://github.com/kubermatic/kubeone/pull/3001), [@kubermatic-bot](https://github.com/kubermatic-bot))
+- Improve error messages when working with remote files over SSH ([#3054](https://github.com/kubermatic/kubeone/pull/3054), [@kubermatic-bot](https://github.com/kubermatic-bot))
+
+### Updates
+
+#### machine-controller
+
+- Update machine-controller to v1.57.5 ([#3057](https://github.com/kubermatic/kubeone/pull/3057), [@xmudrii](https://github.com/xmudrii))
+
+#### operating-system-manager
+
+- Update operating-system-manager to v1.3.4 ([#3041](https://github.com/kubermatic/kubeone/pull/3041), [@kron4eg](https://github.com/kron4eg))
+
+#### Go
+
+- KubeOne is now built with Go 1.21.6 ([#3060](https://github.com/kubermatic/kubeone/pull/3060), [@xmudrii](https://github.com/xmudrii))
+
 # [v1.7.2](https://github.com/kubermatic/kubeone/releases/tag/v1.7.2) - 2024-01-05
 
 ## Changelog since v1.7.1

--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -28,9 +28,9 @@
 ###
 ### Usage:
 ###  The script can be used in the following way:
-###    CHANGELOG_START_REV="v1.5.2" \
-###    CHANGELOG_END_SHA="6c8a662a94ecf78ea98f3ad8cc899465445e7d86" \
-###    CHANGELOG_BRANCH="release/v1.5" \
+###    CHANGELOG_START_REV="v1.7.2" \
+###    CHANGELOG_END_SHA="b96f8510e223bc032a2794f77b864e897a6f6943" \
+###    CHANGELOG_BRANCH="release/v1.7" \
 ###    ./hack/generate-changelog.sh
 ###
 ###  The changelog will be saved to the /tmp directory with the random
@@ -74,7 +74,7 @@ tpl=${CHANGELOG_TPL:-"$(dirname "$0")/changelog.tpl"}
 git_branch="$(git rev-parse --abbrev-ref HEAD)"
 branch=${CHANGELOG_BRANCH:-"$git_branch"}
 
-release-notes \
+release-notes generate \
     --org="$org" \
     --repo="$repo" \
     --start-rev="$CHANGELOG_START_REV" \
@@ -83,4 +83,5 @@ release-notes \
     --go-template="go-template:$tpl" \
     --output="$output" \
     --required-author "" \
-    --markdown-links
+    --markdown-links \
+    --dependencies=false


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add changelogs for v1.7.3 and v1.6.5
- Fix the changelog generation script as the release-notes tool has been changed a little bit

**What type of PR is this?**

/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 