### PR TITLE
Fix local helm releases deletion issue

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -29,6 +29,7 @@ import (
 
 	"k8c.io/kubeone/pkg/addons"
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+	helm "k8c.io/kubeone/pkg/localhelm"
 	"k8c.io/kubeone/pkg/semverutil"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -695,6 +696,13 @@ func ValidateHelmReleases(helmReleases []kubeoneapi.HelmRelease, fldPath *field.
 
 		if hr.Namespace == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), hr.Namespace))
+		}
+
+		if hr.RepoURL == "" {
+			_, err := helm.GetChartNameFromChartYAML(hr.Chart)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("chart"), hr.Chart, fmt.Sprintf("invalid local chart: %v", err)))
+			}
 		}
 
 		for idx, helmValues := range hr.Values {


### PR DESCRIPTION
**What this PR does / why we need it**:

`releasesFilterFn` is used to filter out the helm releases that will be uninstalled. When using local helm charts, the helm releases can be deleted without any releases after applying `kubeone apply` again because we are comparing the Chart Name with the path of the Chart (`HelmRelease.Chart` is considered a chart path for local usage).

This PR will allow kubeone to correctly read the chart name for local and remote helm charts!  

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3211

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix local helm chart releases deletion issue
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
