### PR TITLE
Change order of ensureCABundleConfigMap task

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -260,6 +260,12 @@ func WithResources(t Tasks) Tasks {
 				Predicate:   func(s *state.State) bool { return s.Cluster.CloudProvider.SecretProviderClassName == "" },
 			},
 			{
+				Fn:          ensureCABundleConfigMap,
+				Operation:   "ensuring caBundle configMap",
+				Description: "ensure caBundle configMap",
+				Predicate:   func(s *state.State) bool { return s.Cluster.CABundle != "" },
+			},
+			{
 				Fn:          addons.Ensure,
 				Operation:   "applying addons",
 				Description: "ensure embedded addons",
@@ -273,12 +279,6 @@ func WithResources(t Tasks) Tasks {
 			{
 				Fn:        localhelm.Deploy,
 				Operation: "releasing core helm charts",
-			},
-			{
-				Fn:          ensureCABundleConfigMap,
-				Operation:   "ensuring caBundle configMap",
-				Description: "ensure caBundle configMap",
-				Predicate:   func(s *state.State) bool { return s.Cluster.CABundle != "" },
 			},
 			{
 				Fn:          externalccm.Ensure,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This PR change the order of `ensureCABundleConfigMap` task before start installing add-ons. Loading the CA bundle before any addon installations, resolving issues with untrusted  TLS connections in environments with self-signed certifications.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3238

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Load the CA bundle before any addon installations to resolve issues with untrusted  TLS connections in environments with self-signed certifications.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
