### PR TITLE
Update to Go 1.23

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
   - govet
   - importas
   - ineffassign
+  - intrange
   - makezero
   - misspell
   - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,12 @@ run:
   issues-exit-code: 1
   build-tags:
   - e2e
-  skip-dirs:
+  exclude-dirs:
   - hack
   - vendor
   - pkg/apis/kubeadm
 
-  skip-files:
+  exclude-files:
   - zz_generated.*.go
 
 linters:
@@ -55,7 +55,8 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   goimports:
     local-prefixes: k8c.io/kubeone
   importas:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
+  - copyloopvar
   - dogsled
   - durationcheck
   - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,13 +2,6 @@ run:
   issues-exit-code: 1
   build-tags:
   - e2e
-  exclude-dirs:
-  - hack
-  - vendor
-  - pkg/apis/kubeadm
-
-  exclude-files:
-  - zz_generated.*.go
 
 linters:
   disable-all: true
@@ -74,6 +67,14 @@ linters-settings:
       alias: $1$2
 
 issues:
+  exclude-dirs:
+  - hack
+  - vendor
+  - pkg/apis/kubeadm
+
+  exclude-files:
+  - zz_generated.*.go
+
   exclude-rules:
   - path: pkg/apis/kubeone
     text: "func SetDefaults_"

--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -41,7 +41,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -209,7 +209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -257,7 +257,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -280,7 +280,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -303,7 +303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -326,7 +326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -349,7 +349,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -372,7 +372,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -395,7 +395,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -418,7 +418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -441,7 +441,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -466,7 +466,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -491,7 +491,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -516,7 +516,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -541,7 +541,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -566,7 +566,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -589,7 +589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -613,7 +613,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -636,7 +636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -659,7 +659,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -682,7 +682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -705,7 +705,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -730,7 +730,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -755,7 +755,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -781,7 +781,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -806,7 +806,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -829,7 +829,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -852,7 +852,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -875,7 +875,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -898,7 +898,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -921,7 +921,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -944,7 +944,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -967,7 +967,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -990,7 +990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1013,7 +1013,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1038,7 +1038,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1063,7 +1063,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1088,7 +1088,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1113,7 +1113,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1138,7 +1138,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1161,7 +1161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1185,7 +1185,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1208,7 +1208,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1231,7 +1231,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1254,7 +1254,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1277,7 +1277,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1302,7 +1302,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1327,7 +1327,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1353,7 +1353,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1378,7 +1378,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1401,7 +1401,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1424,7 +1424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1447,7 +1447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1470,7 +1470,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1493,7 +1493,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1516,7 +1516,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1539,7 +1539,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1562,7 +1562,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1585,7 +1585,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1610,7 +1610,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1635,7 +1635,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1660,7 +1660,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1685,7 +1685,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1710,7 +1710,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1735,7 +1735,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1760,7 +1760,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1786,7 +1786,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1811,7 +1811,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1834,7 +1834,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1864,7 +1864,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1894,7 +1894,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1922,7 +1922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1952,7 +1952,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1982,7 +1982,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2012,7 +2012,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2042,7 +2042,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2072,7 +2072,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2103,7 +2103,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2133,7 +2133,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2163,7 +2163,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2193,7 +2193,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2223,7 +2223,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2253,7 +2253,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2283,7 +2283,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2313,7 +2313,7 @@ presubmits:
         value: gce
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2343,7 +2343,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2373,7 +2373,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2403,7 +2403,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2433,7 +2433,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2463,7 +2463,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2493,7 +2493,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2523,7 +2523,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2553,7 +2553,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2583,7 +2583,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2613,7 +2613,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2641,7 +2641,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2671,7 +2671,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2701,7 +2701,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2731,7 +2731,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2761,7 +2761,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2791,7 +2791,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2822,7 +2822,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2852,7 +2852,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2882,7 +2882,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2912,7 +2912,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2942,7 +2942,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2972,7 +2972,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3002,7 +3002,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3032,7 +3032,7 @@ presubmits:
         value: gce
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3062,7 +3062,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3092,7 +3092,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3122,7 +3122,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3152,7 +3152,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3182,7 +3182,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3212,7 +3212,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3242,7 +3242,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3272,7 +3272,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3295,7 +3295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3318,7 +3318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3341,7 +3341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3364,7 +3364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3387,7 +3387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3412,7 +3412,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3437,7 +3437,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3463,7 +3463,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3488,7 +3488,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3511,7 +3511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3534,7 +3534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3557,7 +3557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3580,7 +3580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3603,7 +3603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3626,7 +3626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3649,7 +3649,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3672,7 +3672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3695,7 +3695,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3720,7 +3720,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3745,7 +3745,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3770,7 +3770,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3795,7 +3795,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3820,7 +3820,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3843,7 +3843,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3866,7 +3866,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3889,7 +3889,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3912,7 +3912,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3935,7 +3935,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3960,7 +3960,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3985,7 +3985,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4011,7 +4011,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4036,7 +4036,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4059,7 +4059,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4082,7 +4082,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4105,7 +4105,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4128,7 +4128,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4151,7 +4151,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4174,7 +4174,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4197,7 +4197,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4220,7 +4220,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4243,7 +4243,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4268,7 +4268,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4293,7 +4293,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4318,7 +4318,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4343,7 +4343,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4368,7 +4368,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4391,7 +4391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4414,7 +4414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4437,7 +4437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4460,7 +4460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4483,7 +4483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4508,7 +4508,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4533,7 +4533,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4559,7 +4559,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4584,7 +4584,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4607,7 +4607,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4630,7 +4630,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4653,7 +4653,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4676,7 +4676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4699,7 +4699,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4722,7 +4722,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4745,7 +4745,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4768,7 +4768,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4791,7 +4791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4816,7 +4816,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4841,7 +4841,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4866,7 +4866,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4891,7 +4891,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4916,7 +4916,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4939,7 +4939,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4962,7 +4962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4985,7 +4985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5008,7 +5008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5031,7 +5031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5056,7 +5056,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5081,7 +5081,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5107,7 +5107,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5132,7 +5132,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5155,7 +5155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5178,7 +5178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5201,7 +5201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5224,7 +5224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5247,7 +5247,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5270,7 +5270,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5293,7 +5293,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5316,7 +5316,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5339,7 +5339,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5364,7 +5364,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5389,7 +5389,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5414,7 +5414,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5439,7 +5439,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5464,7 +5464,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5487,7 +5487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5510,7 +5510,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5533,7 +5533,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5556,7 +5556,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5579,7 +5579,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5604,7 +5604,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5629,7 +5629,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5655,7 +5655,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5680,7 +5680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5703,7 +5703,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5726,7 +5726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5749,7 +5749,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5772,7 +5772,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5795,7 +5795,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5818,7 +5818,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5841,7 +5841,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5864,7 +5864,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5887,7 +5887,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5912,7 +5912,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5937,7 +5937,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5962,7 +5962,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5987,7 +5987,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6012,7 +6012,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6035,7 +6035,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6058,7 +6058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6081,7 +6081,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6104,7 +6104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6127,7 +6127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6152,7 +6152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6177,7 +6177,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6203,7 +6203,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6228,7 +6228,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6251,7 +6251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6274,7 +6274,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6297,7 +6297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6320,7 +6320,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6343,7 +6343,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6366,7 +6366,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6389,7 +6389,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6412,7 +6412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6435,7 +6435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6460,7 +6460,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6485,7 +6485,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6510,7 +6510,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6535,7 +6535,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6560,7 +6560,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6583,7 +6583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6606,7 +6606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6629,7 +6629,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6652,7 +6652,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6675,7 +6675,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6700,7 +6700,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6725,7 +6725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6751,7 +6751,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6776,7 +6776,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6799,7 +6799,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6822,7 +6822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6845,7 +6845,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6868,7 +6868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6891,7 +6891,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6914,7 +6914,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6937,7 +6937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6960,7 +6960,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6983,7 +6983,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7008,7 +7008,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7033,7 +7033,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7058,7 +7058,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7083,7 +7083,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7108,7 +7108,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7131,7 +7131,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7154,7 +7154,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7177,7 +7177,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7200,7 +7200,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7223,7 +7223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7248,7 +7248,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7273,7 +7273,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7299,7 +7299,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7324,7 +7324,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7347,7 +7347,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7370,7 +7370,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7393,7 +7393,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7416,7 +7416,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7439,7 +7439,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7462,7 +7462,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7485,7 +7485,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7508,7 +7508,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7531,7 +7531,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7556,7 +7556,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7581,7 +7581,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7606,7 +7606,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7631,7 +7631,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7656,7 +7656,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7679,7 +7679,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7702,7 +7702,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7725,7 +7725,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7748,7 +7748,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7771,7 +7771,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7796,7 +7796,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7821,7 +7821,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7847,7 +7847,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7872,7 +7872,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7895,7 +7895,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7918,7 +7918,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7941,7 +7941,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7964,7 +7964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7987,7 +7987,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8010,7 +8010,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8033,7 +8033,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8056,7 +8056,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8079,7 +8079,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8104,7 +8104,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8129,7 +8129,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8154,7 +8154,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8179,7 +8179,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8204,7 +8204,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8227,7 +8227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8250,7 +8250,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8273,7 +8273,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8296,7 +8296,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8319,7 +8319,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8344,7 +8344,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8369,7 +8369,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8395,7 +8395,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8420,7 +8420,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8443,7 +8443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8466,7 +8466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8489,7 +8489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8512,7 +8512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8535,7 +8535,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8558,7 +8558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8581,7 +8581,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8604,7 +8604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8627,7 +8627,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8652,7 +8652,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8677,7 +8677,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8702,7 +8702,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8727,7 +8727,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8752,7 +8752,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8782,7 +8782,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8812,7 +8812,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8842,7 +8842,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8872,7 +8872,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8902,7 +8902,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8932,7 +8932,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8962,7 +8962,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8993,7 +8993,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9023,7 +9023,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9053,7 +9053,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9083,7 +9083,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9113,7 +9113,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9143,7 +9143,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9173,7 +9173,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9203,7 +9203,7 @@ presubmits:
         value: gce
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9233,7 +9233,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9263,7 +9263,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9293,7 +9293,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9323,7 +9323,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9353,7 +9353,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9383,7 +9383,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9413,7 +9413,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9443,7 +9443,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9473,7 +9473,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9503,7 +9503,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9533,7 +9533,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9563,7 +9563,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9593,7 +9593,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9623,7 +9623,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9653,7 +9653,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9684,7 +9684,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9714,7 +9714,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9744,7 +9744,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9774,7 +9774,7 @@ presubmits:
         value: digitalocean
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9804,7 +9804,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9834,7 +9834,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9864,7 +9864,7 @@ presubmits:
         value: equinixmetal
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9894,7 +9894,7 @@ presubmits:
         value: gce
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9924,7 +9924,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9954,7 +9954,7 @@ presubmits:
         value: hetzner
       - name: TEST_TIMEOUT
         value: 90m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9984,7 +9984,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10014,7 +10014,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10044,7 +10044,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10074,7 +10074,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10104,7 +10104,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10134,7 +10134,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10159,7 +10159,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10184,7 +10184,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10209,7 +10209,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10232,7 +10232,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10257,7 +10257,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10282,7 +10282,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10308,7 +10308,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10333,7 +10333,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10356,7 +10356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.22-node-20-6
+      image: quay.io/kubermatic/build:go-1.23-node-20-0
       imagePullPolicy: Always
       name: ""
       resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - /bin/bash
             - -c
@@ -38,7 +38,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -57,7 +57,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-6
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.3 as builder
+FROM docker.io/golang:1.23.0 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,6 @@ buildenv:
 
 .PHONY: lint
 lint:
-	@golangci-lint version
 	golangci-lint run --timeout=5m -v ./pkg/... ./test/...
 
 .PHONY: verify-licence

--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -161,7 +161,7 @@ func (a *applier) loadAddonsManifests(
 		if !disableTemplating {
 			tpl, err := template.New("addons-base").Funcs(txtFuncMap(overwriteRegistry)).Parse(string(manifestBytes))
 			if err != nil {
-				return nil, fail.Runtime(err, fmt.Sprintf("parsing addons manifest template %q", file.Name()))
+				return nil, fail.Runtime(err, "parsing addons manifest template %q", file.Name())
 			}
 
 			// Make a copy and merge Params
@@ -193,7 +193,7 @@ func (a *applier) loadAddonsManifests(
 
 			manifest = bytes.NewBuffer([]byte{})
 			if err := tpl.Execute(manifest, tplData); err != nil {
-				return nil, fail.Runtime(err, fmt.Sprintf("executing addons manifest template %q", file.Name()))
+				return nil, fail.Runtime(err, "executing addons manifest template %q", file.Name())
 			}
 
 			if len(bytes.TrimSpace(manifest.Bytes())) == 0 {
@@ -209,7 +209,7 @@ func (a *applier) loadAddonsManifests(
 					break
 				}
 
-				return nil, fail.Runtime(err, fmt.Sprintf("reading YAML reader for manifest %q", file.Name()))
+				return nil, fail.Runtime(err, "reading YAML reader for manifest %q", file.Name())
 			}
 
 			yamlDoc = bytes.TrimSpace(yamlDoc)
@@ -220,7 +220,7 @@ func (a *applier) loadAddonsManifests(
 			decoder := kyaml.NewYAMLToJSONDecoder(bytes.NewBuffer(yamlDoc))
 			raw := runtime.RawExtension{}
 			if err := decoder.Decode(&raw); err != nil {
-				return nil, fail.Runtime(err, fmt.Sprintf("unmarshalling manifest %q", file.Name()))
+				return nil, fail.Runtime(err, "unmarshalling manifest %q", file.Name())
 			}
 
 			if len(raw.Raw) == 0 {
@@ -325,10 +325,10 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 func requiredTemplateFunc(warn string, input interface{}) (interface{}, error) {
 	switch val := input.(type) {
 	case nil:
-		return val, fmt.Errorf(warn)
+		return val, errors.New(warn)
 	case string:
 		if val == "" {
-			return val, fmt.Errorf(warn)
+			return val, errors.New(warn)
 		}
 	}
 

--- a/pkg/addons/manifest_test.go
+++ b/pkg/addons/manifest_test.go
@@ -196,7 +196,6 @@ func TestEnsureAddonsLabelsOnResources(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			addonsDir := t.TempDir()
@@ -274,7 +273,6 @@ func TestImageRegistryParsing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			addonsDir := t.TempDir()
 
@@ -328,7 +326,6 @@ func TestCABundleFuncs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt, func(t *testing.T) {
 			tpl, err := template.New("addons-base").Funcs(txtFuncMap("")).Parse(fmt.Sprintf(`{{ %s }}`, tt))
 
@@ -652,7 +649,6 @@ func TestDisableTemplateForLoadManifests(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			addonsDir := t.TempDir()

--- a/pkg/apis/kubeone/config/config_test.go
+++ b/pkg/apis/kubeone/config/config_test.go
@@ -155,7 +155,6 @@ func Test_setRegistriesAuth(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if err := setRegistriesAuth(tt.args.cluster, tt.args.buf); (err != nil) != tt.wantErr {
 				t.Errorf("setRegistriesAuth() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/apis/kubeone/helpers_test.go
+++ b/pkg/apis/kubeone/helpers_test.go
@@ -64,7 +64,6 @@ func TestFeatureGatesString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := marshalFeatureGates(tc.featureGates)
@@ -151,7 +150,6 @@ func TestMapStringStringToString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MapStringStringToString(tt.m1, "="); got != tt.want {
 				t.Errorf("MapStringStringToString() = %v, want %v", got, tt.want)
@@ -265,7 +263,6 @@ func TestDefaultAssetConfiguration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.cluster.DefaultAssetConfiguration()
 			if !reflect.DeepEqual(tt.cluster.AssetConfiguration, tt.expectedAssetConfiguration) {

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -250,7 +250,6 @@ func TestValidateKubeOneCluster(t *testing.T) {
 
 	twentyFour := 24
 	for _, tc := range tests {
-		tc := tc
 		tc.cluster.ClusterNetwork = kubeoneapi.ClusterNetworkConfig{
 			IPFamily:             kubeoneapi.IPFamilyIPv4,
 			PodSubnet:            "10.20.30.40/16",
@@ -325,7 +324,6 @@ func TestValdiateName(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateName(tc.clusterName, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -396,7 +394,6 @@ func TestValidateControlPlaneConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateControlPlaneConfig(tc.controlPlaneConfig, tc.networkConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -460,7 +457,6 @@ func TestValidateAPIEndpoint(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateAPIEndpoint(tc.apiEndpoint, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -780,7 +776,6 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateCloudProviderSpec(tc.providerConfig, tc.networkConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -861,7 +856,6 @@ func TestValidateVersionConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateVersionConfig(tc.versionConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -1078,7 +1072,6 @@ func TestValidateKubernetesSupport(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := kubeoneapi.KubeOneCluster{
 				CloudProvider:  tc.providerConfig,
@@ -1280,7 +1273,6 @@ func TestValidateClusterNetworkConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateClusterNetworkConfig(tc.clusterNetworkConfig, tc.provider, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -1358,7 +1350,6 @@ func TestValidateCNIConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateCNI(tc.cniConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -1454,7 +1445,6 @@ func TestValidateStaticWorkersConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateStaticWorkersConfig(tc.staticWorkersConfig, tc.controlPlane, tc.networkConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -1706,7 +1696,6 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateDynamicWorkerConfig(tc.dynamicWorkerConfig, tc.provider, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -1771,7 +1760,6 @@ func TestValidateCABundle(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateCABundle(tc.caBundle, field.NewPath("caBundle"))
 			if (len(errs) == 0) == tc.expectedError {
@@ -1890,7 +1878,6 @@ func TestValidateFeatures(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateFeatures(tc.features, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -1920,7 +1907,6 @@ func TestValidatePodNodeSelectorConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidatePodNodeSelectorConfig(tc.podNodeSelectorConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -2002,7 +1988,6 @@ func TestValidateStaticAuditLogConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateStaticAuditLogConfig(tc.staticAuditLogConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -2042,7 +2027,6 @@ func TestValidateOIDCConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateOIDCConfig(tc.oidcConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -2082,7 +2066,6 @@ func TestValidateAddons(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateAddons(tc.addons, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -2331,7 +2314,6 @@ func TestValidateHostConfig(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateHostConfig(tc.hostConfig, tc.networkConfig, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -2381,7 +2363,6 @@ func TestValidateRegistryConfiguration(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateRegistryConfiguration(tc.registryConfiguration, nil)
 			if (len(errs) == 0) == tc.expectedError {
@@ -2572,7 +2553,6 @@ func TestValidateAssetConfiguration(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			errs := ValidateAssetConfiguration(tc.assetConfiguration, nil)
 			if (len(errs) == 0) == tc.expectedError {

--- a/pkg/clientutil/label_test.go
+++ b/pkg/clientutil/label_test.go
@@ -68,7 +68,6 @@ func TestAddLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := AddLabels(tt.args.labels, tt.args.objects...); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("AddLabels() = %v, want %v", got, tt.want)

--- a/pkg/clusterstatus/clusterstatus.go
+++ b/pkg/clusterstatus/clusterstatus.go
@@ -123,7 +123,6 @@ func Fetch(s *state.State, preflightChecks bool) ([]NodeStatus, error) {
 	)
 
 	for _, host := range s.Cluster.ControlPlane.Hosts {
-		host := host
 		statusWG.Add(1)
 
 		go func() {

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -45,7 +45,6 @@ func TestRunPrint(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := runPrint(tt.printOptions)

--- a/pkg/cmd/initcmd/init_test.go
+++ b/pkg/cmd/initcmd/init_test.go
@@ -280,7 +280,6 @@ func TestGenKubeOneClusterYAML(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := genKubeOneClusterYAML(tt.opts)
 			if !errors.Is(err, tt.err) {
@@ -318,7 +317,6 @@ func TestGenTerraformVars(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := genTerraformVars(genOpts(withTerraformVars(tt.vars)))
 

--- a/pkg/containerruntime/containerd_config_test.go
+++ b/pkg/containerruntime/containerd_config_test.go
@@ -69,7 +69,6 @@ func Test_marshalContainerdConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := marshalContainerdConfig(tt.cluster)
 			if err != nil {

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -145,7 +145,6 @@ func TestOpenstackValidationFunc(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := openstackValidationFunc(tt.creds)
@@ -230,7 +229,6 @@ func TestVmwareCloudDirectorValidationFunc(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := vmwareCloudDirectorValidationFunc(tt.creds)

--- a/pkg/scripts/ccm_csi_migration_test.go
+++ b/pkg/scripts/ccm_csi_migration_test.go
@@ -54,7 +54,6 @@ func TestCCMMigrationRegenerateControlPlaneConfigs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := CCMMigrationRegenerateControlPlaneConfigs(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)

--- a/pkg/scripts/configs_test.go
+++ b/pkg/scripts/configs_test.go
@@ -36,7 +36,6 @@ func TestSaveCloudConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := SaveCloudConfig(tt.workdir)
@@ -64,7 +63,6 @@ func TestSaveAuditPolicyConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := SaveAuditPolicyConfig(tt.workdir)
@@ -92,7 +90,6 @@ func TestSaveAuditWebhookConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := SaveAuditWebhookConfig(tt.workdir)

--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -54,7 +54,6 @@ func TestKubeadmJoin(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmJoin(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
@@ -100,7 +99,6 @@ func TestKubeadmJoinWorker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmJoinWorker(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
@@ -146,7 +144,6 @@ func TestKubeadmCert(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmCert(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
@@ -198,7 +195,6 @@ func TestKubeadmInit(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmInit(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag, tt.args.token, tt.args.tokenTTL, "")
@@ -241,7 +237,6 @@ func TestKubeadmReset(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmReset(tt.args.verboseFlag, tt.args.workdir)
@@ -287,7 +282,6 @@ func TestKubeadmUpgrade(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmUpgrade(tt.args.kubeadmCmd, tt.args.workdir, tt.args.leader, 0)

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -152,7 +152,6 @@ func TestKubeadmDebian(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmDebian(&tt.args.cluster, false)
@@ -191,7 +190,6 @@ func TestMigrateToContainerd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cls := genCluster(
@@ -249,7 +247,6 @@ func TestKubeadmCentOS(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmCentOS(&tt.args.cluster, tt.args.force)
@@ -333,7 +330,6 @@ func TestKubeadmAmazonLinux(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmAmazonLinux(&tt.args.cluster, tt.args.force)
@@ -396,7 +392,6 @@ func TestKubeadmFlatcar(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := KubeadmFlatcar(&tt.args.cluster)

--- a/pkg/scripts/proxy_test.go
+++ b/pkg/scripts/proxy_test.go
@@ -69,7 +69,6 @@ func TestEnvironmentFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := EnvironmentFile(tt.args.cluster)

--- a/pkg/state/cluster_test.go
+++ b/pkg/state/cluster_test.go
@@ -45,7 +45,6 @@ func TestCluster_CertsToExpireInLessThen90Days(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Cluster{
 				ControlPlane: tt.hosts,

--- a/pkg/state/context_test.go
+++ b/pkg/state/context_test.go
@@ -165,7 +165,6 @@ func TestShouldEnableInTreeCloudProvider(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			s := &State{
 				Cluster:     tc.cluster,
@@ -368,7 +367,6 @@ func TestShouldEnableCSIMigration(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			s := &State{
 				Cluster:      tc.cluster,
@@ -572,7 +570,6 @@ func TestShouldUnregisterInTreeProvider(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			s := &State{
 				Cluster:              tc.cluster,

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -333,7 +333,6 @@ func migrateOpenStackPVs(s *state.State) error {
 	}
 
 	for i, pv := range pvList.Items {
-		pv := pv
 		if pv.Annotations[provisionedByAnnotation] == provisionedByOpenStackInTreeCinder {
 			pvKey := client.ObjectKeyFromObject(&pv)
 			if s.Verbose {

--- a/pkg/tasks/certs_test.go
+++ b/pkg/tasks/certs_test.go
@@ -57,7 +57,6 @@ func Test_timeBefore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := timeBefore(tt.args.t1, tt.args.t2); got != tt.want {
 				t.Errorf("timeBefore() = %v, want %v", got, tt.want)

--- a/pkg/tasks/common_test.go
+++ b/pkg/tasks/common_test.go
@@ -42,7 +42,6 @@ func Test_marshalKubeletFlags(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := marshalKubeletFlags(tt.args.kubeletflags); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("marshalKubeletFlags() = \n%s, want\n%s", got, tt.want)
@@ -94,7 +93,6 @@ func Test_unmarshalKubeletFlags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := unmarshalKubeletFlags(tt.buf)
 			if (err != nil) != tt.wantErr {

--- a/pkg/tasks/containerd.go
+++ b/pkg/tasks/containerd.go
@@ -57,7 +57,6 @@ func patchCRISocketAnnotation(s *state.State) error {
 	}
 
 	for _, node := range nodes.Items {
-		node := node
 		if socketPath, found := node.Annotations[kubeadmCRISocket]; found {
 			if socketPath != "/var/run/dockershim.sock" {
 				continue

--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -156,8 +156,6 @@ func labelNodes(s *state.State) error {
 
 func applyHostLabels(ctx context.Context, hosts map[string]kubeoneapi.HostConfig, dynClient client.Client) error {
 	for nodeName, host := range hosts {
-		nodeName := nodeName
-		host := host
 		updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			var node corev1.Node
 

--- a/pkg/tasks/preflight_checks.go
+++ b/pkg/tasks/preflight_checks.go
@@ -235,7 +235,7 @@ func checkHostnames(hostnames []string) error {
 	if len(allErrors) > 0 {
 		allErrors = append(allErrors, "Please rename host(s)")
 
-		return fail.Runtime(fmt.Errorf(strings.Join(allErrors, "\n")), "validating node hostnames")
+		return fail.Runtime(errors.New(strings.Join(allErrors, "\n")), "validating node hostnames")
 	}
 
 	return nil

--- a/pkg/tasks/preflight_checks_test.go
+++ b/pkg/tasks/preflight_checks_test.go
@@ -60,7 +60,6 @@ func TestParseContainerImageVersionValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ver, err := parseContainerImageVersion(corev1.Container{Image: tc.image})
@@ -99,7 +98,6 @@ func TestParseContainerImageVersionInvalid(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := parseContainerImageVersion(corev1.Container{Image: tc.image})
@@ -175,7 +173,6 @@ func TestCheckVersionSkewValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkVersionSkew(tc.desiredVersion, tc.currentVersion, tc.diff)
@@ -257,7 +254,6 @@ func TestCheckVersionSkewInvalid(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkVersionSkew(tc.desiredVersion, tc.currentVersion, tc.diff)
@@ -299,7 +295,6 @@ Please rename host(s)`),
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkHostnames(tc.hostnames)

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tasks
 
 import (
+	"github.com/pkg/errors"
+
 	"k8c.io/kubeone/pkg/addons"
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/certificate"
@@ -40,7 +42,10 @@ func (t Tasks) Run(s *state.State) error {
 			continue
 		}
 		if err := step.Run(s); err != nil {
-			return fail.Runtime(err, step.Operation)
+			return fail.RuntimeError{
+				Op:  step.Operation,
+				Err: errors.WithStack(err),
+			}
 		}
 	}
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -123,10 +124,10 @@ func retryFn(fn func() error) error {
 func requiredTemplateFunc(warn string, input interface{}) (interface{}, error) {
 	switch val := input.(type) {
 	case nil:
-		return val, fmt.Errorf(warn)
+		return val, errors.New(warn)
 	case string:
 		if val == "" {
-			return val, fmt.Errorf(warn)
+			return val, errors.New(warn)
 		}
 	}
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -57,7 +57,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/build:go-1.22-node-20-6"
+	prowImage             = "quay.io/kubermatic/build:go-1.23-node-20-0"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/testexec/exec_test.go
+++ b/test/testexec/exec_test.go
@@ -42,7 +42,6 @@ func TestWithMapEnv(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := Exec{}
 			WithMapEnv(tt.args)(&e)


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates KubeOne to use the latest Go release. I also enabled the two new linters that ship with golangci-lint:

* `copyloopvar` is a linter detects places where loop variables are copied.
* `intrange` is a program for checking for loops that could use the [Go 1.22](https://go.dev/ref/spec#Go_1.22) integer range feature.

Fixes #3345

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.23.0
```

**Documentation**:
```documentation
NONE
```
