### PR TITLE
Fix initKubeOneVersion for v1.27 E2E tests

### DIFF
--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -2432,7 +2432,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2462,7 +2462,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2492,7 +2492,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2522,7 +2522,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2553,7 +2553,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2583,7 +2583,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2611,7 +2611,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2639,7 +2639,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2667,7 +2667,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2695,7 +2695,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2723,7 +2723,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2751,7 +2751,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2779,7 +2779,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2809,7 +2809,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2839,7 +2839,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2869,7 +2869,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2900,7 +2900,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2930,7 +2930,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2958,7 +2958,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2986,7 +2986,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3014,7 +3014,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3042,7 +3042,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3070,7 +3070,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3098,7 +3098,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3126,7 +3126,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3154,7 +3154,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3182,7 +3182,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3210,7 +3210,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3238,7 +3238,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3268,7 +3268,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3298,7 +3298,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3328,7 +3328,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3358,7 +3358,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3388,7 +3388,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3416,7 +3416,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3444,7 +3444,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8587,7 +8587,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8615,7 +8615,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8643,7 +8643,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8671,7 +8671,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8699,7 +8699,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8727,7 +8727,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8755,7 +8755,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8785,7 +8785,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8815,7 +8815,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8845,7 +8845,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8876,7 +8876,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8906,7 +8906,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8934,7 +8934,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8962,7 +8962,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -8990,7 +8990,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9018,7 +9018,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9046,7 +9046,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9074,7 +9074,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9102,7 +9102,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9130,7 +9130,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9158,7 +9158,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9186,7 +9186,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9214,7 +9214,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9244,7 +9244,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9274,7 +9274,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9304,7 +9304,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9334,7 +9334,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9364,7 +9364,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9392,7 +9392,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9420,7 +9420,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: main
+  - base_ref: release/v1.7
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -134,7 +134,6 @@
 - scenario: upgrade_containerd
   initVersion: v1.27.11
   upgradedVersion: v1.28.7
-  initKubeOneVersion: "main"
   infrastructures:
     - name: azure_centos_stable
     - name: azure_default_stable
@@ -146,7 +145,6 @@
 - scenario: upgrade_containerd_external
   initVersion: v1.27.11
   upgradedVersion: v1.28.7
-  initKubeOneVersion: "main"
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -425,7 +423,6 @@
 
 - scenario: upgrade_cilium_containerd_external
   initVersion: v1.27.11
-  initKubeOneVersion: "main"
   upgradedVersion: v1.28.7
   infrastructures:
     - name: aws_amzn_stable


### PR DESCRIPTION
**What this PR does / why we need it**:

The main purpose of v1.27 to v1.28 upgrade E2E tests is regression testing; to make sure that if you created a cluster using a previous KubeOne minor release, you can safely upgrade it using the current KubeOne minor release.

This change is going to break Azure upgrade tests, but we're done with them. Those tests anyways need some more attention before we cut the release.

Reverts part of #3154 

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 
/priority critical-urgent