### PR TITLE
VCD: Add bastion host to terraform configs

### DIFF
--- a/examples/terraform/vmware-cloud-director/README.md
+++ b/examples/terraform/vmware-cloud-director/README.md
@@ -58,11 +58,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [vcd_network_routed.network](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/network_routed) | resource |
+| [vcd_nsxv_dnat.rule_ssh_bastion](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/nsxv_dnat) | resource |
 | [vcd_nsxv_firewall_rule.rule_internet](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/nsxv_firewall_rule) | resource |
+| [vcd_nsxv_firewall_rule.rule_ssh_bastion](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/nsxv_firewall_rule) | resource |
 | [vcd_nsxv_snat.rule_internal](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/nsxv_snat) | resource |
 | [vcd_nsxv_snat.rule_internet](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/nsxv_snat) | resource |
 | [vcd_vapp.cluster](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/vapp) | resource |
 | [vcd_vapp_org_network.network](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/vapp_org_network) | resource |
+| [vcd_vapp_vm.bastion](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/vapp_vm) | resource |
 | [vcd_vapp_vm.control_plane](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/resources/vapp_vm) | resource |
 | [vcd_catalog.catalog](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/data-sources/catalog) | data source |
 | [vcd_catalog_vapp_template.vapp_template](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs/data-sources/catalog_vapp_template) | data source |
@@ -74,7 +77,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_insecure"></a> [allow\_insecure](#input\_allow\_insecure) | allow insecure https connection to VMware Cloud Director API | `bool` | `false` | no |
 | <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | Subject alternative names for the API Server signing certificate | `list(string)` | `[]` | no |
+| <a name="input_bastion_host_cpu_cores"></a> [bastion\_host\_cpu\_cores](#input\_bastion\_host\_cpu\_cores) | Number of cores per socket for the bastion host VM | `number` | `1` | no |
+| <a name="input_bastion_host_cpus"></a> [bastion\_host\_cpus](#input\_bastion\_host\_cpus) | Number of CPUs for the bastion host VM | `number` | `1` | no |
 | <a name="input_bastion_host_key"></a> [bastion\_host\_key](#input\_bastion\_host\_key) | Bastion SSH host public key | `string` | `null` | no |
+| <a name="input_bastion_host_memory"></a> [bastion\_host\_memory](#input\_bastion\_host\_memory) | Memory size of the bastion host in MB | `number` | `2048` | no |
+| <a name="input_bastion_host_ssh_port"></a> [bastion\_host\_ssh\_port](#input\_bastion\_host\_ssh\_port) | SSH port to be used for the bastion host | `number` | `22` | no |
 | <a name="input_catalog_name"></a> [catalog\_name](#input\_catalog\_name) | Name of catalog that contains vApp templates | `string` | n/a | yes |
 | <a name="input_cluster_autoscaler_max_replicas"></a> [cluster\_autoscaler\_max\_replicas](#input\_cluster\_autoscaler\_max\_replicas) | maximum number of replicas per MachineDeployment (requires cluster-autoscaler) | `number` | `0` | no |
 | <a name="input_cluster_autoscaler_min_replicas"></a> [cluster\_autoscaler\_min\_replicas](#input\_cluster\_autoscaler\_min\_replicas) | minimum number of replicas per MachineDeployment (requires cluster-autoscaler) | `number` | `0` | no |
@@ -87,6 +94,7 @@ No modules.
 | <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | number of control plane instances | `number` | `3` | no |
 | <a name="input_dhcp_end_address"></a> [dhcp\_end\_address](#input\_dhcp\_end\_address) | Last address for the DHCP IP Pool range | `string` | `"192.168.1.50"` | no |
 | <a name="input_dhcp_start_address"></a> [dhcp\_start\_address](#input\_dhcp\_start\_address) | Starting address for the DHCP IP Pool range | `string` | `"192.168.1.2"` | no |
+| <a name="input_enable_bastion_host"></a> [enable\_bastion\_host](#input\_enable\_bastion\_host) | Enable bastion host | `bool` | `false` | no |
 | <a name="input_external_network_ip"></a> [external\_network\_ip](#input\_external\_network\_ip) | IP address to which source addresses (the virtual machines) on outbound packets are translated to when they send traffic to the external network.<br>Defaults to default external network IP for the edge gateway. | `string` | `""` | no |
 | <a name="input_external_network_name"></a> [external\_network\_name](#input\_external\_network\_name) | Name of the external network to be used to send traffic to the external networks. Defaults to edge gateway's default external network. | `string` | `""` | no |
 | <a name="input_gateway_ip"></a> [gateway\_ip](#input\_gateway\_ip) | Gateway IP for the routed network | `string` | `"192.168.1.1"` | no |
@@ -121,3 +129,4 @@ No modules.
 | <a name="output_kubeone_api"></a> [kubeone\_api](#output\_kubeone\_api) | kube-apiserver LB endpoint |
 | <a name="output_kubeone_hosts"></a> [kubeone\_hosts](#output\_kubeone\_hosts) | Control plane endpoints to SSH to |
 | <a name="output_kubeone_workers"></a> [kubeone\_workers](#output\_kubeone\_workers) | Workers definitions, that will be transformed into MachineDeployment object |
+| <a name="output_ssh_commands"></a> [ssh\_commands](#output\_ssh\_commands) | n/a |

--- a/examples/terraform/vmware-cloud-director/output.tf
+++ b/examples/terraform/vmware-cloud-director/output.tf
@@ -23,6 +23,10 @@ output "kubeone_api" {
   }
 }
 
+output "ssh_commands" {
+  value = var.enable_bastion_host ? formatlist("ssh -J ${var.ssh_username}@${local.external_network_ip}:${var.bastion_host_ssh_port} ${var.ssh_username}@%s", vcd_vapp_vm.control_plane.*.network.0.ip) : formatlist("ssh ${var.ssh_username}@%s", vcd_vapp_vm.control_plane.*.network.0.ip)
+}
+
 output "kubeone_hosts" {
   description = "Control plane endpoints to SSH to"
 
@@ -40,6 +44,9 @@ output "kubeone_hosts" {
       storage_profile      = var.worker_disk_storage_profile
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      bastion              = var.enable_bastion_host ? local.external_network_ip : null
+      bastion_port         = var.enable_bastion_host ? var.bastion_host_ssh_port : null
+      bastion_user         = var.enable_bastion_host ? var.ssh_username : null
     }
   }
 }

--- a/examples/terraform/vmware-cloud-director/variables.tf
+++ b/examples/terraform/vmware-cloud-director/variables.tf
@@ -299,3 +299,33 @@ Name of operating system profile for MachineDeployments, only applicable if oper
 If not specified, the default value will be added by machine-controller addon.
 EOF
 }
+
+variable "enable_bastion_host" {
+  description = "Enable bastion host"
+  default     = false
+  type        = bool
+}
+
+variable "bastion_host_memory" {
+  description = "Memory size of the bastion host in MB"
+  default     = 2048
+  type        = number
+}
+
+variable "bastion_host_cpus" {
+  description = "Number of CPUs for the bastion host VM"
+  default     = 1
+  type        = number
+}
+
+variable "bastion_host_cpu_cores" {
+  description = "Number of cores per socket for the bastion host VM"
+  default     = 1
+  type        = number
+}
+
+variable "bastion_host_ssh_port" {
+  description = "SSH port to be used for the bastion host"
+  default     = 22
+  type        = number
+}

--- a/test/e2e/testdata/vmware-cloud-director.tfvars
+++ b/test/e2e/testdata/vmware-cloud-director.tfvars
@@ -1,0 +1,10 @@
+# TODO: These values are for demonstration purposes only and should later be used when E2E tests for VMware Cloud Director are implemented.
+catalog_name  = "kubermatic"
+template_name = "machine-controller-ubuntu"
+network_dns_server_1 = "8.8.8.8"
+network_dns_server_2 = "8.8.4.4"
+gateway_ip         = "192.168.2.1"
+dhcp_start_address = "192.168.2.2"
+dhcp_end_address   = "192.168.2.50"
+worker_disk_storage_profile        = "Intermediate"
+control_plane_disk_storage_profile = "Intermediate"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This PR adds a bastion host for the VCD terraform provider. 

Currently, we have a limitation "that there is only 1 public IP in our VDC and that cannot be used for e2e tests since it's attached to the edge gateway" as stated in https://github.com/kubermatic/kubeone/issues/2056. We have a single edge gateway that is shared within our organization on VCD. Hence, using this public IP to further expose resources like bastion VMs, kubeapi server, etc., using NAT is not ideal and can result in conflicts. 

With that said, I'm not aware of the current state of our VCD infra as reportedly NSX-T has been enabled for our organization there. Having NSX-T should fix the limitation of using edge gateway's public IP and there should be some pool of public IPs that we can then use. Anyways, due to a lack of knowledge, I'll leave this up to the KubeOne maintainers, or whoever ends up working on this ticket to figure this out.

This should unblock KubeOne maintainers from continuing with https://github.com/kubermatic/kubeone/issues/3228, https://github.com/kubermatic/kubeone/issues/2056, and https://github.com/kubermatic/kubeone/issues/2057, etc., without being dependent on me.

I've also added a [sample](https://github.com/kubermatic/kubeone/blob/bc7e9290a5866493b0dbba5efc9046dc4a28adef/test/e2e/testdata/vmware-cloud-director.tfvars) `tfvars` file that documents the values that can be used for this provider and can be later used in the E2E tests as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VCD: Add bastion host support to terraform configs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
