### PR TITLE
Remove release date for 1.8.1

### DIFF
--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -1,4 +1,4 @@
-# [v1.8.1](https://github.com/kubermatic/kubeone/releases/tag/v1.8.1) - 2024-06-28
+# [v1.8.1](https://github.com/kubermatic/kubeone/releases/tag/v1.8.1) - TBD
 
 ## Changelog since v1.8.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We discovered some regression in 1.8.1 that we would like to investigate before proceeding with the release. Because of that, this PR removes the release date from the changelog. It'll be re-added once we have a new release date for 1.8.1.

**Which issue(s) this PR fixes**:
xref #3285 

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 