### PR TITLE
Fix typo in the cluster autoscaler addon documentation

### DIFF
--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -126,11 +126,11 @@ You need to replace the following values with the actual ones:
 * `CLUSTER_AUTOSCALER_ENFORCE_NODE_GROUP_MIN_SIZE` can be used to define the value of `--enforce-node-group-min-size=`.
   * Possible values are `"true"` or `"false"`.
   * Default is `"false"`, as described in the [FAQ][autoscaler-faq].
-  * Set the value to `"true"`, if you are facing issue similare to the one described over [here][enforce-node-group-min-size] in the [FAQ][autoscaler-faq].
+  * Set the value to `"true"`, if you are facing issue similar to the one described over [here][enforce-node-group-min-size] in the [FAQ][autoscaler-faq].
 * `CLUSTER_AUTOSCALER_BALANCE_SIMILAR_NODE_GROUP` can be used to define the value of `--balance-similar-node-groups=`.
   * Possible values are `"true"` or `"false"`.
   * Default is `"false"`, as described in the [FAQ][autoscaler-faq].
-  * Set the value to `"true"`, if you are facing issue similare to the one described over [here][balance-similar-node-groups] in the [FAQ][autoscaler-faq].
+  * Set the value to `"true"`, if you are facing issue similar to the one described over [here][balance-similar-node-groups] in the [FAQ][autoscaler-faq].
 
 You can find more information about deploying addons in the
 [Addons document][using-addons].


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This PR is to fix the typo in the cluster autoscaler addon documentation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
