### PR TITLE
update canal to v3.28.0

### DIFF
--- a/addons/cni-canal/Kustomization
+++ b/addons/cni-canal/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/projectcalico/calico/v3.27.3/manifests/canal.yaml
+  - https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/canal.yaml
 
 patches:
   - patch: |-

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -207,11 +207,11 @@ func FindResource(name string) (Resource, error) {
 
 func baseResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
-		CalicoCNI:              {"*": "quay.io/calico/cni:v3.27.3"},
-		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.27.3"},
-		CalicoNode:             {"*": "quay.io/calico/node:v3.27.3"},
+		CalicoCNI:              {"*": "quay.io/calico/cni:v3.28.0"},
+		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.28.0"},
+		CalicoNode:             {"*": "quay.io/calico/node:v3.28.0"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.23.1"},
-		Flannel:                {"*": "docker.io/flannel/flannel:v0.21.3"},
+		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:d62ab03c71afd83c2d13549b06f85bd4621ef186"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.1"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.5.2"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Continues https://github.com/kubermatic/kubeone/pull/3214 to update canal-cni. 

Additionally fixes Critical CVEs in the older flannel image ( CVE-2023-38545, CVE-2023-26463, CVE-2023-41913 ).

**Which issue(s) this PR fixes**:
Fixes #3206 (the first Task, the others should be fixed by the preceding PR)

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Update canal to v3.28.0
```

**Documentation**:

Do we need a hint to https://docs.tigera.io/calico/latest/release-notes/#important-upgrade-notes and that restarts of calico controllers might be necessary after the update? 
Not sure how to handle that. 

```documentation
NONE
```
