### PR TITLE
Fix GCE in-tree upgrade test

### DIFF
--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -2590,14 +2590,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.27.11-to-v1.28.7
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_27_11_ToV1_28_7
+      - TestGceDefaultStableUpgradeContainerdFromV1_27_11_ToV1_28_7
       env:
       - name: PROVIDER
         value: gce

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -973,9 +973,9 @@ func TestAzureRockylinuxStableUpgradeContainerdFromV1_27_11_ToV1_28_7(t *testing
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_27_11_ToV1_28_7(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["gce_default"]
+	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -140,7 +140,7 @@
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: gce_default
+    - name: gce_default_stable
 
 - scenario: upgrade_containerd_external
   initVersion: v1.27.11


### PR DESCRIPTION
**What this PR does / why we need it**:

GCE in-tree upgrade test has been using a wrong infrastructure provider, this PR fixes it.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 