### PR TITLE
Rerun failed Kubernetes conformance tests

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -594,6 +594,10 @@ func waitKubeOneNodesReady(ctx context.Context, t *testing.T, k1 *kubeoneBin) {
 }
 
 func sonobuoyRun(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, proxyURL string) {
+	sonobuoyRunWithRunCount(ctx, t, k1, mode, proxyURL, 0)
+}
+
+func sonobuoyRunWithRunCount(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, proxyURL string, runCount int) {
 	kubeconfigPath, err := k1.kubeconfigPath(t.TempDir())
 	if err != nil {
 		t.Fatalf("fetching kubeconfig failed")
@@ -605,7 +609,12 @@ func sonobuoyRun(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuo
 		proxyURL:   proxyURL,
 	}
 
-	if err = retryFnWithBackoff(SonobuoyRetry, func() error { return sb.Run(ctx, mode) }); err != nil {
+	rerunFailed := false
+	if runCount > 0 {
+		rerunFailed = true
+	}
+
+	if err = retryFnWithBackoff(SonobuoyRetry, func() error { return sb.Run(ctx, mode, rerunFailed) }); err != nil {
 		t.Fatalf("sonobuoy run failed: %v", err)
 	}
 
@@ -636,7 +645,14 @@ func sonobuoyRun(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuo
 		if err = enc.Encode(report); err != nil {
 			t.Errorf("failed to json encode sonobuoy report: %v", err)
 		}
-		t.Fatalf("some e2e tests failed:\n%s", buf.String())
+
+		if runCount < sonobuoyRunRetries {
+			t.Logf("some e2e tests failed:\n%s", buf.String())
+			t.Logf("restarting failed e2e tests (try %d/%d)...", runCount+1, sonobuoyRunRetries)
+			sonobuoyRunWithRunCount(ctx, t, k1, mode, proxyURL, runCount+1)
+		} else {
+			t.Fatalf("some e2e tests failed:\n%s", buf.String())
+		}
 	}
 }
 

--- a/test/e2e/sonobuoy.go
+++ b/test/e2e/sonobuoy.go
@@ -27,7 +27,10 @@ import (
 	"k8c.io/kubeone/test/testexec"
 )
 
-const sonobuoyResultsFile = "results.tar.gz"
+const (
+	sonobuoyResultsFile = "results.tar.gz"
+	sonobuoyRunRetries  = 3
+)
 
 type sonobuoyReport struct {
 	Name    string                 `json:"name"`
@@ -55,7 +58,11 @@ type sonobuoyBin struct {
 	proxyURL   string
 }
 
-func (sbb *sonobuoyBin) Run(ctx context.Context, mode sonobuoyMode) error {
+func (sbb *sonobuoyBin) Run(ctx context.Context, mode sonobuoyMode, rerunFailed bool) error {
+	if rerunFailed {
+		return sbb.run(ctx, "run", fmt.Sprintf("--mode=%s", mode), fmt.Sprintf("--rerun-failed=%s", sonobuoyResultsFile))
+	}
+
 	return sbb.run(ctx, "run", fmt.Sprintf("--mode=%s", mode))
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Turns out, Sonobuoy can very easily restart failed conformance tests, at least in theory. Let's put that into the practice!

With this PR, failed conformance tests will be restarted 3 times. This way, we don't fail the whole job if some tests flakes, instead we try to run them again. Those flakes cannot be caused by KubeOne, those flakes can be only the result of the unstable infrastructure or a bug in the test itself.

This should save us quite a lot of time when testing PRs and releases. Although, we might need to increase timeouts, but let's first see how this works.

**Which issue(s) this PR fixes**:
Fixes #3287 

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 