### PR TITLE
Update CSI feature gates

### DIFF
--- a/addons/ccm-gcp/Kustomization
+++ b/addons/ccm-gcp/Kustomization
@@ -52,6 +52,8 @@ patches:
           metadata:
             annotations:
               kubeone.k8c.io/credentials-hash: '{{ .CredentialsCCMHash }}'
+            labels:
+              k8s-app: gce-cloud-controller-manager
           spec:
             containers:
               - name: cloud-controller-manager

--- a/addons/ccm-gcp/ccm-gcp.yaml
+++ b/addons/ccm-gcp/ccm-gcp.yaml
@@ -306,6 +306,7 @@ spec:
         kubeone.k8c.io/credentials-hash: '{{ .CredentialsCCMHash }}'
       labels:
         component: cloud-controller-manager
+        k8s-app: gce-cloud-controller-manager
         tier: control-plane
     spec:
       affinity:

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -307,29 +307,19 @@ func (c KubeOneCluster) CSIMigrationSupported() bool {
 }
 
 func (c KubeOneCluster) csiMigrationFeatureGates(complete bool) (map[string]bool, error) {
-	featureGates := map[string]bool{}
-
 	switch {
 	case c.CloudProvider.AWS != nil:
-		if complete {
-			featureGates["InTreePluginAWSUnregister"] = true
-		}
 	case c.CloudProvider.Azure != nil:
-		if complete {
-			featureGates["InTreePluginAzureDiskUnregister"] = true
-			featureGates["InTreePluginAzureFileUnregister"] = true
-		}
+	case c.CloudProvider.GCE != nil:
 	case c.CloudProvider.Openstack != nil:
-		if complete {
-			featureGates["InTreePluginOpenStackUnregister"] = true
-		}
 	case c.CloudProvider.Vsphere != nil:
-		featureGates["CSIMigrationvSphere"] = true
-		if complete {
-			featureGates["InTreePluginvSphereUnregister"] = true
-		}
 	default:
 		return nil, fail.ConfigValidation(fmt.Errorf("csi migration is not supported for selected provider"))
+	}
+
+	featureGates := map[string]bool{}
+	if complete {
+		featureGates["DisableCloudProviders"] = true
 	}
 
 	return featureGates, nil

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -293,6 +293,7 @@ func (p CloudProviderSpec) CloudProviderInTree() bool {
 	return !p.External
 }
 
+// OriginalInTreeCloudProvider indicates if configured cloud provider originally been an in-tree provider.
 func (p CloudProviderSpec) OriginalInTreeCloudProvider() bool {
 	switch {
 	case p.AWS != nil:

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -293,6 +293,20 @@ func (p CloudProviderSpec) CloudProviderInTree() bool {
 	return !p.External
 }
 
+func (p CloudProviderSpec) OriginalInTreeCloudProvider() bool {
+	switch {
+	case p.AWS != nil:
+	case p.Azure != nil:
+	case p.GCE != nil:
+	case p.Openstack != nil:
+	case p.Vsphere != nil:
+	default:
+		return false
+	}
+
+	return true
+}
+
 // CSIMigrationSupported returns if CSI migration is supported for the specified provider.
 // NB: The CSI migration can be supported only if KubeOne supports CSI plugin and driver
 // for the provider

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -311,25 +311,28 @@ func ValidateKubernetesSupport(c kubeoneapi.KubeOneCluster, fldPath *field.Path)
 		return append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, ".versions.kubernetes is not a semver string"))
 	}
 
-	// We require external CCM/CSI on vSphere starting with Kubernetes 1.25
-	// because the in-tree volume plugin requires the CSI driver to be
-	// deployed for Kubernetes 1.25 and newer.
-	// Existing clusters running the in-tree cloud provider must be migrated
-	// to the external CCM/CSI before upgrading to Kubernetes 1.25.
-	if v.Minor() >= 25 && c.CloudProvider.Vsphere != nil && !c.CloudProvider.External {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.25 and newer doesn't support in-tree cloud provider with vsphere"))
-	}
-
-	// The in-tree cloud provider for OpenStack has been removed in
-	// Kubernetes 1.26.
-	if v.Minor() >= 26 && c.CloudProvider.Openstack != nil && !c.CloudProvider.External {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.26 and newer doesn't support in-tree cloud provider with openstack"))
-	}
-
-	// The in-tree cloud provider for AWS has been removed in
-	// Kubernetes 1.26.
-	if v.Minor() >= 27 && c.CloudProvider.AWS != nil && !c.CloudProvider.External {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.27 and newer doesn't support in-tree cloud provider with aws"))
+	if !c.CloudProvider.External {
+		switch {
+		case c.CloudProvider.AWS != nil && v.Minor() >= 27:
+			// The in-tree cloud provider for AWS has been removed in Kubernetes 1.27.
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.27 and newer doesn't support in-tree cloud provider with aws"))
+		case c.CloudProvider.Azure != nil && v.Minor() >= 27:
+			// The in-tree cloud provider for Azure has been removed in Kubernetes 1.27.
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.27 and newer doesn't support in-tree cloud provider with azure"))
+		case c.CloudProvider.GCE != nil && v.Minor() >= 29:
+			// The in-tree cloud provider for GCE has been removed in Kubernetes 1.29.
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.29 and newer doesn't support in-tree cloud provider with gce"))
+		case c.CloudProvider.Openstack != nil && v.Minor() >= 26:
+			// The in-tree cloud provider for OpenStack has been removed in Kubernetes 1.26.
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.26 and newer doesn't support in-tree cloud provider with openstack"))
+		case c.CloudProvider.Vsphere != nil && v.Minor() >= 25:
+			// We require external CCM/CSI on vSphere starting with Kubernetes 1.25
+			// because the in-tree volume plugin requires the CSI driver to be
+			// deployed for Kubernetes 1.25 and newer.
+			// Existing clusters running the in-tree cloud provider must be migrated
+			// to the external CCM/CSI before upgrading to Kubernetes 1.25.
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.25 and newer doesn't support in-tree cloud provider with vsphere"))
+		}
 	}
 
 	return allErrs

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -138,7 +138,7 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			    done after all worker nodes managed by machine-controller are rolled-out.
 
 			Make sure to familiarize yourself with the CCM/CSI migration requirements by checking the following document:
-			https://docs.kubermatic.com/kubeone/v1.8/guides/ccm-csi-migration/
+			https://docs.kubermatic.com/kubeone/main/guides/ccm-csi-migration/
 		`),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(fs)

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -138,7 +138,7 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			    done after all worker nodes managed by machine-controller are rolled-out.
 
 			Make sure to familiarize yourself with the CCM/CSI migration requirements by checking the following document:
-			https://docs.kubermatic.com/kubeone/v1.7/guides/ccm-csi-migration/
+			https://docs.kubermatic.com/kubeone/v1.8/guides/ccm-csi-migration/
 		`),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(fs)

--- a/pkg/state/context_test.go
+++ b/pkg/state/context_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestShouldEnableInTreeCloudProvider(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name                 string
 		cluster              *kubeoneapi.KubeOneCluster
@@ -183,8 +181,6 @@ func TestShouldEnableInTreeCloudProvider(t *testing.T) {
 }
 
 func TestShouldEnableCSIMigration(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name         string
 		cluster      *kubeoneapi.KubeOneCluster
@@ -264,7 +260,7 @@ func TestShouldEnableCSIMigration(t *testing.T) {
 			name: "new vSphere cluster with external disabled",
 			cluster: &kubeoneapi.KubeOneCluster{
 				CloudProvider: kubeoneapi.CloudProviderSpec{
-					Hetzner:  &kubeoneapi.HetznerSpec{},
+					Vsphere:  &kubeoneapi.VsphereSpec{},
 					External: false,
 				},
 				Versions: kubeoneapi.VersionConfig{
@@ -281,7 +277,7 @@ func TestShouldEnableCSIMigration(t *testing.T) {
 			name: "new vSphere cluster with external enabled",
 			cluster: &kubeoneapi.KubeOneCluster{
 				CloudProvider: kubeoneapi.CloudProviderSpec{
-					Hetzner:  &kubeoneapi.HetznerSpec{},
+					Vsphere:  &kubeoneapi.VsphereSpec{},
 					External: true,
 				},
 				Versions: kubeoneapi.VersionConfig{
@@ -292,7 +288,7 @@ func TestShouldEnableCSIMigration(t *testing.T) {
 				CCMStatus: nil,
 			},
 			ccmMigration: false,
-			want:         false,
+			want:         true,
 		},
 		{
 			name: "existing OpenStack cluster with external disabled",
@@ -390,8 +386,6 @@ func TestShouldEnableCSIMigration(t *testing.T) {
 }
 
 func TestShouldUnregisterInTreeProvider(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name                 string
 		cluster              *kubeoneapi.KubeOneCluster
@@ -471,7 +465,7 @@ func TestShouldUnregisterInTreeProvider(t *testing.T) {
 			name: "new vSphere cluster with external disabled",
 			cluster: &kubeoneapi.KubeOneCluster{
 				CloudProvider: kubeoneapi.CloudProviderSpec{
-					Hetzner:  &kubeoneapi.HetznerSpec{},
+					Vsphere:  &kubeoneapi.VsphereSpec{},
 					External: false,
 				},
 				Versions: kubeoneapi.VersionConfig{
@@ -488,7 +482,7 @@ func TestShouldUnregisterInTreeProvider(t *testing.T) {
 			name: "new vSphere cluster with external enabled",
 			cluster: &kubeoneapi.KubeOneCluster{
 				CloudProvider: kubeoneapi.CloudProviderSpec{
-					Hetzner:  &kubeoneapi.HetznerSpec{},
+					Vsphere:  &kubeoneapi.VsphereSpec{},
 					External: true,
 				},
 				Versions: kubeoneapi.VersionConfig{
@@ -499,7 +493,7 @@ func TestShouldUnregisterInTreeProvider(t *testing.T) {
 				CCMStatus: nil,
 			},
 			ccmMigrationComplete: false,
-			want:                 false,
+			want:                 true,
 		},
 		{
 			name: "existing OpenStack cluster with external disabled and in-tree provider registered",
@@ -582,8 +576,6 @@ func TestShouldUnregisterInTreeProvider(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			s := &State{
 				Cluster:              tc.cluster,
 				LiveCluster:          tc.liveCluster,

--- a/pkg/state/context_test.go
+++ b/pkg/state/context_test.go
@@ -167,7 +167,6 @@ func TestShouldEnableInTreeCloudProvider(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			s := &State{
 				Cluster:     tc.cluster,
 				LiveCluster: tc.liveCluster,
@@ -371,7 +370,6 @@ func TestShouldEnableCSIMigration(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			s := &State{
 				Cluster:      tc.cluster,
 				LiveCluster:  tc.liveCluster,

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -782,6 +782,8 @@ func detectCCMMigrationStatus(s *state.State) (*state.CCMStatus, error) {
 	}
 
 	status := &state.CCMStatus{
+		// permanently enable CSIMigrationEnabled for all former in-tree providers since now all the providers are
+		// extrnal
 		CSIMigrationEnabled: s.Cluster.CloudProvider.OriginalInTreeCloudProvider(),
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use DisableCloudProviders feature gate instead of each individual provider InTreePluginXXXUnregister

**Which issue(s) this PR fixes**:
This is a follow up PR #3048

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Use DisableCloudProviders feature gate as a replacement for InTreePluginXXXUnregister for each former in-tree provider
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/
```
