### PR TITLE
Fix incorrect args for AWS and Azure CCM

### DIFF
--- a/addons/ccm-aws/ccm-aws.yaml
+++ b/addons/ccm-aws/ccm-aws.yaml
@@ -152,6 +152,9 @@ spec:
             - --configure-cloud-routes=false
             - --cloud-config=/etc/kubernetes/cloud/cloud-config
             - --v=2
+            {{- with .Params.CCM_CONCURRENT_SERVICE_SYNCS }}
+            - --concurrent-service-syncs={{ . }}
+            {{- end }}
           env: []
           image: '{{ .InternalImages.Get "AwsCCM" }}'
           name: aws-cloud-controller-manager

--- a/addons/ccm-azure/Kustomization
+++ b/addons/ccm-azure/Kustomization
@@ -35,6 +35,17 @@ patches:
             containers:
               - name: cloud-controller-manager
                 image: '{{ .InternalImages.Get "AzureCCM" }}'
+                args:
+                  - --allocate-node-cidrs=false
+                  - --cloud-config=/etc/cloud/cloud-config
+                  - --cloud-provider=azure
+                  - --cluster-name={{ .Config.Name }}
+                  - --configure-cloud-routes=false
+                  - --controllers=*,-cloud-node
+                  - --leader-elect=true
+                  - --route-reconciliation-period=10s
+                  - --secure-port=10268
+                  - --v=2
                 env:
                   - name: SSL_CERT_FILE
                     value: /usr/share/ca-certificates/ca-certificates.crt

--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -211,14 +211,16 @@ spec:
             - --allocate-node-cidrs=false
             - --cloud-config=/etc/cloud/cloud-config
             - --cloud-provider=azure
-            - --cluster-cidr=10.244.0.0/16
-            - --cluster-name=kubernetes
+            - --cluster-name={{ .Config.Name }}
             - --configure-cloud-routes=false
             - --controllers=*,-cloud-node
             - --leader-elect=true
             - --route-reconciliation-period=10s
             - --secure-port=10268
             - --v=2
+            {{- with .Params.CCM_CONCURRENT_SERVICE_SYNCS }}
+            - --concurrent-service-syncs={{ . }}
+            {{- end }}
           command:
             - cloud-controller-manager
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix AWS and Azure CCM manifests:

- AWS: re-add `CCM_CONCURRENT_SERVICE_SYNCS` parameter
- Azure: re-add `CCM_CONCURRENT_SERVICE_SYNCS` parameter
- Azure: fix `--cluster-name` flag and remove `--cluster-cidr` flag

**What type of PR is this?**

/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @ahmedwaleedmalik @embik @xrstf 