### PR TITLE
Make default stable kubernetes version == v1.29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ export CGO_ENABLED=0
 export GOPROXY?=https://proxy.golang.org
 export GO111MODULE=on
 export GOFLAGS?=-mod=readonly -trimpath
-export DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.28.txt)
+export DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.29.txt)
 
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
xref #2997

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make default stable kubernetes version == v1.29
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
