### PR TITLE
[release/v1.7] Update vSphere images to use upstream image repository or our mirror

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -355,10 +355,10 @@ func optionalResources() map[Resource]map[string]string {
 
 		// vSphere CCM
 		VsphereCCM: {
-			"1.24.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.24.4",
-			"1.25.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.25.3",
-			"1.26.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.2",
-			">= 1.27.0": "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.27.0",
+			"1.24.x":    "quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.24.5",
+			"1.25.x":    "quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.25.3",
+			"1.26.x":    "quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.26.2",
+			">= 1.27.0": "quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.27.0",
 		},
 
 		// VMware Cloud Director CSI
@@ -368,8 +368,8 @@ func optionalResources() map[Resource]map[string]string {
 		VMwareCloudDirectorCSINodeDriverRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
 
 		// vSphere CSI
-		VsphereCSIDriver:                    {"*": "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.2"},
-		VsphereCSISyncer:                    {"*": "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.2"},
+		VsphereCSIDriver:                    {"*": "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.0.2"},
+		VsphereCSISyncer:                    {"*": "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.0.2"},
 		VsphereCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v4.2.0"},
 		VsphereCSILivenessProbe:             {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.9.0"},
 		VsphereCSINodeDriverRegistar:        {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #3376 

This PR replaces the registry used for vSphere CCM and CSI images. Unfortunately:
- The new vSphere CCM image registry has images only starting from v1.28.0
- There are no images in the new official vSphere CSI image registry at the moment

Because of that, we unfortunately have to resort to the mirroring the old/unavailable images.

**Which issue(s) this PR fixes**:
xref #3375 

**What type of PR is this?**
/kind bug
/kind regression
/priority critical-urgent

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Fix vSphere CCM and CSI images. The CCM images for versions starting with v1.28.0 are pulled from the new community-owned image repository. The CCM images for versions prior to v1.28.0, and the CSI images, are pulled from the Kubermatic-managed mirror on `quay.io`. If you have a vSphere cluster, we strongly recommend upgrading to the latest KubeOne patch release and running `kubeone apply` **as soon as possible**, because the old image repository (`gcr.io/cloud-provider-vsphere`) is not available anymore, hence it's not possible to pull the needed images from that repository
```

**Documentation**:

```documentation
TBD
```