### PR TITLE
Remove centos7 e2e tests

### DIFF
--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -29,29 +29,6 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -133,31 +110,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -271,29 +223,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -328,29 +257,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -455,29 +361,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -512,31 +395,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -647,31 +505,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -730,29 +563,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_28_7
       env:
       - name: PROVIDER
         value: aws
@@ -849,31 +659,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -987,29 +772,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -1044,29 +806,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -1171,29 +910,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -1228,31 +944,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -1363,31 +1054,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -1446,29 +1112,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_29_2
       env:
       - name: PROVIDER
         value: aws
@@ -1565,31 +1208,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -1703,29 +1321,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -1760,29 +1355,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -1887,29 +1459,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -1944,31 +1493,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -2079,31 +1603,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -2162,29 +1661,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_30_1
       env:
       - name: PROVIDER
         value: aws
@@ -2281,31 +1757,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -2419,29 +1870,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -2476,29 +1904,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -2603,29 +2008,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -2660,31 +2042,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -2795,31 +2152,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -2856,31 +2188,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_27_11
-      env:
-      - name: PROVIDER
-        value: azure
       - name: TEST_TIMEOUT
         value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -3019,31 +2326,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -3156,36 +2438,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -3384,36 +2636,6 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: aws
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -3517,36 +2739,6 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -3685,36 +2877,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -3756,36 +2918,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -3925,36 +3057,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: hetzner
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -3998,36 +3100,6 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -4165,36 +3237,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -4263,36 +3305,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: aws
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
       env:
       - name: PROVIDER
         value: aws
@@ -4435,36 +3447,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -4586,36 +3568,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -4657,36 +3609,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -4826,36 +3748,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: hetzner
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -4899,36 +3791,6 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -5066,36 +3928,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -5164,36 +3996,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: aws
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
       env:
       - name: PROVIDER
         value: aws
@@ -5336,36 +4138,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -5487,36 +4259,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -5558,36 +4300,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -5727,36 +4439,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: hetzner
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -5800,36 +4482,6 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -5967,36 +4619,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -6060,29 +4682,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdExternalV1_27_11
       env:
       - name: PROVIDER
         value: aws
@@ -6178,31 +4777,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -6316,29 +4890,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-calico-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -6373,29 +4924,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -6500,29 +5028,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-calico-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -6557,31 +5062,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -6692,31 +5172,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -6775,29 +5230,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdExternalV1_28_7
       env:
       - name: PROVIDER
         value: aws
@@ -6893,31 +5325,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -7031,29 +5438,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-calico-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -7088,29 +5472,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -7215,29 +5576,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-calico-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -7272,31 +5610,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -7407,31 +5720,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -7490,29 +5778,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdExternalV1_29_2
       env:
       - name: PROVIDER
         value: aws
@@ -7608,31 +5873,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -7746,29 +5986,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-calico-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -7803,29 +6020,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -7930,29 +6124,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-calico-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -7987,31 +6158,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -8122,31 +6268,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -8205,29 +6326,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdExternalV1_30_1
       env:
       - name: PROVIDER
         value: aws
@@ -8323,31 +6421,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -8461,29 +6534,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-calico-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -8518,29 +6568,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -8645,29 +6672,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-calico-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -8702,31 +6706,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -8837,31 +6816,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -8920,29 +6874,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdExternalV1_27_11
       env:
       - name: PROVIDER
         value: aws
@@ -9038,31 +6969,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -9176,29 +7082,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-cilium-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -9233,29 +7116,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -9360,29 +7220,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-cilium-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -9417,31 +7254,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -9552,31 +7364,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-external-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdExternalV1_27_11
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-containerd-external-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -9635,29 +7422,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdExternalV1_28_7
       env:
       - name: PROVIDER
         value: aws
@@ -9753,31 +7517,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -9891,29 +7630,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-cilium-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -9948,29 +7664,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -10075,29 +7768,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-cilium-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -10132,31 +7802,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -10267,31 +7912,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-external-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdExternalV1_28_7
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-containerd-external-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -10350,29 +7970,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdExternalV1_29_2
       env:
       - name: PROVIDER
         value: aws
@@ -10468,31 +8065,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -10606,29 +8178,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-cilium-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -10663,29 +8212,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -10790,29 +8316,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-cilium-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -10847,31 +8350,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -10982,31 +8460,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-external-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdExternalV1_29_2
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-containerd-external-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -11065,29 +8518,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdExternalV1_30_1
       env:
       - name: PROVIDER
         value: aws
@@ -11183,31 +8613,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -11321,29 +8726,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-cilium-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -11378,29 +8760,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -11505,29 +8864,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-cilium-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -11562,31 +8898,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -11697,31 +9008,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-external-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdExternalV1_30_1
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-containerd-external-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -11785,36 +9071,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: aws
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
       env:
       - name: PROVIDER
         value: aws
@@ -11957,36 +9213,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -12108,36 +9334,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -12179,36 +9375,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -12348,36 +9514,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: hetzner
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -12421,36 +9557,6 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -12588,36 +9694,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-cilium-containerd-external-from-v1.27.11-to-v1.28.7
   optional: false
   path_alias: k8c.io/kubeone
@@ -12686,36 +9762,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: aws
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
       env:
       - name: PROVIDER
         value: aws
@@ -12858,36 +9904,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -13009,36 +10025,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -13080,36 +10066,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -13249,36 +10205,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: hetzner
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -13322,36 +10248,6 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -13489,36 +10385,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
-      env:
-      - name: PROVIDER
-        value: vsphere
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-cilium-containerd-external-from-v1.28.7-to-v1.29.2
   optional: false
   path_alias: k8c.io/kubeone
@@ -13587,36 +10453,6 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestAwsAmznStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: aws
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
       env:
       - name: PROVIDER
         value: aws
@@ -13759,36 +10595,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -13910,36 +10716,6 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -13981,36 +10757,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -14150,36 +10896,6 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: hetzner
-      - name: TEST_TIMEOUT
-        value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
   optional: false
   path_alias: k8c.io/kubeone
@@ -14223,36 +10939,6 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""
@@ -14371,36 +11057,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.8
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-cilium-containerd-external-from-v1.29.2-to-v1.30.1
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
-      env:
-      - name: PROVIDER
-        value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
@@ -14598,31 +11254,6 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.27.11
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_27_11
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.27.11
   optional: false
   path_alias: k8c.io/kubeone
@@ -14735,31 +11366,6 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.28.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_28_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
       image: quay.io/kubermatic/build:go-1.22-node-20-6
       imagePullPolicy: Always
       name: ""

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -64,49 +64,6 @@ var (
 				outputDir:  "/logs/artifacts/logs",
 			},
 		},
-		"aws_centos": {
-			name: "aws_centos",
-			environ: map[string]string{
-				"PROVIDER": "aws",
-			},
-			labels: map[string]string{
-				"preset-goproxy":         "true",
-				"preset-aws-e2e-kubeone": "true",
-			},
-			terraform: terraformBin{
-				path:    "../../examples/terraform/aws",
-				varFile: "testdata/aws_medium.tfvars",
-				vars: []string{
-					"os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"aws_centos_stable": {
-			name: "aws_centos_stable",
-			environ: map[string]string{
-				"PROVIDER":     "aws",
-				"TEST_TIMEOUT": "90m",
-			},
-			labels: map[string]string{
-				"preset-goproxy":         "true",
-				"preset-aws-e2e-kubeone": "true",
-			},
-			terraform: terraformBin{
-				path:    "../../../kubeone-stable/examples/terraform/aws",
-				varFile: "testdata/aws_stable_medium.tfvars",
-				vars: []string{
-					"os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
 		"aws_rhel": {
 			name: "aws_rhel",
 			environ: map[string]string{
@@ -376,48 +333,6 @@ var (
 				outputDir:  "/logs/artifacts/logs",
 			},
 		},
-		"azure_centos": {
-			name: "azure_centos",
-			labels: map[string]string{
-				"preset-goproxy": "true",
-				"preset-azure":   "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "azure",
-				"TEST_TIMEOUT": "120m",
-			},
-			terraform: terraformBin{
-				path: "../../examples/terraform/azure",
-				vars: []string{
-					"os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"azure_centos_stable": {
-			name: "azure_centos_stable",
-			labels: map[string]string{
-				"preset-goproxy": "true",
-				"preset-azure":   "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "azure",
-				"TEST_TIMEOUT": "120m",
-			},
-			terraform: terraformBin{
-				path: "../../../kubeone-stable/examples/terraform/azure",
-				vars: []string{
-					"os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
 		"azure_flatcar": {
 			name: "azure_flatcar",
 			labels: map[string]string{
@@ -589,50 +504,6 @@ var (
 				outputDir:  "/logs/artifacts/logs",
 			},
 		},
-		"digitalocean_centos": {
-			name: "digitalocean_centos",
-			labels: map[string]string{
-				"preset-goproxy":      "true",
-				"preset-digitalocean": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER": "digitalocean",
-			},
-			terraform: terraformBin{
-				path: "../../examples/terraform/digitalocean",
-				vars: []string{
-					"disable_kubeapi_loadbalancer=true",
-					"os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"digitalocean_centos_stable": {
-			name: "digitalocean_centos_stable",
-			labels: map[string]string{
-				"preset-goproxy":      "true",
-				"preset-digitalocean": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "digitalocean",
-				"TEST_TIMEOUT": "90m",
-			},
-			terraform: terraformBin{
-				path: "../../../kubeone-stable/examples/terraform/digitalocean",
-				vars: []string{
-					"disable_kubeapi_loadbalancer=true",
-					"control_plane_droplet_image=centos-7-x64",
-					"worker_os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
 		"digitalocean_rockylinux": {
 			name: "digitalocean_rockylinux",
 			labels: map[string]string{
@@ -709,50 +580,6 @@ var (
 				vars: []string{
 					"control_plane_operating_system=ubuntu_20_04",
 					"lb_operating_system=ubuntu_20_04",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"equinixmetal_centos": {
-			name: "equinixmetal_centos",
-			labels: map[string]string{
-				"preset-goproxy":       "true",
-				"preset-equinix-metal": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER": "equinixmetal",
-			},
-			terraform: terraformBin{
-				path: "../../examples/terraform/equinixmetal",
-				vars: []string{
-					"os=centos",
-					"lb_operating_system=centos_7",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"equinixmetal_centos_stable": {
-			name: "equinixmetal_centos_stable",
-			labels: map[string]string{
-				"preset-goproxy":       "true",
-				"preset-equinix-metal": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "equinixmetal",
-				"TEST_TIMEOUT": "90m",
-			},
-			terraform: terraformBin{
-				path: "../../../kubeone-stable/examples/terraform/equinixmetal",
-				vars: []string{
-					"control_plane_operating_system=centos_7",
-					"lb_operating_system=centos_7",
-					"worker_os=centos",
 				},
 			},
 			protokol: protokolBin{
@@ -929,50 +756,6 @@ var (
 				outputDir:  "/logs/artifacts/logs",
 			},
 		},
-		"hetzner_centos": {
-			name: "hetzner_centos",
-			labels: map[string]string{
-				"preset-goproxy": "true",
-				"preset-hetzner": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER": "hetzner",
-			},
-			terraform: terraformBin{
-				path: "../../examples/terraform/hetzner",
-				vars: []string{
-					"disable_kubeapi_loadbalancer=true",
-					"os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"hetzner_centos_stable": {
-			name: "hetzner_centos_stable",
-			labels: map[string]string{
-				"preset-goproxy": "true",
-				"preset-hetzner": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "hetzner",
-				"TEST_TIMEOUT": "90m",
-			},
-			terraform: terraformBin{
-				path: "../../../kubeone-stable/examples/terraform/hetzner",
-				vars: []string{
-					"disable_kubeapi_loadbalancer=true",
-					"image=centos-7",
-					"worker_os=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
 		"hetzner_rockylinux": {
 			name: "hetzner_rockylinux",
 			labels: map[string]string{
@@ -1048,44 +831,6 @@ var (
 			terraform: terraformBin{
 				path:    "../../../kubeone-stable/examples/terraform/openstack",
 				varFile: "testdata/openstack_ubuntu.tfvars",
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"openstack_centos": {
-			name: "openstack_centos",
-			labels: map[string]string{
-				"preset-goproxy":   "true",
-				"preset-openstack": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "openstack",
-				"TEST_TIMEOUT": "120m",
-			},
-			terraform: terraformBin{
-				path:    "../../examples/terraform/openstack",
-				varFile: "testdata/openstack_centos.tfvars",
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"openstack_centos_stable": {
-			name: "openstack_centos_stable",
-			labels: map[string]string{
-				"preset-goproxy":   "true",
-				"preset-openstack": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "openstack",
-				"TEST_TIMEOUT": "120m",
-			},
-			terraform: terraformBin{
-				path:    "../../../kubeone-stable/examples/terraform/openstack",
-				varFile: "testdata/openstack_centos.tfvars",
 			},
 			protokol: protokolBin{
 				namespaces: []string{"kube-system"},
@@ -1264,54 +1009,6 @@ var (
 					"template_name=kubeone-ubuntu-22.04",
 					"worker_os=ubuntu",
 					"ssh_username=ubuntu",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"vsphere_centos": {
-			name: "vsphere_centos",
-			labels: map[string]string{
-				"preset-goproxy": "true",
-				"preset-vsphere": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "vsphere",
-				"TEST_TIMEOUT": "120m",
-			},
-			terraform: terraformBin{
-				path:    "../../examples/terraform/vsphere_centos",
-				varFile: "testdata/vsphere.tfvars",
-				vars: []string{
-					"template_name=kkp-centos-7",
-					"worker_os=centos",
-					"ssh_username=centos",
-				},
-			},
-			protokol: protokolBin{
-				namespaces: []string{"kube-system"},
-				outputDir:  "/logs/artifacts/logs",
-			},
-		},
-		"vsphere_centos_stable": {
-			name: "vsphere_centos_stable",
-			labels: map[string]string{
-				"preset-goproxy": "true",
-				"preset-vsphere": "true",
-			},
-			environ: map[string]string{
-				"PROVIDER":     "vsphere",
-				"TEST_TIMEOUT": "120m",
-			},
-			terraform: terraformBin{
-				path:    "../../../kubeone-stable/examples/terraform/vsphere_centos",
-				varFile: "testdata/vsphere.tfvars",
-				vars: []string{
-					"template_name=kkp-centos-7",
-					"worker_os=centos",
-					"ssh_username=centos",
 				},
 			},
 			protokol: protokolBin{

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -19,15 +19,6 @@ func TestAwsAmznInstallContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestAwsDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_default"]
@@ -58,15 +49,6 @@ func TestAwsRhelInstallContainerdExternalV1_27_11(t *testing.T) {
 func TestAwsRockylinuxInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -109,15 +91,6 @@ func TestAzureRockylinuxInstallContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -130,15 +103,6 @@ func TestDigitaloceanDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 func TestDigitaloceanRockylinuxInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -181,15 +145,6 @@ func TestGceDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -202,15 +157,6 @@ func TestHetznerDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 func TestHetznerRockylinuxInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -253,15 +199,6 @@ func TestOpenstackRockylinuxInstallContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultInstallContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -283,15 +220,6 @@ func TestVsphereFlatcarInstallContainerdExternalV1_27_11(t *testing.T) {
 func TestAwsAmznInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -334,15 +262,6 @@ func TestAwsRockylinuxInstallContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -379,15 +298,6 @@ func TestAzureRockylinuxInstallContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -400,15 +310,6 @@ func TestDigitaloceanDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 func TestDigitaloceanRockylinuxInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -451,15 +352,6 @@ func TestGceDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -472,15 +364,6 @@ func TestHetznerDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 func TestHetznerRockylinuxInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -523,15 +406,6 @@ func TestOpenstackRockylinuxInstallContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultInstallContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -553,15 +427,6 @@ func TestVsphereFlatcarInstallContainerdExternalV1_28_7(t *testing.T) {
 func TestAwsAmznInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -604,15 +469,6 @@ func TestAwsRockylinuxInstallContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -649,15 +505,6 @@ func TestAzureRockylinuxInstallContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -670,15 +517,6 @@ func TestDigitaloceanDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 func TestDigitaloceanRockylinuxInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -721,15 +559,6 @@ func TestGceDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -742,15 +571,6 @@ func TestHetznerDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 func TestHetznerRockylinuxInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -793,15 +613,6 @@ func TestOpenstackRockylinuxInstallContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultInstallContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -823,15 +634,6 @@ func TestVsphereFlatcarInstallContainerdExternalV1_29_2(t *testing.T) {
 func TestAwsAmznInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -874,15 +676,6 @@ func TestAwsRockylinuxInstallContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -919,15 +712,6 @@ func TestAzureRockylinuxInstallContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -940,15 +724,6 @@ func TestDigitaloceanDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 func TestDigitaloceanRockylinuxInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -991,15 +766,6 @@ func TestGceDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -1012,15 +778,6 @@ func TestHetznerDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 func TestHetznerRockylinuxInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -1063,15 +820,6 @@ func TestOpenstackRockylinuxInstallContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["install_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultInstallContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -1087,15 +835,6 @@ func TestVsphereFlatcarInstallContainerdExternalV1_30_1(t *testing.T) {
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosInstallContainerdV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["install_containerd"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
 	scenario.Run(ctx, t)
 }
 
@@ -1144,15 +883,6 @@ func TestGceDefaultInstallContainerdV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["install_containerd"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultInstallContainerdV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -1195,15 +925,6 @@ func TestGceDefaultInstallContainerdV1_28_7(t *testing.T) {
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosStableUpgradeContainerdFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
-	scenario := Scenarios["upgrade_containerd"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
 	scenario.Run(ctx, t)
 }
 
@@ -1261,15 +982,6 @@ func TestAwsAmznStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestAwsDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_default_stable"]
@@ -1300,15 +1012,6 @@ func TestAwsRhelStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing
 func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")
@@ -1351,15 +1054,6 @@ func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t 
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default_stable"]
@@ -1372,15 +1066,6 @@ func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_
 func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")
@@ -1423,15 +1108,6 @@ func TestGceDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *test
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default_stable"]
@@ -1444,15 +1120,6 @@ func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *
 func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")
@@ -1495,15 +1162,6 @@ func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *t
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default_stable"]
@@ -1525,15 +1183,6 @@ func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_27_11_ToV1_28_7(t *
 func TestAwsAmznStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7", "v1.29.2")
@@ -1576,15 +1225,6 @@ func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *te
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default_stable"]
@@ -1621,15 +1261,6 @@ func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default_stable"]
@@ -1642,15 +1273,6 @@ func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2
 func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7", "v1.29.2")
@@ -1693,15 +1315,6 @@ func TestGceDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testi
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default_stable"]
@@ -1714,15 +1327,6 @@ func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *t
 func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7", "v1.29.2")
@@ -1765,15 +1369,6 @@ func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *te
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default_stable"]
@@ -1795,15 +1390,6 @@ func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_28_7_ToV1_29_2(t *t
 func TestAwsAmznStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -1846,15 +1432,6 @@ func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *te
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default_stable"]
@@ -1891,15 +1468,6 @@ func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default_stable"]
@@ -1912,15 +1480,6 @@ func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1
 func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -1963,15 +1522,6 @@ func TestGceDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testi
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default_stable"]
@@ -1984,15 +1534,6 @@ func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *t
 func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -2035,15 +1576,6 @@ func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *te
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos_stable"]
-	scenario := Scenarios["upgrade_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default_stable"]
@@ -2065,15 +1597,6 @@ func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_29_2_ToV1_30_1(t *t
 func TestAwsAmznCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -2116,15 +1639,6 @@ func TestAwsRockylinuxCalicoContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -2161,15 +1675,6 @@ func TestAzureRockylinuxCalicoContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -2182,15 +1687,6 @@ func TestDigitaloceanDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 func TestDigitaloceanRockylinuxCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -2233,15 +1729,6 @@ func TestGceDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -2254,15 +1741,6 @@ func TestHetznerDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 func TestHetznerRockylinuxCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -2305,15 +1783,6 @@ func TestOpenstackRockylinuxCalicoContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCalicoContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -2335,15 +1804,6 @@ func TestVsphereFlatcarCalicoContainerdExternalV1_27_11(t *testing.T) {
 func TestAwsAmznCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -2386,15 +1846,6 @@ func TestAwsRockylinuxCalicoContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -2431,15 +1882,6 @@ func TestAzureRockylinuxCalicoContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -2452,15 +1894,6 @@ func TestDigitaloceanDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 func TestDigitaloceanRockylinuxCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -2503,15 +1936,6 @@ func TestGceDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -2524,15 +1948,6 @@ func TestHetznerDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 func TestHetznerRockylinuxCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -2575,15 +1990,6 @@ func TestOpenstackRockylinuxCalicoContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCalicoContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -2605,15 +2011,6 @@ func TestVsphereFlatcarCalicoContainerdExternalV1_28_7(t *testing.T) {
 func TestAwsAmznCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -2656,15 +2053,6 @@ func TestAwsRockylinuxCalicoContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -2701,15 +2089,6 @@ func TestAzureRockylinuxCalicoContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -2722,15 +2101,6 @@ func TestDigitaloceanDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 func TestDigitaloceanRockylinuxCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -2773,15 +2143,6 @@ func TestGceDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -2794,15 +2155,6 @@ func TestHetznerDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 func TestHetznerRockylinuxCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -2845,15 +2197,6 @@ func TestOpenstackRockylinuxCalicoContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCalicoContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -2875,15 +2218,6 @@ func TestVsphereFlatcarCalicoContainerdExternalV1_29_2(t *testing.T) {
 func TestAwsAmznCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -2926,15 +2260,6 @@ func TestAwsRockylinuxCalicoContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -2971,15 +2296,6 @@ func TestAzureRockylinuxCalicoContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -2992,15 +2308,6 @@ func TestDigitaloceanDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 func TestDigitaloceanRockylinuxCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -3043,15 +2350,6 @@ func TestGceDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -3064,15 +2362,6 @@ func TestHetznerDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 func TestHetznerRockylinuxCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -3115,15 +2404,6 @@ func TestOpenstackRockylinuxCalicoContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["calico_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCalicoContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -3145,15 +2425,6 @@ func TestVsphereFlatcarCalicoContainerdExternalV1_30_1(t *testing.T) {
 func TestAwsAmznCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -3196,15 +2467,6 @@ func TestAwsRockylinuxCiliumContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -3241,15 +2503,6 @@ func TestAzureRockylinuxCiliumContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -3262,15 +2515,6 @@ func TestDigitaloceanDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 func TestDigitaloceanRockylinuxCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -3313,15 +2557,6 @@ func TestGceDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -3334,15 +2569,6 @@ func TestHetznerDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 func TestHetznerRockylinuxCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
@@ -3385,15 +2611,6 @@ func TestOpenstackRockylinuxCiliumContainerdExternalV1_27_11(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdExternalV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCiliumContainerdExternalV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -3415,15 +2632,6 @@ func TestVsphereFlatcarCiliumContainerdExternalV1_27_11(t *testing.T) {
 func TestAwsAmznCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -3466,15 +2674,6 @@ func TestAwsRockylinuxCiliumContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -3511,15 +2710,6 @@ func TestAzureRockylinuxCiliumContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -3532,15 +2722,6 @@ func TestDigitaloceanDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 func TestDigitaloceanRockylinuxCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -3583,15 +2764,6 @@ func TestGceDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -3604,15 +2776,6 @@ func TestHetznerDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 func TestHetznerRockylinuxCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7")
@@ -3655,15 +2818,6 @@ func TestOpenstackRockylinuxCiliumContainerdExternalV1_28_7(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdExternalV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCiliumContainerdExternalV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -3685,15 +2839,6 @@ func TestVsphereFlatcarCiliumContainerdExternalV1_28_7(t *testing.T) {
 func TestAwsAmznCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -3736,15 +2881,6 @@ func TestAwsRockylinuxCiliumContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -3781,15 +2917,6 @@ func TestAzureRockylinuxCiliumContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -3802,15 +2929,6 @@ func TestDigitaloceanDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 func TestDigitaloceanRockylinuxCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -3853,15 +2971,6 @@ func TestGceDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -3874,15 +2983,6 @@ func TestHetznerDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 func TestHetznerRockylinuxCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2")
@@ -3925,15 +3025,6 @@ func TestOpenstackRockylinuxCiliumContainerdExternalV1_29_2(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdExternalV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCiliumContainerdExternalV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -3955,15 +3046,6 @@ func TestVsphereFlatcarCiliumContainerdExternalV1_29_2(t *testing.T) {
 func TestAwsAmznCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -4006,15 +3088,6 @@ func TestAwsRockylinuxCiliumContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -4051,15 +3124,6 @@ func TestAzureRockylinuxCiliumContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default"]
@@ -4072,15 +3136,6 @@ func TestDigitaloceanDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 func TestDigitaloceanRockylinuxCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -4123,15 +3178,6 @@ func TestGceDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default"]
@@ -4144,15 +3190,6 @@ func TestHetznerDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 func TestHetznerRockylinuxCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30.1")
@@ -4195,15 +3232,6 @@ func TestOpenstackRockylinuxCiliumContainerdExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdExternalV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos"]
-	scenario := Scenarios["cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultCiliumContainerdExternalV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default"]
@@ -4225,15 +3253,6 @@ func TestVsphereFlatcarCiliumContainerdExternalV1_30_1(t *testing.T) {
 func TestAwsAmznStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")
@@ -4276,15 +3295,6 @@ func TestAwsRockylinuxStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default_stable"]
@@ -4321,15 +3331,6 @@ func TestAzureRockylinuxStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_2
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default_stable"]
@@ -4342,15 +3343,6 @@ func TestDigitaloceanDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_To
 func TestDigitaloceanRockylinuxStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")
@@ -4393,15 +3385,6 @@ func TestGceDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default_stable"]
@@ -4414,15 +3397,6 @@ func TestHetznerDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28
 func TestHetznerRockylinuxStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11", "v1.28.7")
@@ -4465,15 +3439,6 @@ func TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11", "v1.28.7")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28_7(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default_stable"]
@@ -4495,15 +3460,6 @@ func TestVsphereFlatcarStableUpgradeCiliumContainerdExternalFromV1_27_11_ToV1_28
 func TestAwsAmznStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7", "v1.29.2")
@@ -4546,15 +3502,6 @@ func TestAwsRockylinuxStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default_stable"]
@@ -4591,15 +3538,6 @@ func TestAzureRockylinuxStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default_stable"]
@@ -4612,15 +3550,6 @@ func TestDigitaloceanDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV
 func TestDigitaloceanRockylinuxStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7", "v1.29.2")
@@ -4663,15 +3592,6 @@ func TestGceDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t 
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default_stable"]
@@ -4684,15 +3604,6 @@ func TestHetznerDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_
 func TestHetznerRockylinuxStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.28.7", "v1.29.2")
@@ -4735,15 +3646,6 @@ func TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7", "v1.29.2")
-	scenario.Run(ctx, t)
-}
-
 func TestVsphereDefaultStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_2(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["vsphere_default_stable"]
@@ -4765,15 +3667,6 @@ func TestVsphereFlatcarStableUpgradeCiliumContainerdExternalFromV1_28_7_ToV1_29_
 func TestAwsAmznStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["aws_amzn_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -4816,15 +3709,6 @@ func TestAwsRockylinuxStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default_stable"]
@@ -4861,15 +3745,6 @@ func TestAzureRockylinuxStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["digitalocean_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestDigitaloceanDefaultStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_default_stable"]
@@ -4882,15 +3757,6 @@ func TestDigitaloceanDefaultStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV
 func TestDigitaloceanRockylinuxStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -4933,15 +3799,6 @@ func TestGceDefaultStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t 
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["hetzner_centos_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
 func TestHetznerDefaultStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_default_stable"]
@@ -4954,15 +3811,6 @@ func TestHetznerDefaultStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_
 func TestHetznerRockylinuxStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["hetzner_rockylinux_stable"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -4999,15 +3847,6 @@ func TestOpenstackRhelStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1
 func TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["openstack_rockylinux"]
-	scenario := Scenarios["upgrade_cilium_containerd_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.29.2", "v1.30.1")
-	scenario.Run(ctx, t)
-}
-
-func TestVsphereCentosStableUpgradeCiliumContainerdExternalFromV1_29_2_ToV1_30_1(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29.2", "v1.30.1")
@@ -5077,15 +3916,6 @@ func TestAwsDefaultKubeProxyIpvsExternalV1_30_1(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_27_11(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["csi_ccm_migration"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
 func TestAzureDefaultCsiCcmMigrationV1_27_11(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
 	infra := Infrastructures["azure_default"]
@@ -5128,15 +3958,6 @@ func TestGceDefaultCsiCcmMigrationV1_27_11(t *testing.T) {
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.27.11")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosCsiCcmMigrationV1_28_7(t *testing.T) {
-	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["csi_ccm_migration"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.28.7")
 	scenario.Run(ctx, t)
 }
 

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -6,34 +6,27 @@
   initVersion: v1.27.11
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
       runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -41,34 +34,27 @@
   initVersion: v1.28.7
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
       runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -76,34 +62,27 @@
   initVersion: v1.29.2
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
       runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -111,41 +90,33 @@
   initVersion: v1.30.1
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
       runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
 - scenario: install_containerd
   initVersion: v1.27.11
   infrastructures:
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
@@ -155,7 +126,6 @@
 - scenario: install_containerd
   initVersion: v1.28.7
   infrastructures:
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
@@ -170,7 +140,6 @@
   initVersion: v1.27.11
   upgradedVersion: v1.28.7
   infrastructures:
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
@@ -182,33 +151,26 @@
   upgradedVersion: v1.28.7
   infrastructures:
     - name: aws_amzn_stable
-    - name: aws_centos_stable
     - name: aws_default_stable
     - name: aws_flatcar_stable
     - name: aws_rhel_stable
     - name: aws_rockylinux_stable
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: digitalocean_centos_stable
     - name: digitalocean_default_stable
     - name: digitalocean_rockylinux_stable
-    - name: equinixmetal_centos_stable
     - name: equinixmetal_default_stable
     - name: equinixmetal_flatcar_stable
     - name: equinixmetal_rockylinux_stable
     - name: gce_default_stable
-    - name: hetzner_centos_stable
     - name: hetzner_default_stable
     - name: hetzner_rockylinux_stable
-    - name: openstack_centos_stable
     - name: openstack_default_stable
     - name: openstack_flatcar_stable
     - name: openstack_rhel_stable
     - name: openstack_rockylinux_stable
-    - name: vsphere_centos_stable
     - name: vsphere_default_stable
     - name: vsphere_flatcar_stable
 
@@ -217,33 +179,26 @@
   upgradedVersion: v1.29.2
   infrastructures:
     - name: aws_amzn_stable
-    - name: aws_centos_stable
     - name: aws_default_stable
     - name: aws_flatcar_stable
     - name: aws_rhel_stable
     - name: aws_rockylinux_stable
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: digitalocean_centos_stable
     - name: digitalocean_default_stable
     - name: digitalocean_rockylinux_stable
-    - name: equinixmetal_centos_stable
     - name: equinixmetal_default_stable
     - name: equinixmetal_flatcar_stable
     - name: equinixmetal_rockylinux_stable
     - name: gce_default_stable
-    - name: hetzner_centos_stable
     - name: hetzner_default_stable
     - name: hetzner_rockylinux_stable
-    - name: openstack_centos_stable
     - name: openstack_default_stable
     - name: openstack_flatcar_stable
     - name: openstack_rhel_stable
     - name: openstack_rockylinux_stable
-    - name: vsphere_centos_stable
     - name: vsphere_default_stable
     - name: vsphere_flatcar_stable
 
@@ -252,33 +207,26 @@
   upgradedVersion: v1.30.1
   infrastructures:
     - name: aws_amzn_stable
-    - name: aws_centos_stable
     - name: aws_default_stable
     - name: aws_flatcar_stable
     - name: aws_rhel_stable
     - name: aws_rockylinux_stable
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: digitalocean_centos_stable
     - name: digitalocean_default_stable
     - name: digitalocean_rockylinux_stable
-    - name: equinixmetal_centos_stable
     - name: equinixmetal_default_stable
     - name: equinixmetal_flatcar_stable
     - name: equinixmetal_rockylinux_stable
     - name: gce_default_stable
-    - name: hetzner_centos_stable
     - name: hetzner_default_stable
     - name: hetzner_rockylinux_stable
-    - name: openstack_centos_stable
     - name: openstack_default_stable
     - name: openstack_flatcar_stable
     - name: openstack_rhel_stable
     - name: openstack_rockylinux_stable
-    - name: vsphere_centos_stable
     - name: vsphere_default_stable
     - name: vsphere_flatcar_stable
 
@@ -290,33 +238,26 @@
   initVersion: v1.27.11
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -324,33 +265,26 @@
   initVersion: v1.28.7
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -358,33 +292,26 @@
   initVersion: v1.29.2
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -392,33 +319,26 @@
   initVersion: v1.30.1
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -426,33 +346,26 @@
   initVersion: v1.27.11
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -460,33 +373,26 @@
   initVersion: v1.28.7
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -494,33 +400,26 @@
   initVersion: v1.29.2
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -528,33 +427,26 @@
   initVersion: v1.30.1
   infrastructures:
     - name: aws_amzn
-    - name: aws_centos
     - name: aws_default
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
     - name: azure_rockylinux
-    - name: digitalocean_centos
     - name: digitalocean_default
     - name: digitalocean_rockylinux
-    - name: equinixmetal_centos
     - name: equinixmetal_default
     - name: equinixmetal_flatcar
     - name: equinixmetal_rockylinux
     - name: gce_default
-    - name: hetzner_centos
     - name: hetzner_default
     - name: hetzner_rockylinux
-    - name: openstack_centos
     - name: openstack_default
     - name: openstack_flatcar
     - name: openstack_rhel
     - name: openstack_rockylinux
-    - name: vsphere_centos
     - name: vsphere_default
     - name: vsphere_flatcar
 
@@ -563,33 +455,26 @@
   upgradedVersion: v1.28.7
   infrastructures:
     - name: aws_amzn_stable
-    - name: aws_centos_stable
     - name: aws_default_stable
     - name: aws_flatcar_stable
     - name: aws_rhel_stable
     - name: aws_rockylinux_stable
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: digitalocean_centos_stable
     - name: digitalocean_default_stable
     - name: digitalocean_rockylinux_stable
-    - name: equinixmetal_centos_stable
     - name: equinixmetal_default_stable
     - name: equinixmetal_flatcar_stable
     - name: equinixmetal_rockylinux_stable
     - name: gce_default_stable
-    - name: hetzner_centos_stable
     - name: hetzner_default_stable
     - name: hetzner_rockylinux_stable
-    - name: openstack_centos_stable
     - name: openstack_default_stable
     - name: openstack_flatcar_stable
     - name: openstack_rhel_stable
     - name: openstack_rockylinux_stable
-    - name: vsphere_centos_stable
     - name: vsphere_default_stable
     - name: vsphere_flatcar_stable
 
@@ -598,33 +483,26 @@
   upgradedVersion: v1.29.2
   infrastructures:
     - name: aws_amzn_stable
-    - name: aws_centos_stable
     - name: aws_default_stable
     - name: aws_flatcar_stable
     - name: aws_rhel_stable
     - name: aws_rockylinux_stable
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: digitalocean_centos_stable
     - name: digitalocean_default_stable
     - name: digitalocean_rockylinux_stable
-    - name: equinixmetal_centos_stable
     - name: equinixmetal_default_stable
     - name: equinixmetal_flatcar_stable
     - name: equinixmetal_rockylinux_stable
     - name: gce_default_stable
-    - name: hetzner_centos_stable
     - name: hetzner_default_stable
     - name: hetzner_rockylinux_stable
-    - name: openstack_centos_stable
     - name: openstack_default_stable
     - name: openstack_flatcar_stable
     - name: openstack_rhel_stable
     - name: openstack_rockylinux_stable
-    - name: vsphere_centos_stable
     - name: vsphere_default_stable
     - name: vsphere_flatcar_stable
 
@@ -633,33 +511,26 @@
   upgradedVersion: v1.30.1
   infrastructures:
     - name: aws_amzn_stable
-    - name: aws_centos_stable
     - name: aws_default_stable
     - name: aws_flatcar_stable
     - name: aws_rhel_stable
     - name: aws_rockylinux_stable
-    - name: azure_centos_stable
     - name: azure_default_stable
     - name: azure_flatcar_stable
     - name: azure_rhel_stable
     - name: azure_rockylinux_stable
-    - name: digitalocean_centos_stable
     - name: digitalocean_default_stable
     - name: digitalocean_rockylinux_stable
-    - name: equinixmetal_centos_stable
     - name: equinixmetal_default_stable
     - name: equinixmetal_flatcar_stable
     - name: equinixmetal_rockylinux_stable
     - name: gce_default_stable
-    - name: hetzner_centos_stable
     - name: hetzner_default_stable
     - name: hetzner_rockylinux_stable
-    - name: openstack_centos_stable
     - name: openstack_default_stable
     - name: openstack_flatcar_stable
     - name: openstack_rhel_stable
     - name: openstack_rockylinux_stable
-    - name: vsphere_centos_stable
     - name: vsphere_default_stable
     - name: vsphere_flatcar_stable
 ####################
@@ -698,7 +569,6 @@
 - scenario: csi_ccm_migration
   initVersion: v1.27.11
   infrastructures:
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel
@@ -708,7 +578,6 @@
 - scenario: csi_ccm_migration
   initVersion: v1.28.7
   infrastructures:
-    - name: azure_centos
     - name: azure_default
     - name: azure_flatcar
     - name: azure_rhel


### PR DESCRIPTION
**What this PR does / why we need it**:
CentOS7 reached EOL. Mirrors are removed. Our periodic e2e started to fail with:
```
Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=genclo error was
14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
```

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
