### PR TITLE
fix: debian apt-get update running before configuring repositories

### DIFF
--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -33,6 +33,16 @@ source /etc/kubeone/proxy-env
 {{ template "sysctl-k8s" . }}
 {{ template "journald-config" }}
 
+{{- if .CONFIGURE_REPOSITORIES }}
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
+{{- end }}
+
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 {{- if .HTTPS_PROXY }}
@@ -58,16 +68,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 
 {{- if .INSTALL_ISCSI_AND_NFS }}
 sudo systemctl enable --now iscsid
-{{- end }}
-
-{{- if .CONFIGURE_REPOSITORIES }}
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 {{- end }}
 
 kube_ver="{{ .KUBERNETES_VERSION }}-*"

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -43,7 +43,7 @@ Acquire::http::Proxy "{{ .HTTP_PROXY }}";
 {{- end }}
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 {{- if .CONFIGURE_REPOSITORIES }}
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -39,8 +39,6 @@ sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 {{- end }}
 
 sudo mkdir -p /etc/apt/apt.conf.d

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -33,12 +33,12 @@ source /etc/kubeone/proxy-env
 {{ template "sysctl-k8s" . }}
 {{ template "journald-config" }}
 
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
 {{- if .CONFIGURE_REPOSITORIES }}
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 {{- end }}
 
 sudo mkdir -p /etc/apt/apt.conf.d
@@ -66,6 +66,16 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 
 {{- if .INSTALL_ISCSI_AND_NFS }}
 sudo systemctl enable --now iscsid
+{{- end }}
+
+{{- if .CONFIGURE_REPOSITORIES }}
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 {{- end }}
 
 kube_ver="{{ .KUBERNETES_VERSION }}-*"

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -33,14 +33,6 @@ source /etc/kubeone/proxy-env
 {{ template "sysctl-k8s" . }}
 {{ template "journald-config" }}
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-{{- if .CONFIGURE_REPOSITORIES }}
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-{{- end }}
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 {{- if .HTTPS_PROXY }}
@@ -50,6 +42,14 @@ Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
 Acquire::http::Proxy "{{ .HTTP_PROXY }}";
 {{- end }}
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+{{- if .CONFIGURE_REPOSITORIES }}
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
+{{- end }}
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -42,6 +42,11 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -57,13 +62,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -43,17 +43,17 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
   rm -f /etc/apt/sources.list.d/kubernetes.list

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -42,11 +42,12 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
-sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -62,6 +63,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -43,17 +43,17 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
   rm -f /etc/apt/sources.list.d/kubernetes.list

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -42,6 +42,11 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -60,13 +65,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -42,11 +42,12 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
-sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -65,6 +66,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	nfs-common \
 	rsync
 sudo systemctl enable --now iscsid
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -42,6 +42,11 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -57,13 +62,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -43,17 +43,17 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
   rm -f /etc/apt/sources.list.d/kubernetes.list

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -42,11 +42,12 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
-sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -62,6 +63,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -42,6 +42,11 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -57,13 +62,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -43,17 +43,17 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
   rm -f /etc/apt/sources.list.d/kubernetes.list

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -42,11 +42,12 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
-sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -62,6 +63,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 
 kube_ver="1.26.0-*"
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -43,17 +43,17 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
   rm -f /etc/apt/sources.list.d/kubernetes.list

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -42,11 +42,12 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
-sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -62,6 +63,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 
 kube_ver="1.26.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -42,6 +42,11 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -57,13 +62,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 
 kube_ver="1.26.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -43,17 +43,17 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
-# otherwise, apt-get update will fail to upgrade the packages.
-if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
-  rm -f /etc/apt/sources.list.d/kubernetes.list
-fi
-
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
 Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
+
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -49,7 +49,7 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
-# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
   rm -f /etc/apt/sources.list.d/kubernetes.list

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -42,11 +42,12 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
-sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+# Removing old Kubernertes repositories from apt sources is needed when upgrading from older Kubeone versions,
+# otherwise, apt-get update will fail to upgrade the packages.
+if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
+  rm -f /etc/apt/sources.list.d/kubernetes.list
+fi
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -62,6 +63,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
 
 kube_ver="1.26.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -42,6 +42,11 @@ SystemMaxUse=5G
 EOF
 sudo systemctl force-reload systemd-journald
 
+sudo install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
@@ -57,13 +62,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	gnupg \
 	lsb-release \
 	rsync
-sudo install -m 0755 -d /etc/apt/keyrings
-
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-sudo apt-get update
 
 kube_ver="1.26.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
In debian script we were running apt-get update before configuring new repositories for Kubernetes.
When upgrading the KubeOne cluster before these changes, it can lead to an error with trying to download Kubernetes release from deprecated packages.cloud.google.com.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubeone/issues/3077

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed Kubeone upgrades on Debian hosts with deprecated Kubernetes repositories when running apt-get update.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
