### PR TITLE
Bump OSM to v1.5.1

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -214,7 +214,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.59.0-beta.0"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.0"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:d16de939d7164849ab22f5903d528fcca215b9e9"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.5.1"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the latest version, including the cloud-init fix.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update operating-system-manager to v1.5.1
```

**Documentation**:
```documentation
NONE
```
