### PR TITLE
Refactor the upgrade process to stop using config on upgrade

### DIFF
--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -66,7 +66,7 @@ var (
 	`)
 
 	kubeadmUpgradeScriptTemplate = heredoc.Doc(`
-		echo yes | sudo {{ .KUBEADM_UPGRADE }}{{ if .LEADER }} --config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml{{ end }}
+		sudo {{ .KUBEADM_UPGRADE }}
 		sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;
 	`)
 

--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -280,7 +280,7 @@ func TestKubeadmUpgrade(t *testing.T) {
 			name: "leader",
 			args: args{
 				workdir:    "some",
-				kubeadmCmd: "kubeadm upgrade apply v1.1.1",
+				kubeadmCmd: "kubeadm upgrade apply --yes v1.1.1",
 				leader:     true,
 			},
 		},

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
@@ -1,4 +1,4 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-echo yes | sudo kubeadm upgrade apply v1.1.1 --config=some/cfg/master_0.yaml
+sudo kubeadm upgrade apply --yes v1.1.1
 sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-v1beta2.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-v1beta2.golden
@@ -1,4 +1,4 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-echo yes | sudo kubeadm upgrade node
+sudo kubeadm upgrade node
 sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;

--- a/pkg/tasks/kubeadm_upgrade.go
+++ b/pkg/tasks/kubeadm_upgrade.go
@@ -24,10 +24,7 @@ import (
 )
 
 func upgradeLeaderControlPlane(s *state.State, nodeID int) error {
-	kadm, err := kubeadm.New(s.Cluster.Versions.Kubernetes)
-	if err != nil {
-		return err
-	}
+	kadm := kubeadm.New(s.Cluster.Versions.Kubernetes)
 
 	cmd, err := scripts.KubeadmUpgrade(kadm.UpgradeLeaderCommand(), s.WorkDir, true, nodeID)
 	if err != nil {
@@ -40,10 +37,7 @@ func upgradeLeaderControlPlane(s *state.State, nodeID int) error {
 }
 
 func upgradeFollowerControlPlane(s *state.State, nodeID int) error {
-	kadm, err := kubeadm.New(s.Cluster.Versions.Kubernetes)
-	if err != nil {
-		return err
-	}
+	kadm := kubeadm.New(s.Cluster.Versions.Kubernetes)
 
 	cmd, err := scripts.KubeadmUpgrade(kadm.UpgradeFollowerCommand(), s.WorkDir, false, nodeID)
 	if err != nil {
@@ -56,12 +50,9 @@ func upgradeFollowerControlPlane(s *state.State, nodeID int) error {
 }
 
 func upgradeStaticWorker(s *state.State) error {
-	kadm, err := kubeadm.New(s.Cluster.Versions.Kubernetes)
-	if err != nil {
-		return err
-	}
+	kadm := kubeadm.New(s.Cluster.Versions.Kubernetes)
 
-	_, _, err = s.Runner.Run(`sudo `+kadm.UpgradeStaticWorkerCommand(), nil)
+	_, _, err := s.Runner.Run(`sudo `+kadm.UpgradeStaticWorkerCommand(), nil)
 
 	return fail.SSH(err, "running kubeadm upgrade on static worker")
 }

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -324,6 +324,7 @@ func WithUpgrade(t Tasks) Tasks {
 		append(kubernetesConfigFiles()...). // this, in the upgrade process where config rails are handled
 		append(Tasks{
 			{Fn: kubeconfig.BuildKubernetesClientset, Operation: "building kubernetes clientset"},
+			{Fn: uploadKubeadmToConfigMaps, Operation: "updating kubeadm configmaps"},
 			{Fn: runPreflightChecks, Operation: "checking preflight safetynet", Retries: 1},
 			{Fn: upgradeLeader, Operation: "upgrading leader control plane"},
 			{Fn: upgradeFollower, Operation: "upgrading follower control plane"},

--- a/pkg/templates/kubeadm/kubeadm.go
+++ b/pkg/templates/kubeadm/kubeadm.go
@@ -25,16 +25,24 @@ const (
 	kubeadmUpgradeNodeCommand = "kubeadm upgrade node"
 )
 
+type Config struct {
+	FullConfiguration      string
+	ClusterConfiguration   string
+	JoinConfiguration      string
+	KubeletConfiguration   string
+	KubeProxyConfiguration string
+}
+
 // Kubedm interface abstract differences between different kubeadm versions
 type Kubedm interface {
-	Config(s *state.State, instance kubeoneapi.HostConfig) (string, error)
-	ConfigWorker(s *state.State, instance kubeoneapi.HostConfig) (string, error)
+	Config(s *state.State, instance kubeoneapi.HostConfig) (*Config, error)
+	ConfigWorker(s *state.State, instance kubeoneapi.HostConfig) (*Config, error)
 	UpgradeLeaderCommand() string
 	UpgradeFollowerCommand() string
 	UpgradeStaticWorkerCommand() string
 }
 
 // New constructor
-func New(ver string) (Kubedm, error) {
-	return &kubeadmv1beta3{version: ver}, nil
+func New(ver string) Kubedm {
+	return &kubeadmv1beta3{version: ver}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the cluster upgrade process to adhere to recommendations from [the upstream community](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/). With that, using the `--config` flag along with the `kubeadm upgrade apply` command:

- is strictly discouraged because of possible side effects affecting the cluster stability
- is deprecated and partially removed as of Kubernetes 1.30 and will be completely removed with Kubernetes 1.31

`kubeadm` writes configuration to different ConfigMaps in the `kube-system` namespace, mainly `kubeadm-config`, `kubelet-config`, and `kube-proxy`. The recommended workflow is to update the needed ConfigMap and then run the appropriate `kubeadm` command as described in the document.

Upon initiating the upgrade process, KubeOne will build the Kubernetes clientset, generate new Kubeadm configs and update all the ConfigMaps used by Kubeadm. Kubeadm will reconfigure the cluster as needed based on what's changed (if anything is changed at all).

This however means that some options are now immutable, but most of them should not be user-facing, and I don't think we ever supported changing these options:

- Anything in `InitConfiguration` and `JoinConfiguration` structs. There is `.LocalAPIEndpoint.AdvertiseAddress`, but I don't think we support changing the IP address of existing control plane or worker nodes

**Which issue(s) this PR fixes**:
xref #3205 

**What type of PR is this?**

/kind feature
/kind design

**Special notes for your reviewer**:

In the future, we should refactor the force upgrade process to work in a reconciliation manner, i.e. to avoid running the full upgrade process, but only compare what's changed and regenerate only those affected manifests.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Refactor the cluster upgrade process to adhere to the [Kubernetes recommendations](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) by updating ConfigMaps used by Kubeadm instead of providing the full config to Kubeadm itself. This change should not have any effect to cluster upgrades, but if you encounter any issue, please create an issue in our repository
```

**Documentation**:
```documentation
NONE
```