### PR TITLE
Improve the Kubernetes 1.30 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes-support.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes-support.md
@@ -26,6 +26,7 @@ This is a collector issue for Kubernetes 1.2x support in KubeOne. The following 
 * [ ] Update the latest supported Kubernetes version in [the API validation](https://github.com/kubermatic/kubeone/blob/main/pkg/apis/kubeone/validation/validation.go#L40-L41) <!-- (link to the PR) -->
 * [ ] Update [default admission controllers](https://github.com/kubermatic/kubeone/blob/main/pkg/kubeflags/data.go) if needed <!-- (link to the PR) -->
 * [ ] Update `pause` image version in `pkg/apis/kubeone/helpers.go` if needed <!-- (link to the PR) -->
+* [ ] Add the appropriate `cri-tools` version in `pkg/scripts/os_flatcar.go` <!-- (link to the PR) -->
 * [ ] Update [the stable version marker in Makefile](https://github.com/kubermatic/kubeone/blob/5273f9a372736569c6b09b38f2959019d29e4d6a/Makefile#L24) <!-- (link to the PR) -->
 * [ ] Add E2E tests inside `tests.yml` <!-- (link to the PR) -->
 * [ ] Update daily periodics to use the latest Kubernetes release

--- a/.github/ISSUE_TEMPLATE/update-images.md
+++ b/.github/ISSUE_TEMPLATE/update-images.md
@@ -19,18 +19,23 @@ Reference to the previous issue for updating images: <!-- (issue reference) -->
 
 Action items:
 
-- [ ] Update the issue template to add/remove [images](https://github.com/kubermatic/kubeone/blob/main/pkg/templates/images/images.go) as appropriate
+- [ ] Update the issue template to add/remove [images](https://github.com/kubermatic/kubeone/blob/main/pkg/templates/images/images.go) as appropriate <!-- (PR reference|already the latest) -->
 
 The following components/images should be updated:
 
 ### General
 
+- [ ] [machine-controller](https://github.com/kubermatic/machine-controller) <!-- (PR reference|already the latest) -->
+- [ ] [operating-system-manager](https://github.com/kubermatic/operating-system-manager)
+- [ ] [metrics-server](https://github.com/kubernetes-sigs/metrics-server) <!-- (PR reference|already the latest) -->
+- [ ] [NodeLocalDNS](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml) <!-- (PR reference|already the latest) -->
+- [ ] [Cluster Autoscaler](https://github.com/kubernetes/autoscaler) <!-- (PR reference|already the latest) -->
+
+### CNIs
+
 - [ ] [Canal CNI](https://github.com/projectcalico/calico) <!-- (PR reference|already the latest) -->
 - [ ] [Calico VXLAN CNI](https://github.com/projectcalico/calico) <!-- (PR reference|already the latest) -->
 - [ ] [Cilium CNI](https://github.com/cilium/cilium) <!-- (PR reference|already the latest) -->
-- [ ] [NodeLocalDNS](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml) <!-- (PR reference|already the latest) -->
-- [ ] [metrics-server](https://github.com/kubernetes-sigs/metrics-server) <!-- (PR reference|already the latest) -->
-- [ ] [Cluster Autoscaler](https://github.com/kubernetes/autoscaler) <!-- (PR reference|already the latest) -->
 
 ### Cloud provider components
 
@@ -53,12 +58,11 @@ The following components/images should be updated:
 - [ ] [vSphere CCM](https://github.com/kubernetes/cloud-provider-vsphere) <!-- (PR reference|already the latest) -->
 - [ ] [vSphere CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver) <!-- (PR reference|already the latest) -->
 - [ ] [VMware Cloud Director CSI](https://github.com/vmware/cloud-director-named-disk-csi-driver) <!-- (PR reference|already the latest) -->
+- [ ] [External Snapshotter](https://github.com/kubernetes-csi/external-snapshotter) <!-- (PR reference|already the latest) -->
 
 ### Addons
 
 - [ ] [Restic Backups](https://github.com/kubermatic/kubeone/tree/main/addons/backups-restic) <!-- (PR reference|already the latest) -->
 - [ ] [Unattended upgrades](https://github.com/kubermatic/kubeone/tree/main/addons/unattended-upgrades) <!-- (PR reference|already the latest) -->
-- [ ] [Secret Store CSI driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) <!-- (PR reference|already the latest) -->
-- [ ] [Vault CSI Secret Provider](https://github.com/hashicorp/vault-csi-provider) <!-- (PR reference|already the latest) -->
 
 Relevant to <!-- epic number -->

--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -66,7 +66,7 @@ var (
 	`)
 
 	kubeadmUpgradeScriptTemplate = heredoc.Doc(`
-		sudo {{ .KUBEADM_UPGRADE }}{{ if .LEADER }} --config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml{{ end }}
+		echo yes | sudo {{ .KUBEADM_UPGRADE }}{{ if .LEADER }} --config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml{{ end }}
 		sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;
 	`)
 

--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -280,7 +280,7 @@ func TestKubeadmUpgrade(t *testing.T) {
 			name: "leader",
 			args: args{
 				workdir:    "some",
-				kubeadmCmd: "kubeadm upgrade apply -y --certificate-renewal=true v1.1.1",
+				kubeadmCmd: "kubeadm upgrade apply -y v1.1.1",
 				leader:     true,
 			},
 		},

--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -280,7 +280,7 @@ func TestKubeadmUpgrade(t *testing.T) {
 			name: "leader",
 			args: args{
 				workdir:    "some",
-				kubeadmCmd: "kubeadm upgrade apply -y v1.1.1",
+				kubeadmCmd: "kubeadm upgrade apply v1.1.1",
 				leader:     true,
 			},
 		},

--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -245,14 +245,14 @@ func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
 	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)
 
 	switch kubeSemVer.Minor() {
-	case 26:
-		return "1.26.0"
 	case 27:
 		return "1.27.1"
 	case 28:
 		return "1.28.0"
 	case 29:
 		return "1.29.0"
+	case 30:
+		return "1.30.0"
 	}
 
 	return ""

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -88,7 +88,7 @@ func withDefaultAssetConfiguration(cls *kubeoneapi.KubeOneCluster) {
 func genCluster(opts ...genClusterOpts) kubeoneapi.KubeOneCluster {
 	cls := &kubeoneapi.KubeOneCluster{
 		Versions: kubeoneapi.VersionConfig{
-			Kubernetes: "1.26.0",
+			Kubernetes: "1.30.0",
 		},
 		ContainerRuntime: kubeoneapi.ContainerRuntimeConfig{
 			Containerd: &kubeoneapi.ContainerRuntimeContainerd{},

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository
@@ -135,9 +135,9 @@ cd /tmp/k8s-binaries
 # cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
 # to install cri-tools from the Kubernetes repos.
 sudo yum install -y --disableplugin=priorities \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository
@@ -135,9 +135,9 @@ cd /tmp/k8s-binaries
 # cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
 # to install cri-tools from the Kubernetes repos.
 sudo yum install -y --disableplugin=priorities \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository
@@ -137,9 +137,9 @@ cd /tmp/k8s-binaries
 # cri-tools in the AL2 repos. We disable the priorities plugin  to allow yum
 # to install cri-tools from the Kubernetes repos.
 sudo yum install -y --disableplugin=priorities \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -132,9 +132,9 @@ sudo systemctl restart containerd
 
 
 sudo yum install -y \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -135,9 +135,9 @@ sudo systemctl restart containerd
 
 
 sudo yum install -y \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -132,9 +132,9 @@ sudo systemctl restart containerd
 
 
 sudo yum install -y \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -134,9 +134,9 @@ sudo systemctl restart containerd
 
 
 sudo yum install -y \
-	kubelet-1.26.0 \
-	kubeadm-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubeadm-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -65,13 +65,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 
-kube_ver="1.26.0-*"
+kube_ver="1.30.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -68,13 +68,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 sudo systemctl enable --now iscsid
 sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 
-kube_ver="1.26.0-*"
+kube_ver="1.30.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -65,13 +65,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 
-kube_ver="1.26.0-*"
+kube_ver="1.30.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -65,13 +65,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 
-kube_ver="1.26.0-*"
+kube_ver="1.30.0-*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -58,8 +58,8 @@ sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifest
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.26.0"
+RELEASE="v1.30.0"
+CRI_TOOLS_RELEASE="v1.30.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -58,8 +58,8 @@ sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifest
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.26.0"
+RELEASE="v1.30.0"
+CRI_TOOLS_RELEASE="v1.30.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -58,8 +58,8 @@ sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifest
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.26.0"
+RELEASE="v1.30.0"
+CRI_TOOLS_RELEASE="v1.30.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -58,8 +58,8 @@ sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifest
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.26.0"
+RELEASE="v1.30.0"
+CRI_TOOLS_RELEASE="v1.30.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -58,8 +58,8 @@ sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifest
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.26.0"
+RELEASE="v1.30.0"
+CRI_TOOLS_RELEASE="v1.30.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
@@ -1,4 +1,4 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-sudo kubeadm upgrade apply -y v1.1.1 --config=some/cfg/master_0.yaml
+echo yes | sudo kubeadm upgrade apply v1.1.1 --config=some/cfg/master_0.yaml
 sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
@@ -1,4 +1,4 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-sudo kubeadm upgrade apply -y --certificate-renewal=true v1.1.1 --config=some/cfg/master_0.yaml
+sudo kubeadm upgrade apply -y v1.1.1 --config=some/cfg/master_0.yaml
 sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-v1beta2.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-v1beta2.golden
@@ -1,4 +1,4 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-sudo kubeadm upgrade node
+echo yes | sudo kubeadm upgrade node
 sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -133,7 +133,7 @@ sudo systemctl restart containerd
 sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
-	kubeadm-1.26.0 \
+	kubeadm-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -65,13 +65,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 
-kube_ver="1.26.0-*"
+kube_ver="1.30.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 # We must clean 'yum' cache upon changing the package repository

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -56,10 +56,10 @@ sudo mv /tmp/yum.conf /etc/yum.conf
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.26/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
 EOF
 
 source /etc/os-release
@@ -133,8 +133,8 @@ sudo systemctl restart containerd
 sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
-	kubelet-1.26.0 \
-	kubectl-1.26.0 \
+	kubelet-1.30.0 \
+	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -65,13 +65,13 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 sudo install -m 0755 -d /etc/apt/keyrings
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
 
-kube_ver="1.26.0-*"
+kube_ver="1.30.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -361,8 +361,8 @@ func optionalResources() map[Resource]map[string]string {
 		GCPCCM: {
 			"1.27.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v27.1.6",
 			"1.28.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v28.2.1",
-			"1.29.x":    "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v29.0.0",
-			">= 1.30.0": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v30.0.0",
+			"1.29.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v29.0.0",
+			">= 1.30.0": "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v30.0.0",
 		},
 
 		// GCP Compute Persistent Disk CSI

--- a/pkg/templates/kubeadm/kubeadm.go
+++ b/pkg/templates/kubeadm/kubeadm.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	kubeadmUpgradeNodeCommand = "kubeadm upgrade node --certificate-renewal=true"
+	kubeadmUpgradeNodeCommand = "kubeadm upgrade node"
 )
 
 // Kubedm interface abstract differences between different kubeadm versions

--- a/pkg/templates/kubeadm/kubeadmv1beta3.go
+++ b/pkg/templates/kubeadm/kubeadmv1beta3.go
@@ -48,7 +48,7 @@ func (*kubeadmv1beta3) ConfigWorker(s *state.State, instance kubeoneapi.HostConf
 }
 
 func (k *kubeadmv1beta3) UpgradeLeaderCommand() string {
-	return fmt.Sprintf("kubeadm upgrade apply -y --certificate-renewal=true %s", k.version)
+	return fmt.Sprintf("kubeadm upgrade apply -y %s", k.version)
 }
 
 func (*kubeadmv1beta3) UpgradeFollowerCommand() string {

--- a/pkg/templates/kubeadm/kubeadmv1beta3.go
+++ b/pkg/templates/kubeadm/kubeadmv1beta3.go
@@ -48,7 +48,7 @@ func (*kubeadmv1beta3) ConfigWorker(s *state.State, instance kubeoneapi.HostConf
 }
 
 func (k *kubeadmv1beta3) UpgradeLeaderCommand() string {
-	return fmt.Sprintf("kubeadm upgrade apply -y %s", k.version)
+	return fmt.Sprintf("kubeadm upgrade apply %s", k.version)
 }
 
 func (*kubeadmv1beta3) UpgradeFollowerCommand() string {

--- a/test/e2e/testdata/aws_medium.tfvars
+++ b/test/e2e/testdata/aws_medium.tfvars
@@ -7,4 +7,3 @@ control_plane_type        = "t3a.medium"
 control_plane_volume_size = 25
 worker_type               = "t3a.medium"
 worker_volume_size        = 25
-bastion_type              = "t3a.nano"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces several improvements and bug fixes to our Kubernetes 1.30 support:

- Set `cri-tools` version for Kubernetes 1.30 on Flatcar
- Drop `--certificate-renew=true` and `--yes` flags from `kubeadm upgrade apply` command as it's not possible to combine the `--config` flag with other flags as of `kubeadm` 1.30
  - Dropping the `--certificate-renew=true` flag is a no-op change because the flag is `true` by default
  - Dropping the `--yes` flag means that we run `kubeadm` in the interactive mode and that `kubeadm` will ask user to type `yes` to confirm upgrading the cluster. As KubeOne doesn't support interactive inputs, we mitigate this by piping `yes` to the `kubeadm upgrade apply` command
- Fix Rocky Linux tests failing by using `t3.nano` instead of `t3a.nano` for the bastion instance
  - It appears that the latest Rocky Linux AMI doesn't work on `t3a.nano` any longer, the instance is stuck in initializing and it's not possible to SSH to it

Additionally, this PR does some bookkeeping work:

- Add an entry for setting `cri-tools` version for a new Kubernetes version on Flatcar
- Update the `Update images` template with the latest changes

**Which issue(s) this PR fixes**:
xref #3205 #3206

**What type of PR is this?**

/kind bug
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KubeOne now runs `kubeadm upgrade apply` without `--certificate-renewal=true` and `--yes` flags. This change should not have any effect to the upgrade process, but if you discover any issue, please create a new issue in the KubeOne repository
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @xrstf 