### PR TITLE
[release/v1.7] bump OSM to 1.3.5

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -220,7 +220,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.57.6"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.4"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.3.4"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.3.5"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This gives us https://github.com/kubermatic/operating-system-manager/pull/381.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Update operating-system-manager to v1.3.5.
* [ACTION REQUIRED] The latest Ubuntu 22.04 images ship with cloud-init 24.x package. This package has breaking changes and thus rendered our OSPs as incompatible. It's recommended to refresh your machines with latest provided OSPs to ensure that a system-wide package update, that updates cloud-init to 24.x, doesn't break the machines.
```

**Documentation**:
```documentation
NONE
```
