### PR TITLE
Add kubeconfig generate subcommand

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -137,7 +137,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	}
 
 	// Certs for machine-controller-webhook
-	mcCertsMap, err := certificate.NewSignedTLSCert(
+	mcCertsMap, err := certificate.NewSignedKubernetesServiceTLSCert(
 		resources.MachineControllerWebhookName,
 		resources.MachineControllerNameSpace,
 		s.Cluster.ClusterNetwork.ServiceDomainName,
@@ -149,7 +149,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	}
 
 	// Certs for metrics-server
-	msCertsMap, err := certificate.NewSignedTLSCert(
+	msCertsMap, err := certificate.NewSignedKubernetesServiceTLSCert(
 		resources.MetricsServerName,
 		resources.MetricsServerNamespace,
 		s.Cluster.ClusterNetwork.ServiceDomainName,
@@ -304,7 +304,7 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 }
 
 func webhookCerts(certs map[string]string, prefix, webhookName, webhookNamespace, serviceDomainName string, kubeCAPrivateKey *rsa.PrivateKey, kubeCACert *x509.Certificate) error {
-	certsMap, err := certificate.NewSignedTLSCert(
+	certsMap, err := certificate.NewSignedKubernetesServiceTLSCert(
 		webhookName,
 		webhookNamespace,
 		serviceDomainName,

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -82,7 +83,7 @@ func CAKeyPair(config *configupload.Configuration) (*rsa.PrivateKey, *x509.Certi
 	return rsaKey, certs[0], nil
 }
 
-func NewSignedTLSCert(name, namespace, domain string, caKey crypto.Signer, caCert *x509.Certificate) (map[string]string, error) {
+func NewSignedKubernetesServiceTLSCert(name, namespace, domain string, caKey crypto.Signer, caCert *x509.Certificate) (map[string]string, error) {
 	serviceCommonName := strings.Join([]string{name, namespace, "svc"}, ".")
 	serviceFQDNCommonName := strings.Join([]string{serviceCommonName, domain, ""}, ".")
 
@@ -91,7 +92,7 @@ func NewSignedTLSCert(name, namespace, domain string, caKey crypto.Signer, caCer
 		serviceCommonName,
 	}
 
-	newKPKey, err := newPrivateKey()
+	newKPKey, err := NewPrivateKey()
 	if err != nil {
 		return nil, fail.Runtime(err, "generating RSA private key")
 	}
@@ -104,7 +105,7 @@ func NewSignedTLSCert(name, namespace, domain string, caKey crypto.Signer, caCer
 		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 
-	newKPCert, err := newSignedCert(&certCfg, newKPKey, caCert, caKey)
+	newKPCert, err := NewSignedCert(&certCfg, newKPKey, caCert, caKey, time.Now().Add(duration365d))
 	if err != nil {
 		return nil, fail.Runtime(err, "generating certificate")
 	}

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -85,7 +85,7 @@ func kubeconfigGenerateCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		Short:   "Generate kubeconfig",
 		Long:    "Generate kubeconfig with given certificate parameters.",
 		Example: `kubeone kubeconfig generate -m mycluster.yaml -t tf.json --super-admin`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return err

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -98,7 +98,7 @@ func GenerateSuperAdmin(st *state.State, cn string, on []string, ttl time.Durati
 		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 
-	superAdminUserCert, err := certificate.NewSignedCert(&certCfg, superAdminUserKey, caCerts[0], caRSAKey, time.Now().Add(1*time.Hour))
+	superAdminUserCert, err := certificate.NewSignedCert(&certCfg, superAdminUserKey, caCerts[0], caRSAKey, time.Now().Add(ttl))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -48,7 +48,7 @@ const (
 	pkiCAkey = "/etc/kubernetes/pki/ca.key"
 )
 
-func GenerateSuperAdmin(st *state.State, cn string, on []string, ttl time.Duration) ([]byte, error) {
+func Generate(st *state.State, cn string, on []string, ttl time.Duration) ([]byte, error) {
 	host, err := st.Cluster.Leader()
 	if err != nil {
 		return nil, err

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -239,6 +239,10 @@ func WithResources(t Tasks) Tasks {
 				Operation: "saving kubeconfig",
 			},
 			{
+				Fn:        removeSuperKubeconfig,
+				Operation: "removing " + superAdminConfPath,
+			},
+			{
 				Fn: func(s *state.State) error {
 					s.Logger.Info("Downloading PKI...")
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #3082

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Add new `kubeone kubeconfig generate` command with an option to generate kubeconfig file with the custom permissions (for example: the super-admin kubeconfig). 
* Super-admin kubeconfig (`/etc/kubernetes/super-admin.conf`) automatically generated by kubeadm is now removed from the nodes.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
