### PR TITLE
Allow overriding interface used by Flannel and refactor network creation in example Terraform configs for Hetzner

### DIFF
--- a/addons/cni-canal/Kustomization
+++ b/addons/cni-canal/Kustomization
@@ -84,6 +84,12 @@ patches:
                     cpu: '{{ default "250m" .Params.RequestsCPU }}'
               - name: kube-flannel
                 image: '{{ .InternalImages.Get "Flannel" }}'
+                env:
+                  - name: FLANNELD_IFACE_REGEX
+                    valueFrom:
+                      configMapKeyRef:
+                        key: canal_iface_regex
+                        name: canal-config
             initContainers:
               - name: install-cni
                 image: '{{ .InternalImages.Get "CalicoCNI" }}'

--- a/addons/cni-canal/canal-config.yaml
+++ b/addons/cni-canal/canal-config.yaml
@@ -10,7 +10,9 @@ data:
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
-  canal_iface: ""
+  canal_iface: "{{ default "" .Params.IFACE }}"
+
+  canal_iface_regex: '{{ default "" .Params.IFACE_REGEX }}'
 
   # Whether or not to masquerade traffic to destinations not within
   # the pod network.

--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -3399,6 +3399,11 @@ spec:
             - --ip-masq
             - --kube-subnet-mgr
           env:
+            - name: FLANNELD_IFACE_REGEX
+              valueFrom:
+                configMapKeyRef:
+                  key: canal_iface_regex
+                  name: canal-config
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -19,6 +19,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 | Name | Version |
 |------|---------|
 | <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | ~> 1.31.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -39,12 +40,14 @@ No modules.
 | [hcloud_server.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/server) | resource |
 | [hcloud_server_network.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/server_network) | resource |
 | [hcloud_ssh_key.kubeone](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/ssh_key) | resource |
+| [random_integer.random_subnet_netnum](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
+| <a name="input_base_network_cidr"></a> [base\_network\_cidr](#input\_base\_network\_cidr) | base cidr, resulting cidr is randomly generated depending on provided subnet\_mask | `string` | `"10.100.0.0/16"` | no |
 | <a name="input_bastion_host_key"></a> [bastion\_host\_key](#input\_bastion\_host\_key) | Bastion SSH host public key | `string` | `null` | no |
 | <a name="input_cluster_autoscaler_max_replicas"></a> [cluster\_autoscaler\_max\_replicas](#input\_cluster\_autoscaler\_max\_replicas) | maximum number of replicas per MachineDeployment (requires cluster-autoscaler) | `number` | `0` | no |
 | <a name="input_cluster_autoscaler_min_replicas"></a> [cluster\_autoscaler\_min\_replicas](#input\_cluster\_autoscaler\_min\_replicas) | minimum number of replicas per MachineDeployment (requires cluster-autoscaler) | `number` | `0` | no |
@@ -58,7 +61,6 @@ No modules.
 | <a name="input_image_references"></a> [image\_references](#input\_image\_references) | map with images | <pre>map(object({<br>    image_name   = string<br>    ssh_username = string<br>    worker_os    = string<br>  }))</pre> | <pre>{<br>  "centos": {<br>    "image_name": "centos-7",<br>    "ssh_username": "root",<br>    "worker_os": "centos"<br>  },<br>  "rockylinux": {<br>    "image_name": "rocky-8",<br>    "ssh_username": "root",<br>    "worker_os": "rockylinux"<br>  },<br>  "ubuntu": {<br>    "image_name": "ubuntu-22.04",<br>    "ssh_username": "root",<br>    "worker_os": "ubuntu"<br>  }<br>}</pre> | no |
 | <a name="input_initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployments, only applicable if operating-system-manager addon is enabled.<br>If not specified, the default value will be added by machine-controller addon. | `string` | `""` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | Number of replicas per MachineDeployment | `number` | `2` | no |
-| <a name="input_ip_range"></a> [ip\_range](#input\_ip\_range) | ip range to use for private network | `string` | `"192.168.0.0/16"` | no |
 | <a name="input_lb_type"></a> [lb\_type](#input\_lb\_type) | n/a | `string` | `"lb11"` | no |
 | <a name="input_network_zone"></a> [network\_zone](#input\_network\_zone) | network zone to use for private network | `string` | `"eu-central"` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use in image filtering and MachineDeployment | `string` | `"ubuntu"` | no |
@@ -68,6 +70,7 @@ No modules.
 | <a name="input_ssh_private_key_file"></a> [ssh\_private\_key\_file](#input\_ssh\_private\_key\_file) | SSH private key file used to access instances | `string` | `""` | no |
 | <a name="input_ssh_public_key_file"></a> [ssh\_public\_key\_file](#input\_ssh\_public\_key\_file) | SSH public key file | `string` | `"~/.ssh/id_rsa.pub"` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | SSH user, used only in output | `string` | `""` | no |
+| <a name="input_subnet_mask"></a> [subnet\_mask](#input\_subnet\_mask) | subnet mask to use for generating cidr for a private network | `number` | `24` | no |
 | <a name="input_worker_os"></a> [worker\_os](#input\_worker\_os) | OS to run on worker machines | `string` | `""` | no |
 | <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | n/a | `string` | `"cx21"` | no |
 

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -190,10 +190,16 @@ variable "image" {
   type    = string
 }
 
-variable "ip_range" {
-  default     = "192.168.0.0/16"
-  description = "ip range to use for private network"
+variable "base_network_cidr" {
+  default     = "10.100.0.0/16"
+  description = "base cidr, resulting cidr is randomly generated depending on provided subnet_mask"
   type        = string
+}
+
+variable "subnet_mask" {
+  default     = 24
+  description = "subnet mask to use for generating cidr for a private network"
+  type        = number
 }
 
 variable "network_zone" {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is introducing two distinct changes to improve the Hetzner integration.

#### Overriding Canal/Flannel interface

For a long time, we had a problem that Hetzner clusters are using the public interface to communicate between nodes. That's a huge problem both from the efficiency side (bandwidth consumption) and from the security side. It can also make problems with some other components, such as CCM and CSI.

The reason why this happens is that Hetzner servers are configured with a default route that uses the public interface. Canal/Flannel are using that default route to determine what network interface should be used for communications between nodes and VXLAN.

This can be mitigated by forcing Flannel to use another interface in two ways:
- by setting the `FLANNELD_IFACE` environment variable or the `--iface` flag
- by setting the `FLANNELD_IFACE_REGEX` environment variable or the `--iface-regex` flag

KubeOne didn't fully support any of those mechanisms. Even though it is already possible to edit the `canal-config` ConfigMap and set `canal_iface` which is used as a value for the `FLANNELD_IFACE` environment variable, that change would be overridden on the first subsequent `kubeone apply` run.

This problem is solved by introducing a new parameter for the Canal CNI addon called `IFACE` which can be used like this:

```yaml
apiVersion: kubeone.k8c.io/v1beta2
kind: KubeOneCluster
...
addons:
  enable: true
  addons:
    - name: "cni-canal"
      params:
        IFACE: ens10
```

However, this requires knowing the interface name and this is not always possible. Instead, it might be better to use the regex to match the interface name or the interface's IP address. This is possible thanks to the `FLANNELD_IFACE_REGEX` option and it's exposed to KubeOne users via the `IFACE_REGEX` parameter:

```yaml
apiVersion: kubeone.k8c.io/v1beta2
kind: KubeOneCluster
...
addons:
  enable: true
  addons:
    - name: "cni-canal"
      params:
        IFACE_REGEX: '10\.*\.10\.*'
```

Note: using apostrophes is required when passing regex via YAML.

#### Randomly generating network subnet for Hetzner

We have been using the same subnet for all Hetzner clusters (`192.168.0.0/16`). There are multiple problems:

- Even though networks are different, it seems like different networks with the same subnet can collide and cause conflicts
- `/16` subnet is quite large especially if we want to run multiple E2E tests in parallel

To mitigate this, this PR refactors how we handle networks in the example Terraform configs for Hetzner. We are now randomly generating `/24` subnets in the `10.100.0.0/16` range, similar to what are we doing for AWS. This is a breaking change and existing users will have to take additional steps if migrating to the new Terraform configs.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Canal CNI: Add `IFACE` and `IFACE_REGEX` parameters to allow explicitly selecting network interface to be used for inter-node communication and VXLAN
- [ACTION REQUIRED] Refactor example Terraform configs for Hetzner to randomly generate the private network subnet in order to support creating multiple KubeOne clusters
```

**Documentation**:
```documentation
TBD
```

/assign @kron4eg 