### PR TITLE
update to Go 1.22.1

### DIFF
--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -328,7 +328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -351,7 +351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -374,7 +374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -397,7 +397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -420,7 +420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -443,7 +443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -466,7 +466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -489,7 +489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -512,7 +512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -537,7 +537,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -560,7 +560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -585,7 +585,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -610,7 +610,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -635,7 +635,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -658,7 +658,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -681,7 +681,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -704,7 +704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -727,7 +727,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -750,7 +750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -774,7 +774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -797,7 +797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -820,7 +820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -843,7 +843,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -868,7 +868,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -893,7 +893,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -918,7 +918,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -944,7 +944,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -969,7 +969,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -992,7 +992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1015,7 +1015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1038,7 +1038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1061,7 +1061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1084,7 +1084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1107,7 +1107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1130,7 +1130,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1153,7 +1153,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1176,7 +1176,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1199,7 +1199,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1222,7 +1222,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1247,7 +1247,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1270,7 +1270,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1295,7 +1295,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1320,7 +1320,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1345,7 +1345,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1368,7 +1368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1391,7 +1391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1414,7 +1414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1437,7 +1437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1460,7 +1460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1483,7 +1483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1506,7 +1506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1529,7 +1529,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1552,7 +1552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1577,7 +1577,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1602,7 +1602,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1627,7 +1627,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1653,7 +1653,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1678,7 +1678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1701,7 +1701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1724,7 +1724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1747,7 +1747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1770,7 +1770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1793,7 +1793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1816,7 +1816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1839,7 +1839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1862,7 +1862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1885,7 +1885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1908,7 +1908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1931,7 +1931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1956,7 +1956,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1979,7 +1979,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2004,7 +2004,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2029,7 +2029,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2054,7 +2054,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2077,7 +2077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2100,7 +2100,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2123,7 +2123,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2146,7 +2146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2169,7 +2169,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2192,7 +2192,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2215,7 +2215,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2238,7 +2238,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2261,7 +2261,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2286,7 +2286,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2311,7 +2311,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2336,7 +2336,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2362,7 +2362,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2387,7 +2387,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2410,7 +2410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2433,7 +2433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2456,7 +2456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2479,7 +2479,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2502,7 +2502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2525,7 +2525,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2548,7 +2548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2571,7 +2571,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2594,7 +2594,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2617,7 +2617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2640,7 +2640,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2665,7 +2665,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2688,7 +2688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2713,7 +2713,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2738,7 +2738,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2763,7 +2763,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2786,7 +2786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2809,7 +2809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2832,7 +2832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2855,7 +2855,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2878,7 +2878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2902,7 +2902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2925,7 +2925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2948,7 +2948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2971,7 +2971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2996,7 +2996,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3021,7 +3021,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3046,7 +3046,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3072,7 +3072,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3097,7 +3097,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3120,7 +3120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3143,7 +3143,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3166,7 +3166,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3189,7 +3189,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3212,7 +3212,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3235,7 +3235,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3258,7 +3258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3281,7 +3281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3304,7 +3304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3327,7 +3327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3350,7 +3350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3375,7 +3375,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3398,7 +3398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3423,7 +3423,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3448,7 +3448,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3473,7 +3473,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3496,7 +3496,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3519,7 +3519,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3542,7 +3542,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3570,7 +3570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3598,7 +3598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3626,7 +3626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3654,7 +3654,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3682,7 +3682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3710,7 +3710,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3738,7 +3738,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3766,7 +3766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3794,7 +3794,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3822,7 +3822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3850,7 +3850,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3878,7 +3878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3906,7 +3906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3934,7 +3934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3962,7 +3962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3990,7 +3990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4020,7 +4020,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4050,7 +4050,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4080,7 +4080,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4111,7 +4111,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4141,7 +4141,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4169,7 +4169,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4197,7 +4197,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4225,7 +4225,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4253,7 +4253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4281,7 +4281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4309,7 +4309,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4337,7 +4337,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4365,7 +4365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4393,7 +4393,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4421,7 +4421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4449,7 +4449,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4479,7 +4479,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4509,7 +4509,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4539,7 +4539,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4569,7 +4569,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4599,7 +4599,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4627,7 +4627,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4655,7 +4655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4683,7 +4683,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4711,7 +4711,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4739,7 +4739,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4767,7 +4767,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4795,7 +4795,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4823,7 +4823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4851,7 +4851,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4881,7 +4881,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4911,7 +4911,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4941,7 +4941,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4972,7 +4972,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5002,7 +5002,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5030,7 +5030,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5058,7 +5058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5086,7 +5086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5114,7 +5114,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5142,7 +5142,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5170,7 +5170,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5198,7 +5198,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5226,7 +5226,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5254,7 +5254,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5282,7 +5282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5310,7 +5310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5340,7 +5340,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5370,7 +5370,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5400,7 +5400,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5430,7 +5430,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5460,7 +5460,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5488,7 +5488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5516,7 +5516,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5544,7 +5544,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5567,7 +5567,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5590,7 +5590,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5613,7 +5613,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5636,7 +5636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5659,7 +5659,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5682,7 +5682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5707,7 +5707,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5732,7 +5732,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5757,7 +5757,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5783,7 +5783,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5808,7 +5808,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5831,7 +5831,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5854,7 +5854,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5877,7 +5877,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5900,7 +5900,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5923,7 +5923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5946,7 +5946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5969,7 +5969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5992,7 +5992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6015,7 +6015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6038,7 +6038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6061,7 +6061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6086,7 +6086,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6109,7 +6109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6134,7 +6134,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6159,7 +6159,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6184,7 +6184,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6207,7 +6207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6230,7 +6230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6253,7 +6253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6276,7 +6276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6299,7 +6299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6322,7 +6322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6345,7 +6345,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6368,7 +6368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6391,7 +6391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6416,7 +6416,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6441,7 +6441,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6466,7 +6466,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6492,7 +6492,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6517,7 +6517,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6540,7 +6540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6563,7 +6563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6586,7 +6586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6609,7 +6609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6632,7 +6632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6655,7 +6655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6678,7 +6678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6701,7 +6701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6724,7 +6724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6747,7 +6747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6770,7 +6770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6795,7 +6795,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6818,7 +6818,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6843,7 +6843,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6868,7 +6868,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6893,7 +6893,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6916,7 +6916,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6939,7 +6939,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6962,7 +6962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6985,7 +6985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7008,7 +7008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7031,7 +7031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7054,7 +7054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7077,7 +7077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7100,7 +7100,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7125,7 +7125,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7150,7 +7150,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7175,7 +7175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7201,7 +7201,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7226,7 +7226,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7249,7 +7249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7272,7 +7272,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7295,7 +7295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7318,7 +7318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7341,7 +7341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7364,7 +7364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7387,7 +7387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7410,7 +7410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7433,7 +7433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7456,7 +7456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7479,7 +7479,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7504,7 +7504,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7527,7 +7527,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7552,7 +7552,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7577,7 +7577,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7602,7 +7602,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7625,7 +7625,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7648,7 +7648,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7671,7 +7671,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7694,7 +7694,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7717,7 +7717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7740,7 +7740,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7763,7 +7763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7786,7 +7786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7809,7 +7809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7834,7 +7834,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7859,7 +7859,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7884,7 +7884,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7910,7 +7910,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7935,7 +7935,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7958,7 +7958,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7981,7 +7981,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8004,7 +8004,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8027,7 +8027,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8050,7 +8050,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8073,7 +8073,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8096,7 +8096,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8119,7 +8119,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8142,7 +8142,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8165,7 +8165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8188,7 +8188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8213,7 +8213,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8236,7 +8236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8261,7 +8261,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8286,7 +8286,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8311,7 +8311,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8334,7 +8334,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8357,7 +8357,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8380,7 +8380,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8403,7 +8403,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8426,7 +8426,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8449,7 +8449,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8472,7 +8472,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8495,7 +8495,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8518,7 +8518,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8543,7 +8543,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8568,7 +8568,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8593,7 +8593,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8619,7 +8619,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8644,7 +8644,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8667,7 +8667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8690,7 +8690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8713,7 +8713,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8736,7 +8736,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8759,7 +8759,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8782,7 +8782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8805,7 +8805,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8828,7 +8828,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8851,7 +8851,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8874,7 +8874,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8897,7 +8897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8922,7 +8922,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8945,7 +8945,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8970,7 +8970,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8995,7 +8995,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9020,7 +9020,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9043,7 +9043,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9066,7 +9066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9089,7 +9089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9112,7 +9112,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9135,7 +9135,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9158,7 +9158,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9181,7 +9181,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9204,7 +9204,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9227,7 +9227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9252,7 +9252,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9277,7 +9277,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9302,7 +9302,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9328,7 +9328,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9353,7 +9353,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9376,7 +9376,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9399,7 +9399,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9422,7 +9422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9445,7 +9445,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9468,7 +9468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9491,7 +9491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9514,7 +9514,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9537,7 +9537,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9560,7 +9560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9583,7 +9583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9606,7 +9606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9631,7 +9631,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9654,7 +9654,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9679,7 +9679,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9704,7 +9704,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9729,7 +9729,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9752,7 +9752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9775,7 +9775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9798,7 +9798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9821,7 +9821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9844,7 +9844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9867,7 +9867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9890,7 +9890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9913,7 +9913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9936,7 +9936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9961,7 +9961,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9986,7 +9986,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10011,7 +10011,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10037,7 +10037,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10062,7 +10062,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10085,7 +10085,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10108,7 +10108,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10131,7 +10131,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10154,7 +10154,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10177,7 +10177,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10200,7 +10200,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10223,7 +10223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10246,7 +10246,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10269,7 +10269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10292,7 +10292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10315,7 +10315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10340,7 +10340,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10363,7 +10363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10388,7 +10388,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10413,7 +10413,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10438,7 +10438,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10461,7 +10461,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10484,7 +10484,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10507,7 +10507,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10530,7 +10530,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10553,7 +10553,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10576,7 +10576,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10599,7 +10599,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10622,7 +10622,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10645,7 +10645,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10670,7 +10670,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10695,7 +10695,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10720,7 +10720,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10746,7 +10746,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10771,7 +10771,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10794,7 +10794,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10817,7 +10817,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10840,7 +10840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10863,7 +10863,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10886,7 +10886,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10909,7 +10909,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10932,7 +10932,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10955,7 +10955,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10978,7 +10978,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11001,7 +11001,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11024,7 +11024,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11049,7 +11049,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11072,7 +11072,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11097,7 +11097,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11122,7 +11122,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11147,7 +11147,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11170,7 +11170,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11193,7 +11193,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11216,7 +11216,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11239,7 +11239,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11262,7 +11262,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11285,7 +11285,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11308,7 +11308,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11331,7 +11331,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11354,7 +11354,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11379,7 +11379,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11404,7 +11404,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11429,7 +11429,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11455,7 +11455,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11480,7 +11480,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11503,7 +11503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11526,7 +11526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11549,7 +11549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11572,7 +11572,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11595,7 +11595,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11618,7 +11618,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11641,7 +11641,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11664,7 +11664,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11687,7 +11687,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11710,7 +11710,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11733,7 +11733,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11758,7 +11758,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11781,7 +11781,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11806,7 +11806,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11831,7 +11831,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11856,7 +11856,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11879,7 +11879,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11902,7 +11902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11925,7 +11925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11948,7 +11948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11971,7 +11971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11994,7 +11994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12017,7 +12017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12040,7 +12040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12063,7 +12063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12088,7 +12088,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12113,7 +12113,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12138,7 +12138,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12164,7 +12164,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12189,7 +12189,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12212,7 +12212,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12235,7 +12235,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12258,7 +12258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12281,7 +12281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12304,7 +12304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12327,7 +12327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12350,7 +12350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12373,7 +12373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12396,7 +12396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12419,7 +12419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12442,7 +12442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12467,7 +12467,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12490,7 +12490,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12515,7 +12515,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12540,7 +12540,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12565,7 +12565,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12588,7 +12588,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12611,7 +12611,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12634,7 +12634,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12657,7 +12657,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12680,7 +12680,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12703,7 +12703,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12726,7 +12726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12749,7 +12749,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12772,7 +12772,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12797,7 +12797,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12822,7 +12822,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12847,7 +12847,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12873,7 +12873,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12898,7 +12898,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12921,7 +12921,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12944,7 +12944,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12967,7 +12967,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12990,7 +12990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13013,7 +13013,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13036,7 +13036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13059,7 +13059,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13082,7 +13082,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13105,7 +13105,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13128,7 +13128,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13151,7 +13151,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13176,7 +13176,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13199,7 +13199,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13224,7 +13224,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13249,7 +13249,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13274,7 +13274,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13297,7 +13297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13320,7 +13320,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13343,7 +13343,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13371,7 +13371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13399,7 +13399,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13427,7 +13427,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13455,7 +13455,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13483,7 +13483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13511,7 +13511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13541,7 +13541,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13571,7 +13571,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13601,7 +13601,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13632,7 +13632,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13662,7 +13662,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13690,7 +13690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13718,7 +13718,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13746,7 +13746,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13774,7 +13774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13802,7 +13802,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13830,7 +13830,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13858,7 +13858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13886,7 +13886,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13914,7 +13914,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13942,7 +13942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13970,7 +13970,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14000,7 +14000,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14028,7 +14028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14058,7 +14058,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14088,7 +14088,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14118,7 +14118,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14146,7 +14146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14174,7 +14174,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14202,7 +14202,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14230,7 +14230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14258,7 +14258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14286,7 +14286,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14314,7 +14314,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14342,7 +14342,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14370,7 +14370,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14400,7 +14400,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14430,7 +14430,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14460,7 +14460,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14491,7 +14491,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14521,7 +14521,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14549,7 +14549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14577,7 +14577,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14605,7 +14605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14633,7 +14633,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14661,7 +14661,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14689,7 +14689,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14717,7 +14717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14745,7 +14745,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14773,7 +14773,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14801,7 +14801,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14829,7 +14829,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14859,7 +14859,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14887,7 +14887,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14917,7 +14917,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14947,7 +14947,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14977,7 +14977,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15005,7 +15005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15033,7 +15033,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15061,7 +15061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15089,7 +15089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15117,7 +15117,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15145,7 +15145,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15173,7 +15173,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15201,7 +15201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15229,7 +15229,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15259,7 +15259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15289,7 +15289,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15319,7 +15319,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15350,7 +15350,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15380,7 +15380,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15408,7 +15408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15436,7 +15436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15464,7 +15464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15492,7 +15492,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15520,7 +15520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15548,7 +15548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15576,7 +15576,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15604,7 +15604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15632,7 +15632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15660,7 +15660,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15688,7 +15688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15718,7 +15718,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15746,7 +15746,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15776,7 +15776,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15806,7 +15806,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15836,7 +15836,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15864,7 +15864,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15892,7 +15892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15920,7 +15920,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15948,7 +15948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15976,7 +15976,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16004,7 +16004,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16032,7 +16032,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16060,7 +16060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16088,7 +16088,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16118,7 +16118,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16148,7 +16148,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16178,7 +16178,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16209,7 +16209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16239,7 +16239,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16267,7 +16267,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16295,7 +16295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16323,7 +16323,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16351,7 +16351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16379,7 +16379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16407,7 +16407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16435,7 +16435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16463,7 +16463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16491,7 +16491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16519,7 +16519,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16547,7 +16547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16577,7 +16577,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16605,7 +16605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16635,7 +16635,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16665,7 +16665,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16695,7 +16695,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16723,7 +16723,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16751,7 +16751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16779,7 +16779,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16804,7 +16804,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16829,7 +16829,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16854,7 +16854,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16877,7 +16877,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16900,7 +16900,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16923,7 +16923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16946,7 +16946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16969,7 +16969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16992,7 +16992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17015,7 +17015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17038,7 +17038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17061,7 +17061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17084,7 +17084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17109,7 +17109,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17134,7 +17134,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17159,7 +17159,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17185,7 +17185,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17210,7 +17210,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17233,7 +17233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17256,7 +17256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17279,7 +17279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17302,7 +17302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17325,7 +17325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17348,7 +17348,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17371,7 +17371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17394,7 +17394,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17417,7 +17417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17440,7 +17440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17463,7 +17463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17488,7 +17488,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17511,7 +17511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17536,7 +17536,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17561,7 +17561,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17586,7 +17586,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17609,7 +17609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17632,7 +17632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17655,7 +17655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17678,7 +17678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17701,7 +17701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17724,7 +17724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17747,7 +17747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17770,7 +17770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17793,7 +17793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17818,7 +17818,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17843,7 +17843,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17868,7 +17868,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17894,7 +17894,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17919,7 +17919,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17942,7 +17942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17965,7 +17965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17988,7 +17988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18011,7 +18011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18034,7 +18034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18057,7 +18057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18080,7 +18080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18103,7 +18103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18126,7 +18126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18149,7 +18149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18172,7 +18172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18197,7 +18197,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18220,7 +18220,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18245,7 +18245,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18270,7 +18270,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18295,7 +18295,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18318,7 +18318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18341,7 +18341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18364,7 +18364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18387,7 +18387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18410,7 +18410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18433,7 +18433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-18-2
+      image: quay.io/kubermatic/build:go-1.22-node-18-5
       imagePullPolicy: Always
       name: ""
       resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
           command:
             - /bin/bash
             - -c
@@ -38,7 +38,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -57,7 +57,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.22.0
+        - image: golang:1.22.1
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.22.0
+        - image: golang:1.22.1
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.22.0
+        - image: golang:1.22.1
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.22.0
+        - image: golang:1.22.1
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.0 as builder
+FROM docker.io/golang:1.22.1 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/build:go-1.22-node-18-2"
+	prowImage             = "quay.io/kubermatic/build:go-1.22-node-18-5"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps KKP to Go 1.22.1, which comes with some important fixes: https://groups.google.com/g/golang-announce/c/Fm51GRLNRvM/m/F5bwBlXMAQAJ

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.22.1
```

**Documentation**:
```documentation
NONE
```
