### PR TITLE
Use containerd 1.7

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -83,6 +83,6 @@ var libraryTemplate = heredoc.Doc(`
 	`)
 
 const (
-	defaultContainerdVersion       = "'1.6.*'"
+	defaultContainerdVersion       = "'1.7.*'"
 	defaultAmazonContainerdVersion = "'1.6.*'"
 )

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -93,7 +93,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-'1.6.*'
+sudo yum install -y containerd.io-'1.7.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -96,7 +96,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-'1.6.*'
+sudo yum install -y containerd.io-'1.7.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -93,7 +93,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-'1.6.*'
+sudo yum install -y containerd.io-'1.7.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -93,7 +93,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-'1.6.*'
+sudo yum install -y containerd.io-'1.7.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -88,7 +88,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io='1.6.*'
+	containerd.io='1.7.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -91,7 +91,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io='1.6.*'
+	containerd.io='1.7.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -88,7 +88,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io='1.6.*'
+	containerd.io='1.7.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -88,7 +88,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io='1.6.*'
+	containerd.io='1.7.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -93,7 +93,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-'1.6.*'
+sudo yum install -y containerd.io-'1.7.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -89,7 +89,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io='1.6.*'
+	containerd.io='1.7.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -93,7 +93,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-'1.6.*'
+sudo yum install -y containerd.io-'1.7.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -89,7 +89,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io='1.6.*'
+	containerd.io='1.7.*'
 sudo apt-mark hold containerd.io
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
containerd 1.7 continue to support existing config, while declaring it deprecated no real alternative has been introduced. In containerd 2.0 introduced config format v3: https://github.com/containerd/containerd/blob/v2.0.0-rc.3/docs/cri/registry.md which is basically the same as old config but a map key changed from `[plugins."io.containerd.grpc.v1.cri".registry.configs]` to `[plugins."io.containerd.cri.v1.images".registry.configs]`.

It means for now (until 2.0 is available across our supported OSes) we stay at config version 2.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #2076

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:
Follow up PR with the OSM update is pending.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use containerd 1.7
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
