### PR TITLE
[release/v1.7] CentOS docker repo being abandoned, replaced with RHEL

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -167,12 +167,7 @@ var (
 		"yum-containerd": heredoc.Docf(`
 			{{ if .CONFIGURE_REPOSITORIES }}
 			sudo yum install -y yum-utils
-			sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-			{{- /*
-			Due to DNF modules we have to do this on docker-ce repo
-			More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473
-			*/}}
-			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+			sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 			{{ end }}
 
 			sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -90,8 +90,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -90,8 +90,7 @@ sudo yum install -y \
 
 
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
 
 
 sudo yum versionlock delete containerd.io || true

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -196,11 +196,11 @@ func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ executor
 func installKubeadm(s *state.State, node kubeoneapi.HostConfig) error {
 	return runOnOS(s, node.OperatingSystem, map[kubeoneapi.OperatingSystemName]runOnOSFn{
 		kubeoneapi.OperatingSystemNameAmazon:     installKubeadmAmazonLinux,
-		kubeoneapi.OperatingSystemNameCentOS:     installKubeadmCentOS,
+		kubeoneapi.OperatingSystemNameCentOS:     installKubeadmRHELAndAlike,
 		kubeoneapi.OperatingSystemNameDebian:     installKubeadmDebian,
 		kubeoneapi.OperatingSystemNameFlatcar:    installKubeadmFlatcar,
-		kubeoneapi.OperatingSystemNameRHEL:       installKubeadmCentOS,
-		kubeoneapi.OperatingSystemNameRockyLinux: installKubeadmCentOS,
+		kubeoneapi.OperatingSystemNameRHEL:       installKubeadmRHELAndAlike,
+		kubeoneapi.OperatingSystemNameRockyLinux: installKubeadmRHELAndAlike,
 		kubeoneapi.OperatingSystemNameUbuntu:     installKubeadmDebian,
 	})
 }
@@ -216,7 +216,7 @@ func installKubeadmDebian(s *state.State) error {
 	return fail.SSH(err, "installing kubeadm")
 }
 
-func installKubeadmCentOS(s *state.State) error {
+func installKubeadmRHELAndAlike(s *state.State) error {
 	cmd, err := scripts.KubeadmCentOS(s.Cluster, s.ForceInstall)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #3316

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use RHEL upstream docker repo instead of abandoned centos
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 