### PR TITLE
Migrate PVC .status.allocatedResourceStatus after upgrade to v1.31

### DIFF
--- a/pkg/tasks/migrations.go
+++ b/pkg/tasks/migrations.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+
+	"k8c.io/kubeone/pkg/fail"
+	"k8c.io/kubeone/pkg/state"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func migratePVCAllocatedResourceStatus(s *state.State) error {
+	s.Logger.Info("Removing AllocatedResourceStatus from PersistentVolumeClaims...")
+
+	pvcList := corev1.PersistentVolumeClaimList{}
+
+	if err := s.DynamicClient.List(s.Context, &pvcList); err != nil {
+		return fail.KubeClient(err, "getting %T", pvcList)
+	}
+
+	for _, pvc := range pvcList.Items {
+		log := s.Logger.WithField("pvc", fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name))
+		log.Debug("Checking AllocatedResourceStatus for PVC...")
+
+		var found bool
+		for k, v := range pvc.Status.AllocatedResourceStatuses {
+			if k == corev1.ResourceStorage &&
+				(v == corev1.PersistentVolumeClaimControllerResizeFailed || v == corev1.PersistentVolumeClaimNodeResizeFailed) {
+				log.Info("Removing AllocatedResourceStatus from PVC...")
+				found = true
+
+				pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{}
+
+				if err := s.DynamicClient.Status().Update(s.Context, &pvc); err != nil {
+					return fail.KubeClient(err, "updating pvc")
+				}
+
+				break
+			}
+		}
+		if !found {
+			log.Debug("No AllocatedResourceStatus found for PVC.")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The [Kubernetes v1.31 changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#no-really-you-must-read-this-before-you-upgrade) says the following:

> Reduced state change noise when volume expansion fails. Also mark certain failures as infeasible.
>
> ACTION REQUIRED: If you are using the RecoverVolumeExpansionFailure alpha feature gate then after upgrading to this release, you need to update some objects. For any existing PersistentVolumeClaimss with status.allocatedResourceStatus set to either "ControllerResizeFailed" or "NodeResizeFailed", clear the status.allocatedResourceStatus. (https://github.com/kubernetes/kubernetes/pull/126108, [@gnufied](https://github.com/gnufied)) [SIG Apps, Auth, Node, Storage and Testing]

This is very edge case because `.status.allocatedResourceStatus` requires the `RecoverVolumeExpansionFailure` feature gate to be enabled on kube-apiserver, kubelet, and csi-resizer. We have this feature gate enabled on AzureDisk and AzureFile CSI Resizer, however, it's no-op because we don't enable it on kube-apiserver and kubelet.

Some more details can be found in this Slack thread: https://kubernetes.slack.com/archives/C09QZFCE5/p1724771882803599

However, to be on the safe side, we're implementing a migration to remove `.status.allocatedResourceStatus` if it's present.

**Which issue(s) this PR fixes**:
xref #3346 

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

We should look into disabling that feature gate on the AzureDisk and AzureFile CSI Resizer, but I'm leaving that for a follow up.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Migrate PersistentVolumeClaims (PVCs) upon upgrading to Kubernetes v1.31 to remove `.status.allocatedResourceStatus` if needed as instructed by the Kubernetes v1.31.0 changelog
```

**Documentation**:
```documentation
NONE
```

/assign @xrstf 