### PR TITLE
Use RHEL upstream docker repo instead of abandoned centos

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -79,12 +79,7 @@ var containerRuntimeTemplates = map[string]string{
 	"yum-containerd": heredoc.Docf(`
 			{{ if .CONFIGURE_REPOSITORIES }}
 			sudo yum install -y yum-utils
-			sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-			{{- /*
-			Due to DNF modules we have to do this on docker-ce repo
-			More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473
-			*/}}
-			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+			sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 			{{ end }}
 
 			sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -88,8 +88,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -91,8 +91,7 @@ sudo systemctl enable --now iscsid
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -88,8 +88,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -88,8 +88,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -88,8 +88,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -88,8 +88,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -196,11 +196,11 @@ func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ executor
 func installKubeadm(s *state.State, node kubeoneapi.HostConfig) error {
 	return runOnOS(s, node.OperatingSystem, map[kubeoneapi.OperatingSystemName]runOnOSFn{
 		kubeoneapi.OperatingSystemNameAmazon:     installKubeadmAmazonLinux,
-		kubeoneapi.OperatingSystemNameCentOS:     installKubeadmCentOS,
+		kubeoneapi.OperatingSystemNameCentOS:     installKubeadmRHELAndAlike,
 		kubeoneapi.OperatingSystemNameDebian:     installKubeadmDebian,
 		kubeoneapi.OperatingSystemNameFlatcar:    installKubeadmFlatcar,
-		kubeoneapi.OperatingSystemNameRHEL:       installKubeadmCentOS,
-		kubeoneapi.OperatingSystemNameRockyLinux: installKubeadmCentOS,
+		kubeoneapi.OperatingSystemNameRHEL:       installKubeadmRHELAndAlike,
+		kubeoneapi.OperatingSystemNameRockyLinux: installKubeadmRHELAndAlike,
 		kubeoneapi.OperatingSystemNameUbuntu:     installKubeadmDebian,
 	})
 }
@@ -216,7 +216,7 @@ func installKubeadmDebian(s *state.State) error {
 	return fail.SSH(err, "installing kubeadm")
 }
 
-func installKubeadmCentOS(s *state.State) error {
+func installKubeadmRHELAndAlike(s *state.State) error {
 	cmd, err := scripts.KubeadmCentOS(s.Cluster, s.ForceInstall)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
CentOS upstream docker repo being abandoned (naturally as CentOS8 is long time dead). This leads to errors where on rocky8 and rhel8 containerd 1.7 is not found. But it's actually present in RHEL repo!

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use RHEL upstream docker repo instead of abandoned centos
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
