### PR TITLE
Fix snapshot-webhook admitting non-supported objects and add default VolumeSnapshotClass for all supported providers

### DIFF
--- a/addons/csi-external-snapshotter/webhook.yaml
+++ b/addons/csi-external-snapshotter/webhook.yaml
@@ -21,9 +21,9 @@ webhooks:
 - name: "validation-webhook.snapshot.storage.k8s.io"
   rules:
   - apiGroups:   ["snapshot.storage.k8s.io"]
-    apiVersions: ["v1", "v1beta1"]
+    apiVersions: ["v1"]
     operations:  ["CREATE", "UPDATE"]
-    resources:   ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
+    resources:   ["volumesnapshotclasses"]
     scope:       "*"
   clientConfig:
     service:
@@ -32,11 +32,10 @@ webhooks:
       path: "/volumesnapshot"
     caBundle: |
 {{ .Certificates.KubernetesCA | b64enc | indent 6 }}
-  admissionReviewVersions: ["v1", "v1beta1"]
+  admissionReviewVersions: ["v1"]
   sideEffects: None
   failurePolicy: Fail
   timeoutSeconds: 2
-
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -32,11 +32,20 @@ kind: VolumeSnapshotClass
 apiVersion: snapshot.storage.k8s.io/v1
 metadata:
   name: csi-azuredisk-vsc
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
 driver: disk.csi.azure.com
 deletionPolicy: Delete
 parameters:
   incremental: "true"
   tags:
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-azurefile-vsc
+driver: file.csi.azure.com
+deletionPolicy: Delete
 {{ end }}
 ---
 apiVersion: storage.k8s.io/v1
@@ -69,6 +78,15 @@ provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
 volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: ebs-csi
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: ebs.csi.aws.com
+deletionPolicy: Delete
 ---
 {{ end }}
 apiVersion: storage.k8s.io/v1
@@ -217,6 +235,19 @@ parameters:
   isSegmentedIscsiNetwork: {{ default "false" .Params.isSegmentedIscsiNetwork | quote }}
 allowVolumeExpansion: true
 reclaimPolicy: Delete
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: ntnx-csi
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: csi.nutanix.com
+parameters:
+  storageType: NutanixVolumes
+  csi.storage.k8s.io/snapshotter-secret-name: ntnx-secret
+  csi.storage.k8s.io/snapshotter-secret-namespace: kube-system
+deletionPolicy: Delete
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "hetzner" }}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add default VolumeSnapshotClass for all supported providers as part of the `default-storage-class` addon. Some supported providers already had VolumeSnapshotClass, but not all of them
- Fix snapshot-webhook admitting non-supported objects (`VolumeSnapshots` and `VolumeSnapshotContents`). This prevented new snapshots from creating with the following error:
    ```
    E0626 14:17:54.513681       1 snapshot.go:84] expect resource to be {snapshot.storage.k8s.io v1 volumesnapshotclasses}, but found {snapshot.storage.k8s.io v1 volumesnapshots}
    ```

**What type of PR is this?**

/kind bug
/kind regression

**Special notes for your reviewer**:

I'm working on another PR to add E2E tests for snapshotting volumes.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Add default VolumeSnapshotClass for all supported providers as part of the `default-storage-class` addon
- Fix snapshot-webhook admitting non-supported objects (`VolumeSnapshots` and `VolumeSnapshotContents`). This fixes an issue that caused inability to create new `VolumeSnapshots`
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 