### PR TITLE
Allow upstream cluster autoscaler flags configuration

### DIFF
--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -117,14 +117,20 @@ You need to replace the following values with the actual ones:
 
 * `CLUSTER_AUTOSCALER_IMAGE` can be used to replace the Cluster Autoscaler image
   * The minor versions of Cluster Autoscaler and Kubernetes cluster should
-    match, as per
-    [Cluster Autoscaler recommendations][recommended-autoscaler-versions]
+    match, as per [Cluster Autoscaler recommendations][recommended-autoscaler-versions].
   * You can find the available Cluster Autoscaler versions by searching for
-    Cluster Autoscaler in the
-    [autoscaler GitHub repository][autoscaler-releases]
+    Cluster Autoscaler in the [autoscaler GitHub repository][autoscaler-releases].
 * `CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE` can be used to define the value of `--skip-nodes-with-local-storage=`.
   * Possible values are `"true"`or `"false"`
   * Default is `"true"`, as described in the [FAQ][autoscaler-faq].
+* `CLUSTER_AUTOSCALER_ENFORCE_NODE_GROUP_MIN_SIZE` can be used to define the value of `--enforce-node-group-min-size=`.
+  * Possible values are `"true"` or `"false"`.
+  * Default is `"false"`, as described in the [FAQ][autoscaler-faq].
+  * Set the value to `"true"`, if you are facing issue similare to the one described over [here][enforce-node-group-min-size] in the [FAQ][autoscaler-faq].
+* `CLUSTER_AUTOSCALER_BALANCE_SIMILAR_NODE_GROUP` can be used to define the value of `--balance-similar-node-groups=`.
+  * Possible values are `"true"` or `"false"`.
+  * Default is `"false"`, as described in the [FAQ][autoscaler-faq].
+  * Set the value to `"true"`, if you are facing issue similare to the one described over [here][balance-similar-node-groups] in the [FAQ][autoscaler-faq].
 
 You can find more information about deploying addons in the
 [Addons document][using-addons].
@@ -138,3 +144,5 @@ You can find more information about deploying addons in the
 [autoscaler-releases]: https://github.com/kubernetes/autoscaler/releases
 [using-addons]: https://docs.kubermatic.com/kubeone/v1.8/guides/addons/
 [autoscaler-faq]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md
+[enforce-node-group-min-size]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#my-cluster-is-below-minimum--above-maximum-number-of-nodes-but-ca-did-not-fix-that-why
+[balance-similar-node-groups]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#im-running-cluster-with-nodes-in-multiple-zones-for-ha-purposes-is-that-supported-by-cluster-autoscaler

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -181,6 +181,8 @@ spec:
             - --namespace=kube-system
             - --skip-nodes-with-local-storage={{ default "true" .Params.CLUSTER_AUTOSCALER_SKIP_LOCAL_STORAGE }}
             - --node-group-auto-discovery=clusterapi:namespace=kube-system
+            - --enforce-node-group-min-size={{ default "false" .Params.CLUSTER_AUTOSCALER_ENFORCE_NODE_GROUP_MIN_SIZE }}
+            - --balance-similar-node-groups={{ default "false" .Params.CLUSTER_AUTOSCALER_BALANCE_SIMILAR_NODE_GROUP }}
             - --logtostderr=true
             - --stderrthreshold=info
             - --v=4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This PR is to allow the configuration of the upstream cluster-autoscaler supported flags via KubeOne provided cluster-autoscaler addon to address https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#my-cluster-is-below-minimum--above-maximum-number-of-nodes-but-ca-did-not-fix-that-why and https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#im-running-cluster-with-nodes-in-multiple-zones-for-ha-purposes-is-that-supported-by-cluster-autoscaler issue as faced at the one of the customer end. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow the configuration of the upstream cluster-autoscaler flags  `--enforce-node-group-min-size` and `--balance-similar-node-groups`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
