### PR TITLE
Update Canal, Calico VXLAN, and metrics-server

### DIFF
--- a/addons/calico-vxlan/Kustomization
+++ b/addons/calico-vxlan/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/projectcalico/calico/v3.27.2/manifests/calico-vxlan.yaml
+  - https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico-vxlan.yaml
 
 patches:
   - patch: |-

--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -309,7 +309,7 @@ spec:
                   description: Selector for the nodes that should have this peering.  When this is set, the Node field must be empty.
                   type: string
                 numAllowedLocalASNumbers:
-                  description: Maximum number of local AS numbers that are allowed in the AS path for received routes. This removes BGP loop prevention and should only be used if absolutely necesssary.
+                  description: Maximum number of local AS numbers that are allowed in the AS path for received routes. This removes BGP loop prevention and should only be used if absolutely necessary.
                   format: int32
                   type: integer
                 password:
@@ -798,7 +798,7 @@ spec:
                     - Disabled
                   type: string
                 bpfKubeProxyEndpointSlicesEnabled:
-                  description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                  description: BPFKubeProxyEndpointSlicesEnabled is deprecated and has no effect. BPF kube-proxy always accepts endpoint slices. This option will be removed in the next release.
                   type: boolean
                 bpfKubeProxyIptablesCleanupEnabled:
                   description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s iptables chains.  Should only be enabled if kube-proxy is not running.  [Default: true]'
@@ -861,9 +861,18 @@ spec:
                   type: string
                 debugDisableLogDropping:
                   type: boolean
+                debugHost:
+                  description: DebugHost is the host IP or hostname to bind the debug port to.  Only used if DebugPort is set. [Default:localhost]
+                  type: string
                 debugMemoryProfilePath:
                   type: string
+                debugPort:
+                  description: DebugPort if set, enables Felix's debug HTTP port, which allows memory and CPU profiles to be retrieved.  The debug port is not secure, it should not be exposed to the internet.
+                  type: integer
                 debugSimulateCalcGraphHangAfter:
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneApplyDelay:
                   pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                   type: string
                 debugSimulateDataplaneHangAfter:
@@ -889,6 +898,9 @@ spec:
                   type: string
                 endpointReportingEnabled:
                   type: boolean
+                endpointStatusPathPrefix:
+                  description: "EndpointStatusPathPrefix is the path to the directory where endpoint status will be written. Endpoint status file reporting is disabled if field is left empty. \n Chosen directory should match the directory used by the CNI for PodStartupDelay. [Default: \"\"]"
+                  type: string
                 externalNodesList:
                   description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes which may source tunnel traffic and have the tunneled traffic be accepted at calico nodes.
                   items:
@@ -1057,7 +1069,7 @@ spec:
                 maxIpsetSize:
                   type: integer
                 metadataAddr:
-                  description: 'MetadataAddr is the IP address or domain name of the server that can answer VM queries for cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu, nova-api-metadata). A value of none (case insensitive) means that Felix should not set up any NAT rule for the metadata path. [Default: 127.0.0.1]'
+                  description: 'MetadataAddr is the IP address or domain name of the server that can answer VM queries for cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu, nova-api-metadata). A value of none (case-insensitive) means that Felix should not set up any NAT rule for the metadata path. [Default: 127.0.0.1]'
                   type: string
                 metadataPort:
                   description: 'MetadataPort is the port of the metadata server. This, combined with global.MetadataAddr (if not ''None''), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort. In most cases this should not need to be changed [Default: 8775].'
@@ -1699,7 +1711,7 @@ spec:
                   description: PreDNAT indicates to apply the rules in this policy before any DNAT.
                   type: boolean
                 selector:
-                  description: "The selector is an expression used to pick pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
+                  description: "The selector is an expression used to pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
                   type: string
                 serviceAccountSelector:
                   description: ServiceAccountSelector is an optional field for an expression used to select a pod based on service accounts.
@@ -2806,7 +2818,7 @@ spec:
                     type: string
                   type: array
                 selector:
-                  description: "The selector is an expression used to pick pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
+                  description: "The selector is an expression used to pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
                   type: string
                 serviceAccountSelector:
                   description: ServiceAccountSelector is an optional field for an expression used to select a pod based on service accounts.
@@ -3519,9 +3531,11 @@ spec:
           name: lib-modules
         - hostPath:
             path: /var/run/calico
+            type: DirectoryOrCreate
           name: var-run-calico
         - hostPath:
             path: /var/lib/calico
+            type: DirectoryOrCreate
           name: var-lib-calico
         - hostPath:
             path: /run/xtables.lock
@@ -3540,6 +3554,7 @@ spec:
           name: nodeproc
         - hostPath:
             path: /opt/cni/bin
+            type: DirectoryOrCreate
           name: cni-bin-dir
         - hostPath:
             path: /etc/cni/net.d

--- a/addons/cni-canal/Kustomization
+++ b/addons/cni-canal/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/canal.yaml
+  - https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/canal.yaml
 
 patches:
   - patch: |-

--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -309,7 +309,7 @@ spec:
                   description: Selector for the nodes that should have this peering.  When this is set, the Node field must be empty.
                   type: string
                 numAllowedLocalASNumbers:
-                  description: Maximum number of local AS numbers that are allowed in the AS path for received routes. This removes BGP loop prevention and should only be used if absolutely necesssary.
+                  description: Maximum number of local AS numbers that are allowed in the AS path for received routes. This removes BGP loop prevention and should only be used if absolutely necessary.
                   format: int32
                   type: integer
                 password:
@@ -798,7 +798,7 @@ spec:
                     - Disabled
                   type: string
                 bpfKubeProxyEndpointSlicesEnabled:
-                  description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                  description: BPFKubeProxyEndpointSlicesEnabled is deprecated and has no effect. BPF kube-proxy always accepts endpoint slices. This option will be removed in the next release.
                   type: boolean
                 bpfKubeProxyIptablesCleanupEnabled:
                   description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s iptables chains.  Should only be enabled if kube-proxy is not running.  [Default: true]'
@@ -861,9 +861,18 @@ spec:
                   type: string
                 debugDisableLogDropping:
                   type: boolean
+                debugHost:
+                  description: DebugHost is the host IP or hostname to bind the debug port to.  Only used if DebugPort is set. [Default:localhost]
+                  type: string
                 debugMemoryProfilePath:
                   type: string
+                debugPort:
+                  description: DebugPort if set, enables Felix's debug HTTP port, which allows memory and CPU profiles to be retrieved.  The debug port is not secure, it should not be exposed to the internet.
+                  type: integer
                 debugSimulateCalcGraphHangAfter:
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneApplyDelay:
                   pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                   type: string
                 debugSimulateDataplaneHangAfter:
@@ -889,6 +898,9 @@ spec:
                   type: string
                 endpointReportingEnabled:
                   type: boolean
+                endpointStatusPathPrefix:
+                  description: "EndpointStatusPathPrefix is the path to the directory where endpoint status will be written. Endpoint status file reporting is disabled if field is left empty. \n Chosen directory should match the directory used by the CNI for PodStartupDelay. [Default: \"\"]"
+                  type: string
                 externalNodesList:
                   description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes which may source tunnel traffic and have the tunneled traffic be accepted at calico nodes.
                   items:
@@ -1057,7 +1069,7 @@ spec:
                 maxIpsetSize:
                   type: integer
                 metadataAddr:
-                  description: 'MetadataAddr is the IP address or domain name of the server that can answer VM queries for cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu, nova-api-metadata). A value of none (case insensitive) means that Felix should not set up any NAT rule for the metadata path. [Default: 127.0.0.1]'
+                  description: 'MetadataAddr is the IP address or domain name of the server that can answer VM queries for cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu, nova-api-metadata). A value of none (case-insensitive) means that Felix should not set up any NAT rule for the metadata path. [Default: 127.0.0.1]'
                   type: string
                 metadataPort:
                   description: 'MetadataPort is the port of the metadata server. This, combined with global.MetadataAddr (if not ''None''), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort. In most cases this should not need to be changed [Default: 8775].'
@@ -1699,7 +1711,7 @@ spec:
                   description: PreDNAT indicates to apply the rules in this policy before any DNAT.
                   type: boolean
                 selector:
-                  description: "The selector is an expression used to pick pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
+                  description: "The selector is an expression used to pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
                   type: string
                 serviceAccountSelector:
                   description: ServiceAccountSelector is an optional field for an expression used to select a pod based on service accounts.
@@ -2806,7 +2818,7 @@ spec:
                     type: string
                   type: array
                 selector:
-                  description: "The selector is an expression used to pick pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
+                  description: "The selector is an expression used to pick out the endpoints that the policy should be applied to. \n Selector expressions follow this syntax: \n \tlabel == \"string_literal\"  ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"   ->  not equal; also matches if label is not present \tlabel in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is not one of \"a\", \"b\", \"c\" \thas(label_name)  -> True if that label is present \t! expr -> negation of expr \texpr && expr  -> Short-circuit and \texpr || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall() or the empty selector -> matches all endpoints. \n Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive but they do not support escape characters. \n Examples (with made-up labels): \n \ttype == \"webserver\" && deployment == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment != \"dev\" \t! has(label_name)"
                   type: string
                 serviceAccountSelector:
                   description: ServiceAccountSelector is an optional field for an expression used to select a pod based on service accounts.
@@ -3510,9 +3522,11 @@ spec:
           name: lib-modules
         - hostPath:
             path: /var/run/calico
+            type: DirectoryOrCreate
           name: var-run-calico
         - hostPath:
             path: /var/lib/calico
+            type: DirectoryOrCreate
           name: var-lib-calico
         - hostPath:
             path: /run/xtables.lock
@@ -3534,6 +3548,7 @@ spec:
           name: flannel-cfg
         - hostPath:
             path: /opt/cni/bin
+            type: DirectoryOrCreate
           name: cni-bin-dir
         - hostPath:
             path: /etc/cni/net.d

--- a/addons/metrics-server/Kustomization
+++ b/addons/metrics-server/Kustomization
@@ -5,7 +5,7 @@ namespace: kube-system
 helmCharts:
 - name: metrics-server
   repo: https://kubernetes-sigs.github.io/metrics-server/
-  version: v3.12.0
+  version: v3.12.2
   releaseName: metrics-server
   namespace: kube-system
   valuesFile: values

--- a/addons/metrics-server/metrics-server.yaml
+++ b/addons/metrics-server/metrics-server.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: metrics-server
   namespace: kube-system
 ---
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: system:metrics-server
 rules:
   - apiGroups:
@@ -46,8 +46,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -70,8 +70,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: metrics-server-auth-reader
   namespace: kube-system
 roleRef:
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: metrics-server:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109,8 +109,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: system:metrics-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -128,13 +128,14 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: metrics-server
   namespace: kube-system
 spec:
   ports:
-    - name: https
+    - appProtocol: https
+      name: https
       port: 443
       protocol: TCP
       targetPort: https
@@ -150,8 +151,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: metrics-server
   namespace: kube-system
 spec:
@@ -241,8 +242,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: metrics-server
   namespace: kube-system
 spec:
@@ -259,8 +260,8 @@ metadata:
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
-    app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-3.12.0
+    app.kubernetes.io/version: 0.7.2
+    helm.sh/chart: metrics-server-3.12.2
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -207,9 +207,9 @@ func FindResource(name string) (Resource, error) {
 
 func baseResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
-		CalicoCNI:              {"*": "quay.io/calico/cni:v3.28.1"},
-		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.28.1"},
-		CalicoNode:             {"*": "quay.io/calico/node:v3.28.1"},
+		CalicoCNI:              {"*": "quay.io/calico/cni:v3.28.2"},
+		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.28.2"},
+		CalicoNode:             {"*": "quay.io/calico/node:v3.28.2"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.23.1"},
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.60.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -213,7 +213,7 @@ func baseResources() map[Resource]map[string]string {
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.23.1"},
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.3"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.60.0"},
-		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.1"},
+		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.2"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.6.0"},
 	}
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -386,9 +386,9 @@ func optionalResources() map[Resource]map[string]string {
 		WeaveNetCNINPC:  {"*": "docker.io/weaveworks/weave-npc:2.8.1"},
 
 		// Calico VXLAN
-		CalicoVXLANCNI:        {"*": "quay.io/calico/cni:v3.26.3"},
-		CalicoVXLANController: {"*": "quay.io/calico/kube-controllers:v3.26.3"},
-		CalicoVXLANNode:       {"*": "quay.io/calico/node:v3.26.3"},
+		CalicoVXLANCNI:        {"*": "quay.io/calico/cni:v3.28.2"},
+		CalicoVXLANController: {"*": "quay.io/calico/kube-controllers:v3.28.2"},
+		CalicoVXLANNode:       {"*": "quay.io/calico/node:v3.28.2"},
 
 		// Cilium
 		Cilium:         {"*": "quay.io/cilium/cilium:v1.15.6@sha256:6aa840986a3a9722cd967ef63248d675a87add7e1704740902d5d3162f0c0def"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update Canal CNI to v3.28.2
- Update Calico VXLAN CNI addon to v3.28.2
- Update metrics-server to v0.7.2

**Which issue(s) this PR fixes**:
xref #3347 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update Canal CNI to v3.28.2
- Update Calico VXLAN CNI addon to v3.28.2
- Update metrics-server to v0.7.2
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 