### PR TITLE
Fail e2e tests if no test matched

### DIFF
--- a/test/go-test-e2e.sh
+++ b/test/go-test-e2e.sh
@@ -42,6 +42,11 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+function fatal() {
+  echo "$1"
+  exit 1
+}
+
 function generate_ssh_key() {
   local private_ssh_key_file=$1
 
@@ -194,6 +199,7 @@ if [ -n "${RUNNING_IN_CI}" ]; then
 fi
 
 go_test_args=("$@")
+TEST_NAME="$*"
 
 if [ -n "${CREDENTIALS_FILE_PATH}" ]; then
   go_test_args+=("-credentials" "${CREDENTIALS_FILE_PATH}")
@@ -202,6 +208,8 @@ fi
 cd test/e2e
 
 go test -c . -tags e2e
+
+./e2e.test -test.list "$TEST_NAME" | grep -q "$TEST_NAME" || fatal "NO TESTS MATCH $TEST_NAME"
 
 # to handle OS signals directly, we launch e2e tests using dedicated binary
 exec ./e2e.test \


### PR DESCRIPTION
**What this PR does / why we need it**:
We had a problem with periodic jobs that wouldn't fail when we mess with test names and forget to update periodics. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
