### PR TITLE
[release/v1.6] bump OSM to 1.2.5

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -220,7 +220,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.56.6"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.4"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.5"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This gives us https://github.com/kubermatic/operating-system-manager/pull/381.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Update operating-system-manager to v1.2.5.
* [ACTION REQUIRED] The latest Ubuntu 22.04 images ship with cloud-init 24.x package. This package has breaking changes and thus rendered our OSPs as incompatible. It's recommended to refresh your machines with latest provided OSPs to ensure that a system-wide package update, that updates cloud-init to 24.x, doesn't break the machines.
```

**Documentation**:
```documentation
NONE
```
