### PR TITLE
Add server groups to OpenStack example

### DIFF
--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -23,7 +23,7 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
 | Name | Version |
 |------|---------|
-| <a name="provider_openstack"></a> [openstack](#provider\_openstack) | ~> 1.52.0 |
+| <a name="provider_openstack"></a> [openstack](#provider\_openstack) | 1.52.1 |
 
 ## Modules
 
@@ -36,6 +36,7 @@ No modules.
 | [openstack_compute_instance_v2.bastion](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2) | resource |
 | [openstack_compute_instance_v2.control_plane](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2) | resource |
 | [openstack_compute_keypair_v2.deployer](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_keypair_v2) | resource |
+| [openstack_compute_servergroup_v2.control_plane](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_servergroup_v2) | resource |
 | [openstack_lb_listener_v2.kube_apiserver](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/lb_listener_v2) | resource |
 | [openstack_lb_loadbalancer_v2.kube_apiserver](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/lb_loadbalancer_v2) | resource |
 | [openstack_lb_member_v2.kube_apiserver](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/lb_member_v2) | resource |
@@ -73,6 +74,7 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
 | <a name="input_config_drive"></a> [config\_drive](#input\_config\_drive) | If enabled, metadata for machines is stored on a configuration drive instead of the metadata service. | `bool` | `false` | no |
 | <a name="input_control_plane_flavor"></a> [control\_plane\_flavor](#input\_control\_plane\_flavor) | OpenStack instance flavor for the control plane nodes | `string` | `"m1.small"` | no |
+| <a name="input_control_plane_group_policy"></a> [control\_plane\_group\_policy](#input\_control\_plane\_group\_policy) | OpenStack instance group policy for the control plane nodes. Cannot be changed without recreating VMs! | `string` | `"soft-anti-affinity"` | no |
 | <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | number of control plane instances | `number` | `3` | no |
 | <a name="input_external_network_name"></a> [external\_network\_name](#input\_external\_network\_name) | OpenStack external network name | `string` | n/a | yes |
 | <a name="input_image"></a> [image](#input\_image) | image name to use | `string` | `""` | no |

--- a/examples/terraform/openstack/control_plane.tf
+++ b/examples/terraform/openstack/control_plane.tf
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+resource "openstack_compute_servergroup_v2" "control_plane" {
+  name     = "${var.cluster_name}-control_plane"
+  policies = [var.control_plane_group_policy]
+}
+
 resource "openstack_networking_port_v2" "control_plane" {
   count = var.control_plane_vm_count
   name  = "${var.cluster_name}-control_plane-${count.index}"
@@ -36,6 +41,10 @@ resource "openstack_compute_instance_v2" "control_plane" {
   key_pair        = openstack_compute_keypair_v2.deployer.name
   security_groups = [openstack_networking_secgroup_v2.securitygroup.name]
   config_drive    = var.config_drive
+
+  scheduler_hints {
+    group = openstack_compute_servergroup_v2.control_plane.id
+  }
 
   network {
     port = element(openstack_networking_port_v2.control_plane[*].id, count.index)

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -88,6 +88,12 @@ variable "control_plane_flavor" {
   type        = string
 }
 
+variable "control_plane_group_policy" {
+  description = "OpenStack instance group policy for the control plane nodes. Cannot be changed without recreating VMs!"
+  default     = "soft-anti-affinity"
+  type        = string
+}
+
 # Worker Node Variables
 variable "worker_os" {
   description = "OS to run on worker machines"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

Add server groups to OpenStack example. Server groups allow controlling anti affinity of control plane nodes. Therefore, you can ensure that control plane nodes run on different hypervisors. Per default, its configured to use "soft-anti-affinity" (try to use different hypervisors, fallback to use the same hypervisors if not possible to spread).

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind feature
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
