### PR TITLE
replace generate-internal-groups with newer kube-codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -36,7 +36,7 @@ export GOFLAGS=-mod=vendor
 # * the external types dir
 # * group and versions to generate code for
 cd $(dirname ${BASH_SOURCE})/..
-bash vendor/k8s.io/code-generator/generate-internal-groups.sh \
+bash vendor/k8s.io/code-generator/kube_codegen.sh \
   "deepcopy,conversion,defaulter" "" ./pkg/apis ./pkg/apis \
   "kubeone:v1beta2,v1beta3" \
   --go-header-file hack/boilerplate/boilerplate.generatego.txt


### PR DESCRIPTION
**-- Just putting this already here as draft, so I don't forget it in the future --**

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
Allows for using `make make update-codegen` without having your code inside GOPATH, which is in line with Go development standards. In addition resolves "unsupported type" warnings like this one 

```txt
W0619 10:30:57.813447   34549 parse.go:863] Making unsupported type entry "T" for: &types.TypeParam{check:(*types.Checker)(nil), id:0x1, obj:(*types.TypeName)(0xc00fed58b0), index:0, bound:(*types.Named)(0xc0000221c0)}
Generating defaulters
```

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

Ran `make update-codegen` afterwards to ensure that there are no changes in the generated code.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
