### PR TITLE
add logging to label step

### DIFF
--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -97,6 +97,8 @@ func ensureRestartKubeAPIServerCrictl(s *state.State) error {
 }
 
 func labelNodes(s *state.State) error {
+	s.Logger.Infof("Labeling nodes...")
+
 	candidateNodes := sets.NewString()
 	nodeList := corev1.NodeList{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

Adds a logging line to indicate that kubeone is starting to label nodes. Without this line I felt that error messages can sometimes be confusing. Here is an example, where label nodes failed:

```sh
INFO[16:03:22 CET] Applying addon nodelocaldns...               
WARN[16:03:24 CET] Task failed, error was: kubernetes: updating NUC-1 Node
nodes "NUC-1" not found 
WARN[16:03:34 CET] Retrying task...                             
WARN[16:03:34 CET] Task failed, error was: kubernetes: updating NUC-1 Node
nodes "NUC-1" not found 
```

My first impression was that applying the nodelocaldns addon failed (which was not the case), because there is no mention of label nodes.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
