### PR TITLE
fix: Deploy User defined addons before external CCM initialization

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -265,6 +265,12 @@ func WithResources(t Tasks) Tasks {
 				Description: "ensure embedded addons",
 			},
 			{
+				Fn:          addons.EnsureUserAddons,
+				Operation:   "applying addons",
+				Description: "ensure custom addons",
+				Predicate:   func(s *state.State) bool { return s.Cluster.Addons != nil && s.Cluster.Addons.Enable },
+			},
+			{
 				Fn:        localhelm.Deploy,
 				Operation: "releasing core helm charts",
 			},
@@ -279,12 +285,6 @@ func WithResources(t Tasks) Tasks {
 				Operation:   "ensuring external CCM",
 				Description: "ensure external CCM",
 				Predicate:   func(s *state.State) bool { return s.Cluster.CloudProvider.External },
-			},
-			{
-				Fn:          addons.EnsureUserAddons,
-				Operation:   "applying addons",
-				Description: "ensure custom addons",
-				Predicate:   func(s *state.State) bool { return s.Cluster.Addons != nil && s.Cluster.Addons.Enable },
 			},
 			{
 				Fn:          ensureVsphereCSICABundleConfigMap,


### PR DESCRIPTION
**What this PR does / why we need it**:
This is fix for situation when we have both cloud provider and CNI set to external.

```yaml
apiVersion: kubeone.k8c.io/v1beta2
kind: KubeOneCluster

versions:
  kubernetes: v1.28.7

cloudProvider:
  external: true

clusterNetwork:
  cni:
    external: {}

addons:
  enable: true
  addons:
  - name: calico-vxlan

```

This results to endless waiting for control-plane nodes to be initialized. It happens because Nodes are not ready (for the lack of CNI).

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Deploy User defined addons before external CCM initialization
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
