### PR TITLE
Disable the KubeOneCluster v1beta3 API

### DIFF
--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -51,7 +51,7 @@ var (
 	// AllowedAPIs contains APIs which are allowed to be used
 	AllowedAPIs = map[string]string{
 		kubeonev1beta2.SchemeGroupVersion.String(): "",
-		kubeonev1beta3.SchemeGroupVersion.String(): "",
+		// kubeonev1beta3.SchemeGroupVersion.String(): "",
 	}
 
 	// DeprecatedAPIs contains APIs which are deprecated
@@ -143,13 +143,13 @@ func BytesToKubeOneCluster(cluster, tfOutput, credentialsFile []byte, logger log
 		}
 
 		return DefaultedV1Beta2KubeOneCluster(v1beta2Cluster, tfOutput, credentialsFile, logger)
-	case kubeonev1beta3.SchemeGroupVersion.String():
-		v1beta3Cluster := kubeonev1beta3.NewKubeOneCluster()
-		if err := runtime.DecodeInto(kubeonescheme.Codecs.UniversalDecoder(), cluster, v1beta3Cluster); err != nil {
-			return nil, fail.Config(err, fmt.Sprintf("decoding %s", v1beta3Cluster.GroupVersionKind()))
-		}
+	// case kubeonev1beta3.SchemeGroupVersion.String():
+	// 	v1beta3Cluster := kubeonev1beta3.NewKubeOneCluster()
+	// 	if err := runtime.DecodeInto(kubeonescheme.Codecs.UniversalDecoder(), cluster, v1beta3Cluster); err != nil {
+	// 		return nil, fail.Config(err, fmt.Sprintf("decoding %s", v1beta3Cluster.GroupVersionKind()))
+	// 	}
 
-		return DefaultedV1Beta3KubeOneCluster(v1beta3Cluster, tfOutput, credentialsFile, logger)
+	// 	return DefaultedV1Beta3KubeOneCluster(v1beta3Cluster, tfOutput, credentialsFile, logger)
 	default:
 		return nil, fail.Config(fmt.Errorf("invalid api version %q", typeMeta.APIVersion), "api version")
 	}

--- a/pkg/cmd/config-dump.go
+++ b/pkg/cmd/config-dump.go
@@ -27,7 +27,6 @@ import (
 	"k8c.io/kubeone/pkg/apis/kubeone/config"
 	kubeonescheme "k8c.io/kubeone/pkg/apis/kubeone/scheme"
 	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
-	kubeonev1beta3 "k8c.io/kubeone/pkg/apis/kubeone/v1beta3"
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/templates"
 
@@ -101,13 +100,13 @@ func dumpConfig(opts *configDumpOpts) error {
 		}
 
 		objs = append(objs, versionedCluster)
-	case kubeonev1beta3.SchemeGroupVersion.String():
-		versionedCluster := kubeonev1beta3.NewKubeOneCluster()
-		if cErr := kubeonescheme.Scheme.Convert(cluster, versionedCluster, nil); cErr != nil {
-			return fail.Config(cErr, fmt.Sprintf("converting %s to internal object", versionedCluster.GroupVersionKind()))
-		}
+	// case kubeonev1beta3.SchemeGroupVersion.String():
+	// 	versionedCluster := kubeonev1beta3.NewKubeOneCluster()
+	// 	if cErr := kubeonescheme.Scheme.Convert(cluster, versionedCluster, nil); cErr != nil {
+	// 		return fail.Config(cErr, fmt.Sprintf("converting %s to internal object", versionedCluster.GroupVersionKind()))
+	// 	}
 
-		objs = append(objs, versionedCluster)
+	// 	objs = append(objs, versionedCluster)
 	default:
 		return fail.ConfigError{
 			Op:  "checking KubeOneCluster apiVersion",

--- a/pkg/cmd/config-images.go
+++ b/pkg/cmd/config-images.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	kubeonev1beta3 "k8c.io/kubeone/pkg/apis/kubeone/v1beta3"
+	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/templates/images"
 
@@ -120,7 +120,7 @@ func listImages(opts *listImagesOpts) error {
 	if configErr == nil {
 		// Custom loading of the config is needed to avoid "normal" validation process, but we here don't care about
 		// validity of the config, the only part that's needed is `.RegistryConfiguration`
-		var conf kubeonev1beta3.KubeOneCluster
+		var conf kubeonev1beta2.KubeOneCluster
 		if err := yaml.Unmarshal(configBuf, &conf); err != nil {
 			return err
 		}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -31,8 +31,7 @@ import (
 	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v2"
 
-	"k8c.io/kubeone/pkg/apis/kubeone/config"
-	kubeonev1beta3 "k8c.io/kubeone/pkg/apis/kubeone/v1beta3"
+	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
 	"k8c.io/kubeone/pkg/containerruntime"
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
@@ -200,7 +199,7 @@ func configPrintCmd() *cobra.Command {
 }
 
 // configMigrateCmd setups the migrate command
-func configMigrateCmd(rootFlags *pflag.FlagSet) *cobra.Command {
+func configMigrateCmd(_ *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Migrate the v1beta2 KubeOneCluster manifest to the v1beta3 version",
@@ -214,12 +213,14 @@ The new manifest is printed on the standard output.
 		Example:       `kubeone config migrate --manifest mycluster.yaml`,
 		SilenceErrors: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			gopts, err := persistentGlobalOptions(rootFlags)
-			if err != nil {
-				return err
-			}
+			// gopts, err := persistentGlobalOptions(rootFlags)
+			// if err != nil {
+			// 	return err
+			// }
 
-			return runMigrate(gopts)
+			// return runMigrate(gopts)
+
+			return errors.New("migrating to the v1beta3 API is not possible in this KubeOne version")
 		},
 	}
 
@@ -279,7 +280,8 @@ func runPrint(printOptions *printOpts) error {
 			return fail.Runtime(err, "executing example-manifest template")
 		}
 
-		cfg := kubeonev1beta3.NewKubeOneCluster()
+		// cfg := kubeonev1beta3.NewKubeOneCluster()
+		cfg := kubeonev1beta2.NewKubeOneCluster()
 		err = kyaml.UnmarshalStrict(buffer.Bytes(), &cfg)
 		if err != nil {
 			return fail.Runtime(err, "testing marshal/unmarshal")
@@ -463,28 +465,28 @@ func parseControlPlaneHosts(cfg *yamled.Document, hostList string) error {
 }
 
 // runMigrate migrates the KubeOneCluster manifest from v1alpha1 to v1beta1
-func runMigrate(opts *globalOptions) error {
-	var (
-		tfOutput []byte
-		err      error
-	)
+// func runMigrate(opts *globalOptions) error {
+// 	var (
+// 		tfOutput []byte
+// 		err      error
+// 	)
 
-	if opts.TerraformState != "" {
-		tfOutput, err = config.TFOutput(opts.TerraformState)
-		if err != nil {
-			return err
-		}
-	}
+// 	if opts.TerraformState != "" {
+// 		tfOutput, err = config.TFOutput(opts.TerraformState)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
 
-	v1beta3Manifest, err := config.MigrateV1beta2V1beta3(opts.ManifestFile, tfOutput)
-	if err != nil {
-		return err
-	}
+// 	v1beta3Manifest, err := config.MigrateV1beta2V1beta3(opts.ManifestFile, tfOutput)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	fmt.Printf("%s\n", v1beta3Manifest)
+// 	fmt.Printf("%s\n", v1beta3Manifest)
 
-	return nil
-}
+// 	return nil
+// }
 
 // runGenerateMachineDeployments generates the MachineDeployments manifest
 func runGenerateMachineDeployments(opts *globalOptions) error {
@@ -512,7 +514,7 @@ func validateAndPrintConfig(cfgYaml interface{}) error {
 		return fail.Runtime(err, "marshalling new config as YAML")
 	}
 
-	cfg := kubeonev1beta3.NewKubeOneCluster()
+	cfg := kubeonev1beta2.NewKubeOneCluster()
 	if err = kyaml.UnmarshalStrict(buffer.Bytes(), &cfg); err != nil {
 		return fail.Runtime(err, "testing marshal/unmarshal")
 	}

--- a/pkg/cmd/example-manifest.tmpl.yaml
+++ b/pkg/cmd/example-manifest.tmpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: {{ .ClusterName }}
 
@@ -154,6 +154,11 @@ features:
       # configFilePath is is a required field.
       # More info: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#configuration-file-format-1
       configFilePath: ""
+  # Enables PodSecurityPolicy admission plugin in API server, as well as creates
+  # default 'privileged' PodSecurityPolicy, plus RBAC rules to authorize
+  # 'kube-system' namespace pods to 'use' it.
+  podSecurityPolicy:
+    enable: {{ .EnablePodSecurityPolicy }}
   # Enables and configures audit log backend.
   # More info: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend
   staticAuditLog:
@@ -258,40 +263,33 @@ registryConfiguration:
 
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
 addons:
+  enable: false
   # In case when the relative path is provided, the path is relative
   # to the KubeOne configuration file.
   # This path is required only if you want to provide custom addons or override
   # embedded addons.
   path: "./addons"
+  # globalParams is a key-value map of values passed to the addons templating engine,
+  # to be used in the addons' manifests. The values defined here are passed to all
+  # addons.
+  globalParams:
+    key: value
   # addons is used to enable addons embedded in the KubeOne binary.
   # Currently backups-restic, default-storage-class, and unattended-upgrades are
   # available addons.
   # Check out the documentation to find more information about what are embedded
   # addons and how to use them:
-  # https://docs.kubermatic.com/kubeone/main/guides/addons/
+  # https://docs.kubermatic.com/kubeone/v1.8/guides/addons/
   addons:
-    - addon:
-        # name of the addon to be enabled/deployed (e.g. backups-restic)
-        name: "custom-addon"
-        # delete triggers deletion of the deployed addon
-        delete: false
-        # params is a key-value map of values passed to the addons templating engine,
-        # to be used in the addon's manifests. Values defined here override the values
-        # defined in globalParams.
-        params:
-          key: value
-
-    # helm chart can be also deployed as an addon
-    - helmRelease:
-        chart: flannel
-        repoURL: https://flannel-io.github.io/flannel/
-        namespace: kube-system
-        version: v0.25.4
-        values:
-          - valuesFile: path/to/custom-values.yaml
-          - inline:
-              custom:
-                values: variable-value
+    # name of the addon to be enabled/deployed (e.g. backups-restic)
+    - name: ""
+      # delete triggers deletion of the deployed addon
+      delete: false
+      # params is a key-value map of values passed to the addons templating engine,
+      # to be used in the addon's manifests. Values defined here override the values
+      # defined in globalParams.
+      params:
+        key: value
 
 # The list of nodes can be overwritten by providing Terraform output.
 # You are strongly encouraged to provide an odd number of nodes and

--- a/test/e2e/testdata/containerd_calico_external.yaml
+++ b/test/e2e/testdata/containerd_calico_external.yaml
@@ -1,8 +1,11 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
   kubernetes: "{{ required ".VERSION is required" .VERSION }}"
+    
+containerRuntime:
+  containerd: {}
 
 clusterNetwork:
   cni:
@@ -12,8 +15,7 @@ cloudProvider:
   external: true
 
 addons:
+  enable: true
   addons:
-    - addon:
-        name: default-storage-class
-    - addon:
-        name: calico-vxlan
+  - name: default-storage-class
+  - name: calico-vxlan

--- a/test/e2e/testdata/containerd_cilium_external.yaml
+++ b/test/e2e/testdata/containerd_cilium_external.yaml
@@ -1,8 +1,11 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
   kubernetes: "{{ required ".VERSION is required" .VERSION }}"
+    
+containerRuntime:
+  containerd: {}
 
 clusterNetwork:
   cni:
@@ -13,6 +16,6 @@ cloudProvider:
   external: true
 
 addons:
+  enable: true
   addons:
-    - addon:
-        name: default-storage-class
+  - name: default-storage-class

--- a/test/e2e/testdata/containerd_flannel_helm_external.yaml
+++ b/test/e2e/testdata/containerd_flannel_helm_external.yaml
@@ -1,19 +1,23 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
   kubernetes: "{{ required ".VERSION is required" .VERSION }}"
+
+containerRuntime:
+  containerd: {}
 
 clusterNetwork:
   cni:
     external: {}
 
 addons:
+  enable: true
   addons:
-    - addon:
-        name: default-storage-class
-    - helmRelease:
-        chart: flannel
-        repoURL: https://flannel-io.github.io/flannel/
-        namespace: kube-system
-        version: v0.25.4
+  - name: default-storage-class
+
+helmReleases:
+  - chart: flannel
+    repoURL: https://flannel-io.github.io/flannel/
+    namespace: kube-system
+    version: v0.25.4

--- a/test/e2e/testdata/containerd_simple_external.yaml
+++ b/test/e2e/testdata/containerd_simple_external.yaml
@@ -1,13 +1,16 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
   kubernetes: "{{ required ".VERSION is required" .VERSION }}"
 
-cloudProvider:
-  external: true
+containerRuntime:
+  containerd: {}
 
 addons:
+  enable: true
   addons:
-    - addon:
-        name: default-storage-class
+  - name: default-storage-class
+
+cloudProvider:
+  external: true

--- a/test/e2e/testdata/kube_proxy_ipvs_external.yaml
+++ b/test/e2e/testdata/kube_proxy_ipvs_external.yaml
@@ -1,8 +1,11 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
   kubernetes: "{{ required ".VERSION is required" .VERSION }}"
+    
+containerRuntime:
+  containerd: {}
 
 clusterNetwork:
   kubeProxy:
@@ -13,6 +16,6 @@ cloudProvider:
   external: true
 
 addons:
+  enable: true
   addons:
-    - addon:
-        name: default-storage-class
+  - name: default-storage-class

--- a/test/e2e/testdata/legacy_machine_controller_containerd_external.yaml
+++ b/test/e2e/testdata/legacy_machine_controller_containerd_external.yaml
@@ -1,8 +1,11 @@
-apiVersion: kubeone.k8c.io/v1beta3
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
   kubernetes: "{{ required ".VERSION is required" .VERSION }}"
+
+containerRuntime:
+  containerd: {}
 
 operatingSystemManager:
   deploy: false
@@ -11,6 +14,6 @@ cloudProvider:
   external: true
 
 addons:
+  enable: true
   addons:
-    - addon:
-        name: default-storage-class
+  - name: default-storage-class


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disables the KubeOneCluster v1beta3 API as we decided to give it some more development and testing time, then release it in KubeOne 1.10.

This PR is supposed to be reverted after KubeOne 1.9 is released. To make it easier, some code was commented instead of removed, to avoid some potential conflicts.

**Which issue(s) this PR fixes**:
Fixes #3405

**What type of PR is this?**
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Disable the KubeOneCluster v1beta3 API to give it additional development and testing time, the new API will be released in KubeOne 1.10
```

**Documentation**:
```documentation
TBD
```
(we'll have to shuffle release notes a bit for both 1.9 and 1.10)

/assign @kron4eg 