### PR TITLE
Fix openstack CCM addon

### DIFF
--- a/addons/ccm-openstack/Kustomization
+++ b/addons/ccm-openstack/Kustomization
@@ -9,6 +9,20 @@ patches:
       namespace: kube-system
       name: openstack-cloud-controller-manager
     patch: |-
+      - op: add
+        path: "/spec/template/metadata/labels/k8s-app"
+        value: "openstack-cloud-controller-manager"
+      - op: add
+        path: "/spec/template/metadata/annotations"
+        value:
+          "kubeone.k8c.io/cabundle-hash": '{{.Config.CABundle | sha256sum}}'
+          "kubeone.k8c.io/cloudconfig-hash": '{{.Config.CloudProvider.CloudConfig | sha256sum}}'
       - op: replace
         path: "/spec/template/spec/containers/0/env/0/value"
         value: "/etc/config/cloud-config"
+      - op: replace
+        path: "/spec/template/spec/containers/0/image"
+        value: '{{ .InternalImages.Get "OpenstackCCM" }}'
+      - op: replace
+        path: "/spec/template/spec/containers/0/env/1/value"
+        value: '{{ default "kubernetes" .CCMClusterName }}'

--- a/addons/ccm-openstack/README.md
+++ b/addons/ccm-openstack/README.md
@@ -16,4 +16,4 @@ helm template openstack-ccm cpo/openstack-cloud-controller-manager \
 kubectl kustomize --output ccm-openstack.yaml .
 ```
 
-**Note:** some manual adjustments are required (e.g. CA certs env/volumes), images...
+**Note:** some manual adjustments are required (e.g. CA certs env/volumes)

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -149,13 +149,14 @@ spec:
   template:
     metadata:
       annotations:
-        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
-        "kubeone.k8c.io/cloudconfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
+        kubeone.k8c.io/cabundle-hash: '{{.Config.CABundle | sha256sum}}'
+        kubeone.k8c.io/cloudconfig-hash: '{{.Config.CloudProvider.CloudConfig | sha256sum}}'
       labels:
         app: openstack-cloud-controller-manager
         chart: openstack-cloud-controller-manager-2.30.1
         component: controllermanager
         heritage: Helm
+        k8s-app: openstack-cloud-controller-manager
         release: openstack-ccm
     spec:
       containers:
@@ -175,8 +176,8 @@ spec:
         - name: CLOUD_CONFIG
           value: /etc/config/cloud-config
         - name: CLUSTER_NAME
-          value: {{ default "kubernetes" .CCMClusterName }}
-        image: {{ .InternalImages.Get "OpenstackCCM" }}
+          value: '{{ default "kubernetes" .CCMClusterName }}'
+        image: '{{ .InternalImages.Get "OpenstackCCM" }}'
         name: openstack-cloud-controller-manager
         volumeMounts:
         - mountPath: /etc/config


### PR DESCRIPTION
**What this PR does / why we need it**:
on cluster upgrade we check if openstack ccm is present and kubeone want to find it using k8s-app label selector.

* add proper label that kubeone expects CCM to have in order to locate it
* automate some routinte like image and annotations

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix openstack CCM addon
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
