### PR TITLE
Don't downgrade GCP CCM for v1.27 clusters

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -359,7 +359,7 @@ func optionalResources() map[Resource]map[string]string {
 
 		// GCP CCM
 		GCPCCM: {
-			"1.27.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v27.1.6",
+			"1.27.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v28.2.1",
 			"1.28.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v28.2.1",
 			"1.29.x":    "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v29.0.0",
 			">= 1.30.0": "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v30.0.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeOne 1.8.0 has used GCP CCM v28.2.1 for all (supported) Kubernetes versions including v1.27. We changed this with #3232 so that we deploy GCP CCM version corresponding to the Kubernetes version.

However, this means that KubeOne 1.8.1 will downgrade the GCP CCM to an older version (from v28.2.1 to v27.1.6) for Kubernetes 1.27 clusters. This can cause regressions, especially as GCP CCM v28.2.1 has more features and controllers than v27.1.6.

To avoid any risks associated with this, this PR proposes that we continue using GCP CCP v28.2.1 for Kubernetes v1.27 clusters as we were doing in KubeOne 1.8.0.

**What type of PR is this?**
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 