### PR TITLE
bump GCP CCM to 30.x, using staging images

### DIFF
--- a/addons/ccm-gcp/Kustomization
+++ b/addons/ccm-gcp/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/providers/v0.28.2/deploy/packages/default/manifest.yaml
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/ccm/v30.0.0/deploy/packages/default/manifest.yaml
 
 patches:
   - target:

--- a/addons/ccm-gcp/ccm-gcp.yaml
+++ b/addons/ccm-gcp/ccm-gcp.yaml
@@ -359,7 +359,6 @@ spec:
               name: cloudconfig
               readOnly: true
       hostNetwork: true
-      nodeSelector: null
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -358,7 +358,7 @@ func optionalResources() map[Resource]map[string]string {
 		NutanixCSISnapshotter:   {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3"},
 
 		// GCP CCM
-		GCPCCM: {"*": "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v28.2.1"},
+		GCPCCM: {"*": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v30.0.0"},
 
 		// GCP Compute Persistent Disk CSI
 		// see: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/images/stable-master/image.yaml

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -358,7 +358,12 @@ func optionalResources() map[Resource]map[string]string {
 		NutanixCSISnapshotter:   {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3"},
 
 		// GCP CCM
-		GCPCCM: {"*": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v30.0.0"},
+		GCPCCM: {
+			"1.27.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v27.1.6",
+			"1.28.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v28.2.1",
+			"1.29.x":    "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v29.0.0",
+			">= 1.30.0": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v30.0.0",
+		},
 
 		// GCP Compute Persistent Disk CSI
 		// see: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/images/stable-master/image.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Still waiting for https://github.com/kubernetes/cloud-provider-gcp/issues/289#issuecomment-1889176432, so in the meantime we're using the unpromoted images.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update GCP CCM to v30.0.0.
```

**Documentation**:
```documentation
NONE
```
