### PR TITLE
silence warning about unset logger in e2e tests

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -51,6 +52,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	k8spath "k8s.io/utils/path"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -63,6 +65,8 @@ func init() {
 	if err := clusterv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		panic(err)
 	}
+
+	ctrlruntimelog.SetLogger(logr.Discard())
 }
 
 func mustGetwd() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This gets rid of

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 12 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0003266c0, {0x18d52a2, 0x14})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/log/deleg.go:147 +0x3e
	>  github.com/go-logr/logr.Logger.WithName({{0x1c64da0, 0xc0003266c0}, 0x0}, {0x18d52a2?, 0x0?})
	>  	/home/prow/go/pkg/mod/github.com/go-logr/logr@v1.3.0/logr.go:349 +0x36
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x1747da0?, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/client/client.go:122 +0xf1
	>  sigs.k8s.io/controller-runtime/pkg/client.New(0xc0005642a0?, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/client/client.go:103 +0x7d
	>  k8c.io/kubeone/test/e2e.(*kubeoneBin).DynamicClient(0xc00005d940?)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/kubeone.go:89 +0x45
	>  k8c.io/kubeone/test/e2e.dynamicClientRetriable.func1()
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/helpers.go:465 +0x29
	>  k8s.io/client-go/util/retry.OnError.func1()
	>  	/home/prow/go/pkg/mod/k8s.io/client-go@v0.29.2/util/retry/util.go:51 +0x30
	>  k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0xc00005d9e8?)
	>  	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/wait.go:145 +0x3e
	>  k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0xc000525a18)
	>  	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/backoff.go:461 +0x5a
	>  k8s.io/client-go/util/retry.OnError({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0x0?, 0x0?)
	>  	/home/prow/go/pkg/mod/k8s.io/client-go@v0.29.2/util/retry/util.go:50 +0xa5
	>  k8c.io/kubeone/test/e2e.retryFn(...)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/helpers.go:105
	>  k8c.io/kubeone/test/e2e.dynamicClientRetriable(0xc000370ea0, 0xc000147208?)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/helpers.go:464 +0x9b
	>  k8c.io/kubeone/test/e2e.waitKubeOneNodesReady({0x1c60a60, 0xc000459140}, 0xc000370ea0, 0xc0005642a0)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/helpers.go:557 +0x48
	>  k8c.io/kubeone/test/e2e.(*scenarioInstall).test(0xc0001e6dd0, {0x1c60a60, 0xc000459140}, 0xc000370ea0)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/scenario_install.go:163 +0x30e
	>  k8c.io/kubeone/test/e2e.(*scenarioInstall).Run(0xc0001e6dd0, {0x1c60a60, 0xc000459140}, 0xc000370ea0)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/scenario_install.go:63 +0xc8
	>  k8c.io/kubeone/test/e2e.TestOpenstackFlatcarInstallContainerdExternalV1_27_11(0xc000370ea0)
	>  	/home/prow/go/src/k8c.io/kubeone/test/e2e/tests_test.go:235 +0x189
	>  testing.tRunner(0xc000370ea0, 0x1ad2ec0)
	>  	/usr/local/go/src/testing/testing.go:1689 +0xfb
	>  created by testing.(*T).Run in goroutine 1
	>  	/usr/local/go/src/testing/testing.go:1742 +0x390
```

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
