### PR TITLE
[release/v1.6] bump OSM to v1.2.6

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -220,7 +220,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.56.6"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.5"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.2.6"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This includes a fix for Ubuntu on Azure.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Update operating-system-manager to v1.3.6. The latest Ubuntu 22.04 images on Azure have modified the configuration for `cloud-init` and how it accesses its datasource in Azure, in a breaking way. If you're having an Azure cluster, it's required to [refresh your machines](https://docs.kubermatic.com/kubeone/v1.7/cheat-sheets/rollout-machinedeployment/) with the latest provided OSPs to ensure that a system-wide package update doesn't result in broken machines.
```

**Documentation**:
```documentation
NONE
```
