### PR TITLE
Increase version constraint for Azure with in-tree provider

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -316,9 +316,9 @@ func ValidateKubernetesSupport(c kubeoneapi.KubeOneCluster, fldPath *field.Path)
 		case c.CloudProvider.AWS != nil && v.Minor() >= 27:
 			// The in-tree cloud provider for AWS has been removed in Kubernetes 1.27.
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.27 and newer doesn't support in-tree cloud provider with aws"))
-		case c.CloudProvider.Azure != nil && v.Minor() >= 27:
-			// The in-tree cloud provider for Azure has been removed in Kubernetes 1.27.
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.27 and newer doesn't support in-tree cloud provider with azure"))
+		case c.CloudProvider.Azure != nil && v.Minor() >= 29:
+			// The in-tree cloud provider for Azure has been removed in Kubernetes 1.29.
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.29 and newer doesn't support in-tree cloud provider with azure"))
 		case c.CloudProvider.GCE != nil && v.Minor() >= 29:
 			// The in-tree cloud provider for GCE has been removed in Kubernetes 1.29.
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("cloudProvider").Child("external"), c.CloudProvider.External, "kubernetes 1.29 and newer doesn't support in-tree cloud provider with gce"))


### PR DESCRIPTION
**What this PR does / why we need it**:

#3075 by mistake introduced a constraint for Azure that external CCM is required from 1.27. This is a regression because:

- Azure supports in-tree cloud provider up until 1.29 (see https://github.com/kubernetes/kubernetes/blob/release-1.29/cmd/cloud-controller-manager/providers.go)
- KubeOne 1.7 supported Azure clusters with in-tree cloud provider running Kubernetes 1.27

Replaces #3158, those tests are not invalid

**What type of PR is this?**

/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 
/priority critical-urgent