### PR TITLE
Clean `yum` caches when configuring repos

### DIFF
--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -44,15 +44,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 {{ if .CONFIGURE_REPOSITORIES }}
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -68,10 +59,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 {{ end }}
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -77,10 +68,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -77,10 +68,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -77,10 +68,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -77,10 +68,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -77,10 +68,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -71,10 +62,11 @@ gpgcheck=1
 gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
 EOF
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -53,15 +53,6 @@ echo -n "${yum_proxy}" >> /tmp/yum.conf
 sudo mv /tmp/yum.conf /etc/yum.conf
 
 
-# Rebuilding the yum cache is required upon migrating from the legacy to the community-owned
-# repositories, otherwise, yum will fail to upgrade the packages because it's trying to
-# use old revisions (e.g. 1.27.0-0 instead of 1.27.5-150500.1.1).
-repo_migration_needed=false
-
-if sudo grep -q "packages.cloud.google.com" /etc/yum.repos.d/kubernetes.repo; then
-  repo_migration_needed=true
-fi
-
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -77,10 +68,11 @@ if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 fi
 
-if [[ $repo_migration_needed == "true" ]]; then
-  sudo yum clean all
-  sudo yum makecache
-fi
+# We must clean 'yum' cache upon changing the package repository
+# because older 'yum' versions (e.g. CentOS and Amazon Linux 2)
+# don't detect the change otherwise.
+sudo yum clean all
+sudo yum makecache
 
 
 sudo yum install -y \


### PR DESCRIPTION
**What this PR does / why we need it**:

We must clean `yum` cache upon changing the package repository because older `yum` versions (e.g. CentOS and Amazon Linux 2) don't detect the change otherwise.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Clean `yum` cache upon configuring Kubernetes repos. This fixes an issue with cluster upgrades failing on nodes with an older `yum` version
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 