### PR TITLE
AWS prerelease e2e testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubermatic KubeOne
 
+## E2E prerelease testing
+
 <p align="center">
   <img src="docs/img/kubeone-logo-text.png#gh-light-mode-only" width="700px" />
   <img src="docs/img/kubeone-logo-text-dark.png#gh-dark-mode-only" width="700px" />


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is only intended to be used as a way to manually trigger different E2E prow jobs

