### PR TITLE
Add an option to disable Flatcar auto-upgrades

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -71,6 +71,7 @@ No modules.
 | <a name="input_control_plane_type"></a> [control\_plane\_type](#input\_control\_plane\_type) | AWS instance type | `string` | `"t3.medium"` | no |
 | <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | number of control plane instances | `number` | `3` | no |
 | <a name="input_control_plane_volume_size"></a> [control\_plane\_volume\_size](#input\_control\_plane\_volume\_size) | Size of the EBS volume, in Gb | `number` | `100` | no |
+| <a name="input_disable_auto_update"></a> [disable\_auto\_update](#input\_disable\_auto\_update) | Disable automatic flatcar updates (and reboot) | `bool` | `false` | no |
 | <a name="input_disable_kubeapi_loadbalancer"></a> [disable\_kubeapi\_loadbalancer](#input\_disable\_kubeapi\_loadbalancer) | E2E tests specific variable to disable usage of any loadbalancer in front of kubeapi-server | `bool` | `false` | no |
 | <a name="input_initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployments, only applicable if operating-system-manager addon is enabled.<br>If not specified default is used based on the OS specified for workers. | `string` | `""` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | number of replicas per MachineDeployment | `number` | `1` | no |

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -307,6 +307,8 @@ resource "aws_instance" "control_plane" {
     http_put_response_hop_limit = var.control_plane_http_put_max_hops
   }
 
+  user_data = var.disable_auto_update ? file("./userdata_flatcar_upgrades.json") : null
+
   tags = tomap({
     "Name"                   = "${var.cluster_name}-cp-${count.index + 1}",
     (local.kube_cluster_tag) = "shared",
@@ -334,6 +336,8 @@ resource "aws_instance" "static_workers1" {
     http_put_response_hop_limit = var.static_workers_http_put_max_hops
   }
 
+  user_data = var.disable_auto_update ? file("./userdata_flatcar_upgrades.json") : null
+
   tags = tomap({
     "Name"                   = "${var.cluster_name}-workers1-${count.index + 1}",
     (local.kube_cluster_tag) = "shared",
@@ -355,6 +359,8 @@ resource "aws_instance" "bastion" {
     volume_type = "gp2"
     volume_size = 100
   }
+
+  user_data = var.disable_auto_update ? file("./userdata_flatcar_upgrades.json") : null
 
   tags = tomap({
     "Cluster"                = var.cluster_name,

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -96,6 +96,8 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
+          disableAutoUpdate   = var.disable_auto_update
+          disableLocksmithD   = var.disable_auto_update
           provisioningUtility = var.provisioning_utility
         }
         labels = {
@@ -156,6 +158,8 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
+          disableAutoUpdate   = var.disable_auto_update
+          disableLocksmithD   = var.disable_auto_update
           provisioningUtility = var.provisioning_utility
         }
         labels = {
@@ -216,6 +220,8 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
+          disableAutoUpdate   = var.disable_auto_update
+          disableLocksmithD   = var.disable_auto_update
           provisioningUtility = var.provisioning_utility
         }
         labels = {

--- a/examples/terraform/aws/userdata_flatcar_upgrades.json
+++ b/examples/terraform/aws/userdata_flatcar_upgrades.json
@@ -1,10 +1,1 @@
-%{ if os == "rhel" }
-#cloud-config
-rh_subscription:
-  username: ${rhsm_username}
-  password: '${rhsm_password}'
-  auto-attach: false
-%{ endif }
-%{ if disable_auto_update }
 {"ignition":{"version":"3.3.0"},"storage":{"files":[{"overwrite":true,"path":"/etc/flatcar/update.conf","contents":{"compression":"","source":"data:,SERVER%3Ddisabled%0A"},"mode":420}]}}
-%{ endif }

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -313,3 +313,9 @@ Name of operating system profile for MachineDeployments, only applicable if oper
 If not specified default is used based on the OS specified for workers.
 EOF
 }
+
+variable "disable_auto_update" {
+  description = "Disable automatic flatcar updates (and reboot)"
+  type        = bool
+  default     = false
+}

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -288,11 +288,12 @@ resource "azurerm_virtual_machine" "control_plane" {
   os_profile {
     computer_name  = "${var.cluster_name}-cp-${count.index}"
     admin_username = local.ssh_username
-    custom_data = templatefile("./cloud-config.tftpl", {
-      os            = var.os
-      rhsm_username = var.rhsm_username
-      rhsm_password = var.rhsm_password
-    })
+    custom_data = base64encode(trimspace(templatefile("./cloud-config.tftpl", {
+      os                  = var.os
+      rhsm_username       = var.rhsm_username
+      rhsm_password       = var.rhsm_password
+      disable_auto_update = var.disable_auto_update
+    })))
   }
 
   os_profile_linux_config {

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -63,6 +63,7 @@ output "kubeone_workers" {
         operatingSystemSpec = {
           distUpgradeOnBoot               = false
           disableAutoUpdate               = var.disable_auto_update
+          disableLocksmithD               = var.disable_auto_update
           rhelSubscriptionManagerUser     = var.rhsm_username
           rhelSubscriptionManagerPassword = var.rhsm_password
           rhsmOfflineToken                = var.rhsm_offline_token

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -74,6 +74,7 @@ No modules.
 | <a name="input_config_drive"></a> [config\_drive](#input\_config\_drive) | If enabled, metadata for machines is stored on a configuration drive instead of the metadata service. | `bool` | `false` | no |
 | <a name="input_control_plane_flavor"></a> [control\_plane\_flavor](#input\_control\_plane\_flavor) | OpenStack instance flavor for the control plane nodes | `string` | `"m1.small"` | no |
 | <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | number of control plane instances | `number` | `3` | no |
+| <a name="input_disable_auto_update"></a> [disable\_auto\_update](#input\_disable\_auto\_update) | Disable automatic flatcar updates (and reboot) | `bool` | `false` | no |
 | <a name="input_external_network_name"></a> [external\_network\_name](#input\_external\_network\_name) | OpenStack external network name | `string` | n/a | yes |
 | <a name="input_image"></a> [image](#input\_image) | image name to use | `string` | `""` | no |
 | <a name="input_image_properties_query"></a> [image\_properties\_query](#input\_image\_properties\_query) | in absence of var.image, this will be used to query API for the image | `map(any)` | <pre>{<br>  "os_distro": "ubuntu",<br>  "os_version": "24.04"<br>}</pre> | no |

--- a/examples/terraform/openstack/bastion.tf
+++ b/examples/terraform/openstack/bastion.tf
@@ -33,6 +33,10 @@ resource "openstack_compute_instance_v2" "bastion" {
   security_groups = [openstack_networking_secgroup_v2.securitygroup.name]
   config_drive    = var.config_drive
 
+  user_data = var.disable_auto_update ? templatefile("./userdata_flatcar_upgrades.json", {
+    ssh_key = trimspace(file(pathexpand(var.ssh_public_key_file)))
+  }) : null
+
   network {
     port = openstack_networking_port_v2.bastion.id
   }

--- a/examples/terraform/openstack/control_plane.tf
+++ b/examples/terraform/openstack/control_plane.tf
@@ -37,6 +37,10 @@ resource "openstack_compute_instance_v2" "control_plane" {
   security_groups = [openstack_networking_secgroup_v2.securitygroup.name]
   config_drive    = var.config_drive
 
+  user_data = var.disable_auto_update ? templatefile("./userdata_flatcar_upgrades.json", {
+    ssh_key = trimspace(file(pathexpand(var.ssh_public_key_file)))
+  }) : null
+
   network {
     port = element(openstack_networking_port_v2.control_plane[*].id, count.index)
   }

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -72,6 +72,8 @@ output "kubeone_workers" {
         operatingSystem = var.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot = false
+          disableAutoUpdate = var.disable_auto_update
+          disableLocksmithD = var.disable_auto_update
         }
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {

--- a/examples/terraform/openstack/userdata_flatcar_upgrades.json
+++ b/examples/terraform/openstack/userdata_flatcar_upgrades.json
@@ -1,0 +1,1 @@
+{"ignition":{"version":"3.3.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["${ssh_key}"]}]},"storage":{"files":[{"overwrite":true,"path":"/etc/flatcar/update.conf","contents":{"compression":"","source":"data:,SERVER%3Ddisabled%0A"},"mode":420}]}}

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -196,3 +196,9 @@ Name of operating system profile for MachineDeployments, only applicable if oper
 If not specified, the default value will be added by machine-controller addon.
 EOF
 }
+
+variable "disable_auto_update" {
+  description = "Disable automatic flatcar updates (and reboot)"
+  type        = bool
+  default     = false
+}

--- a/examples/terraform/vsphere_flatcar/README.md
+++ b/examples/terraform/vsphere_flatcar/README.md
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_datastore_cluster_name"></a> [datastore\_cluster\_name](#input\_datastore\_cluster\_name) | datastore cluster name | `string` | `""` | no |
 | <a name="input_datastore_name"></a> [datastore\_name](#input\_datastore\_name) | datastore name | `string` | `"datastore1"` | no |
 | <a name="input_dc_name"></a> [dc\_name](#input\_dc\_name) | datacenter name | `string` | `"dc-1"` | no |
+| <a name="input_disable_auto_update"></a> [disable\_auto\_update](#input\_disable\_auto\_update) | Disable automatic flatcar updates (and reboot) | `bool` | `false` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | disk size | `number` | `50` | no |
 | <a name="input_folder_name"></a> [folder\_name](#input\_folder\_name) | folder name | `string` | `"kubeone"` | no |
 | <a name="input_initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployments, only applicable if operating-system-manager addon is enabled.<br>If not specified, the default value will be added by machine-controller addon. | `string` | `""` | no |

--- a/examples/terraform/vsphere_flatcar/main.tf
+++ b/examples/terraform/vsphere_flatcar/main.tf
@@ -116,16 +116,27 @@ resource "vsphere_virtual_machine" "control_plane" {
           ]
         },
         storage = {
-          files = [
-            {
-              filesystem = "root"
-              path       = "/etc/hostname"
-              mode       = 420
-              contents = {
-                source = "data:,${local.hostnames[count.index]}"
+          files = concat(
+            [
+              {
+                filesystem = "root"
+                path       = "/etc/hostname"
+                mode       = 420
+                contents = {
+                  source = "data:,${local.hostnames[count.index]}"
+                }
               }
-            }
-          ]
+            ], var.disable_auto_update ?
+            [
+              {
+                filesystem = "root"
+                path       = "/etc/flatcar/update.conf"
+                mode       = 420
+                contents = {
+                  source = "data:,SERVER%3Ddisabled%0A"
+                }
+              }
+          ] : [])
         },
         passwd = {
           users = [

--- a/examples/terraform/vsphere_flatcar/outputs.tf
+++ b/examples/terraform/vsphere_flatcar/outputs.tf
@@ -64,6 +64,8 @@ output "kubeone_workers" {
         operatingSystem = var.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot = false
+          disableAutoUpdate = var.disable_auto_update
+          disableLocksmithD = var.disable_auto_update
         }
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {

--- a/examples/terraform/vsphere_flatcar/variables.tf
+++ b/examples/terraform/vsphere_flatcar/variables.tf
@@ -233,3 +233,9 @@ variable "is_vsphere_enterprise_plus_license" {
   type        = bool
   default     = true
 }
+
+variable "disable_auto_update" {
+  description = "Disable automatic flatcar updates (and reboot)"
+  type        = bool
+  default     = false
+}

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -176,6 +176,7 @@ var (
 				varFile: "testdata/aws_medium.tfvars",
 				vars: []string{
 					"os=flatcar",
+					"disable_auto_update=true",
 				},
 			},
 			protokol: protokolBin{
@@ -218,6 +219,7 @@ var (
 				varFile: "testdata/aws_medium.tfvars",
 				vars: []string{
 					"os=flatcar",
+					"disable_auto_update=true",
 					"worker_deploy_ssh_key=false",
 				},
 			},
@@ -1034,6 +1036,7 @@ var (
 				varFile: "testdata/vsphere.tfvars",
 				vars: []string{
 					"template_name=kkp-flatcar-stable",
+					"disable_auto_update=true",
 				},
 			},
 			protokol: protokolBin{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an option to the example Terraform configs for AWS, OpenStack, and vSphere to disable Flatcar auto-upgrades, as documented here: https://www.flatcar.org/docs/latest/setup/releases/update-strategies/#disable-automatic-updates

This option already exists for Azure, but it's only applied on MachineDeployments, now it has been extended to Terraform-managed nodes as well.

The option is called `disable_auto_update` and it's disabled by default, but explicitly enabled in our E2E tests.

**Which issue(s) this PR fixes**:
xref #2320 
(to be closed once TODOs are resolved)

**What type of PR is this?**
/kind flake

**Special notes for your reviewer**:

TODO:

- Backport this PR to the previous release branch
- Apply it to Equinix Metal

This PR has been tested manually and it works well.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `disable_auto_update` option to example Terraform configs for AWS, Azure, OpenStack, and vSphere, used to disable automatic updates for all Flatcar nodes
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 