### PR TITLE
bump OSM to v1.5.2

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -214,7 +214,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.59.0-beta.0"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.0"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.5.1"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.5.2"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This includes a fix for Ubuntu on Azure.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Update operating-system-manager to v1.3.6. The latest Ubuntu 22.04 images on Azure have modified the configuration for `cloud-init` and how it accesses its datasource in Azure, in a breaking way. If you're having an Azure cluster, it's required to [refresh your machines](https://docs.kubermatic.com/kubeone/v1.7/cheat-sheets/rollout-machinedeployment/) with the latest provided OSPs to ensure that a system-wide package update doesn't result in broken machines.
```

**Documentation**:
```documentation
NONE
```
