### PR TITLE
Use the same bastion_type on AWS as worker_type

### DIFF
--- a/test/e2e/testdata/aws_rhel.tfvars
+++ b/test/e2e/testdata/aws_rhel.tfvars
@@ -4,7 +4,6 @@ os                           = "rhel"
 
 # Use smaller instances in Ireland for E2E tests
 aws_region                = "eu-west-1"
-control_plane_type        = "t3.medium"
+control_plane_type        = "t3a.medium"
 control_plane_volume_size = 50
-worker_type               = "t3.medium"
-bastion_type              = "t3.micro"
+worker_type               = "t3a.medium"

--- a/test/e2e/testdata/aws_small.tfvars
+++ b/test/e2e/testdata/aws_small.tfvars
@@ -7,4 +7,3 @@ control_plane_type        = "t3a.small"
 control_plane_volume_size = 25
 worker_type               = "t3a.small"
 worker_volume_size        = 25
-bastion_type              = "t3a.nano"

--- a/test/e2e/testdata/aws_stable_medium.tfvars
+++ b/test/e2e/testdata/aws_stable_medium.tfvars
@@ -6,4 +6,3 @@ aws_region                = "eu-west-1"
 control_plane_type        = "t3a.medium"
 control_plane_volume_size = 25
 worker_type               = "t3a.medium"
-bastion_type              = "t3a.nano"

--- a/test/e2e/testdata/aws_stable_small.tfvars
+++ b/test/e2e/testdata/aws_stable_small.tfvars
@@ -6,4 +6,3 @@ aws_region                = "eu-west-1"
 control_plane_type        = "t3a.small"
 control_plane_volume_size = 25
 worker_type               = "t3a.small"
-bastion_type              = "t3a.nano"


### PR DESCRIPTION
**What this PR does / why we need it**:
Port of https://github.com/kubermatic/kubeone/pull/3264 to the main.

Removes the customization of AWS bastion VM types.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind flake

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
