### PR TITLE
Update machine-controller to v1.59.1 and remove fields added in v1.29 from kubelet and kubeproxy configs

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -212,7 +212,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:             {"*": "quay.io/calico/node:v3.27.2"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.28"},
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
-		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.59.0-beta.0"},
+		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.59.1"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.0"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.5.2"},
 	}

--- a/pkg/templates/kubernetesconfigs/kubelet.go
+++ b/pkg/templates/kubernetesconfigs/kubelet.go
@@ -51,5 +51,9 @@ func NewKubeletConfiguration(cluster *kubeoneapi.KubeOneCluster, featureGates ma
 		kubeletConfig.ClusterDNS = []string{resources.NodeLocalDNSVirtualIP}
 	}
 
-	return dropFields(kubeletConfig, []string{"logging"}, []string{"containerRuntimeEndpoint"})
+	return dropFields(kubeletConfig,
+		[]string{"containerRuntimeEndpoint"},
+		[]string{"imageMaximumGCAge"},
+		[]string{"logging"},
+	)
 }

--- a/pkg/templates/kubernetesconfigs/kubeproxy.go
+++ b/pkg/templates/kubernetesconfigs/kubeproxy.go
@@ -54,5 +54,14 @@ func NewKubeProxyConfiguration(cluster *kubeoneapi.KubeOneCluster) (runtime.Obje
 		}
 	}
 
-	return dropFields(kubeProxyConfig, []string{"detectLocal"}, []string{"winkernel"}, []string{"iptables", "localhostNodePorts"}, []string{"logging"})
+	return dropFields(kubeProxyConfig,
+		[]string{"conntrack", "tcpBeLiberal"},
+		[]string{"conntrack", "udpStreamTimeout"},
+		[]string{"conntrack", "udpTimeout"},
+		[]string{"detectLocal"},
+		[]string{"iptables", "localhostNodePorts"},
+		[]string{"logging"},
+		[]string{"nftables"},
+		[]string{"winkernel"},
+	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update machine-controller to v1.59.1
- Remove fields added in Kubernetes v1.29 from kubelet and kubeproxy configs

This resolves the following warning produced by `kubeadm`:

```
[172.31.209.122] W0511 09:19:23.312331    4023 initconfiguration.go:306] error unmarshaling configuration schema.GroupVersionKind{Group:"kubelet.config.k8s.io", Version:"v1beta1", Kind:"KubeletConfiguration"}: strict decoding error: unknown field "imageMaximumGCAge"
[172.31.209.122] W0511 09:19:23.313272    4023 initconfiguration.go:306] error unmarshaling configuration schema.GroupVersionKind{Group:"kubeproxy.config.k8s.io", Version:"v1alpha1", Kind:"KubeProxyConfiguration"}: strict decoding error: unknown field "conntrack.tcpBeLiberal", unknown field "conntrack.udpStreamTimeout", unknown field "conntrack.udpTimeout", unknown field "nftables"
```

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update machine-controller to v1.59.1
```

**Documentation**:
```documentation
NONE
```

/assign @xrstf @embik 
/hold for final testing