### PR TITLE
Use kube-system namespace for CSI snapshotter on vSphere

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -270,8 +270,6 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 	switch {
 	// Certs for vsphere-csi-webhook (deployed only if CSIMigration is enabled)
 	case s.Cluster.CloudProvider.Vsphere != nil:
-		webhookNamespace = resources.VsphereCSIWebhookNamespace
-
 		if err := webhookCerts(data.Certificates,
 			webhookCertsCSI,
 			webhookName,
@@ -285,6 +283,7 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 
 		certNamePrefix = webhookCertsCSIMigration
 		webhookName = resources.VsphereCSIWebhookName
+		webhookNamespace = resources.VsphereCSIWebhookNamespace
 
 		if !csiMigration {
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

CSI snapshotter has been decoupled from CSI drivers and is now a dedicated addon. Previously, we deployed CSI snapshotter in `vmware-system-csi` namespace, but now that we have one addon for all providers, it's always deployed in `kube-system` namespace.

This PR ensures this is also reflected upon generating the certificate for CSI snapshotter, fixing the following error:

```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation-webhook.snapshot.storage.k8s.io": failed to call webhook: Post "https://snapshot-validation-service.kube-system.svc:443/volumesnapshot?timeout=2s": dial tcp 10.96.33.141:443: connect: connection refused
```

**What type of PR is this?**

/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```