### PR TITLE
Fix some of bugs discovered in the KubeOne 1.9 testing phase

### DIFF
--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -1,3 +1,4 @@
+{{ $kubernetesVersion := semver .Config.Versions.Kubernetes }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -897,6 +898,13 @@ spec:
       k8s-app: cilium
   template:
     metadata:
+      {{ if lt $kubernetesVersion.Minor 30 }}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
+        container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
+        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
+        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
+      {{ end }}
       labels:
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium
@@ -1260,9 +1268,11 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
       restartPolicy: Always
+      {{ if ge $kubernetesVersion.Minor 30 }}
       securityContext:
         appArmorProfile:
           type: Unconfined
+      {{ end }}
       serviceAccountName: cilium
       terminationGracePeriodSeconds: 1
       tolerations:
@@ -1375,6 +1385,10 @@ spec:
       k8s-app: cilium-envoy
   template:
     metadata:
+      {{ if lt $kubernetesVersion.Minor 30 }}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/cilium-envoy: unconfined
+      {{ end }}
       labels:
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium
@@ -1502,9 +1516,11 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
       restartPolicy: Always
+      {{ if ge $kubernetesVersion.Minor 30 }}
       securityContext:
         appArmorProfile:
           type: Unconfined
+      {{ end }}
       serviceAccountName: cilium-envoy
       terminationGracePeriodSeconds: 1
       tolerations:

--- a/addons/csi-external-snapshotter/webhook.yaml
+++ b/addons/csi-external-snapshotter/webhook.yaml
@@ -34,7 +34,7 @@ webhooks:
 {{ .Certificates.KubernetesCA | b64enc | indent 6 }}
   admissionReviewVersions: ["v1"]
   sideEffects: None
-  failurePolicy: Fail
+  failurePolicy: {{ .SnapshotterWebhookFailurePolicy }}
   timeoutSeconds: 2
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -59,7 +59,7 @@ webhooks:
 {{ .Certificates.KubernetesCA | b64enc | indent 6 }}
   admissionReviewVersions: ["v1"]
   sideEffects: None
-  failurePolicy: Fail
+  failurePolicy: {{ .SnapshotterWebhookFailurePolicy }}
   timeoutSeconds: 2
 ---
 apiVersion: apps/v1

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -62,7 +62,7 @@ No modules.
 | <a name="input_cluster_autoscaler_max_replicas"></a> [cluster\_autoscaler\_max\_replicas](#input\_cluster\_autoscaler\_max\_replicas) | maximum number of replicas per MachineDeployment (requires cluster-autoscaler) | `number` | `0` | no |
 | <a name="input_cluster_autoscaler_min_replicas"></a> [cluster\_autoscaler\_min\_replicas](#input\_cluster\_autoscaler\_min\_replicas) | minimum number of replicas per MachineDeployment (requires cluster-autoscaler) | `number` | `0` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
-| <a name="input_control_plane_image_family"></a> [control\_plane\_image\_family](#input\_control\_plane\_image\_family) | Image family to use for provisioning instances | `string` | `"ubuntu-2404-lts"` | no |
+| <a name="input_control_plane_image_family"></a> [control\_plane\_image\_family](#input\_control\_plane\_image\_family) | Image family to use for provisioning instances | `string` | `"ubuntu-2404-lts-amd64"` | no |
 | <a name="input_control_plane_image_project"></a> [control\_plane\_image\_project](#input\_control\_plane\_image\_project) | Project of the image to use for provisioning instances | `string` | `"ubuntu-os-cloud"` | no |
 | <a name="input_control_plane_target_pool_members_count"></a> [control\_plane\_target\_pool\_members\_count](#input\_control\_plane\_target\_pool\_members\_count) | n/a | `number` | `3` | no |
 | <a name="input_control_plane_type"></a> [control\_plane\_type](#input\_control\_plane\_type) | GCE instance type | `string` | `"n1-standard-2"` | no |

--- a/examples/terraform/gce/variables.tf
+++ b/examples/terraform/gce/variables.tf
@@ -124,7 +124,7 @@ variable "control_plane_volume_size" {
 }
 
 variable "control_plane_image_family" {
-  default     = "ubuntu-2404-lts"
+  default     = "ubuntu-2404-lts-amd64"
   description = "Image family to use for provisioning instances"
   type        = string
 }

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -78,6 +78,7 @@ type templateData struct {
 	CSIMigrationFeatureGates                 string
 	CalicoIptablesBackend                    string
 	DeployCSIAddon                           bool
+	SnapshotterWebhookFailurePolicy          string
 	MachineControllerCredentialsEnvVars      string
 	MachineControllerCredentialsHash         string
 	OperatingSystemManagerEnabled            bool
@@ -199,6 +200,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		CSIMigrationFeatureGates:            csiMigrationFeatureGates,
 		CalicoIptablesBackend:               calicoIptablesBackend,
 		DeployCSIAddon:                      deployCSI,
+		SnapshotterWebhookFailurePolicy:     "Fail",
 		MachineControllerCredentialsEnvVars: string(credsEnvVarsMC),
 		MachineControllerCredentialsHash:    mcCredsHash,
 		OperatingSystemManagerEnabled:       s.Cluster.OperatingSystemManager.Deploy,
@@ -209,6 +211,10 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		},
 		Resources: resources.All(),
 		Params:    map[string]string{},
+	}
+
+	if !s.LiveCluster.IsProvisioned() {
+		data.SnapshotterWebhookFailurePolicy = "Ignore"
 	}
 
 	if err := csiWebhookCerts(s, &data, csiMigration, kubeCAPrivateKey, kubeCACert); err != nil {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -706,7 +706,7 @@ func NewSignalContext(logger func(format string, args ...any)) context.Context {
 	// but `sonobuoy wait` will continue running until the ProwJob doesn't
 	// timeout. This also means, because the main process has been terminated,
 	// there will be NO cleanup, so we'll leak resources.
-	testTimeout := time.Hour
+	testTimeout := 120 * time.Minute
 	if timeout, ok := os.LookupEnv("TEST_TIMEOUT"); ok {
 		if parsedDuration, err := time.ParseDuration(timeout); err == nil {
 			testTimeout = parsedDuration


### PR DESCRIPTION
**What this PR does / why we need it**:

- Properly handle AppArmor policies for Cilium
  - The latest Cilium manifests and Helm chart are using the `appArmorProfile` field in `securityContext` to set the needed AppArmor profile. However, this field is only available starting with Kubernetes v1.30. Prior versions shall still use annotations, which is ensured by this change
- Initially deploy CSI Snapshotter webhook with `failurePolicy: Ignore`
  - This is a tricky one. First of all, it's recommended by [the CSI Snapshotter maintainers](https://github.com/kubernetes-csi/external-snapshotter/blob/d5c03dbde7ca6664707c05870eae3de4255766fb/deploy/kubernetes/webhook-example/admission-configuration-template#L21) to do it that way, i.e. deploy with `failurePolicy: Ignore` then change to `failurePolicy: Fail`. Second, we have a problem in our flow, because we first deploy this webhook, then we deploy the built-in addons (including `default-storage-class`), and then at the end we deploy user-provided addons. This is a problem when using an external CNI. That's because KubeOne will deploy the CSI Snapshotter webhook, which will wait for CNI. When trying to deploy `default-storage-class` addon, it would fail to do so, because the webhook is not running. CNI is not yet deployed, it's supposed to be deployed at the very end. To avoid this situation, we allow the webhook to run in the Ignore mode, and then change it to the Fail mode on subsequent `kubeone apply` run
- Fix GCP Ubuntu 24.04 image
- Increase context timeout in tests to 120m
  - This was the cause of flakes we were observing recently. The context had a timeout out 1 hour - 5 minutes, but tests have timeout of 2 hours by default. Because the context would timeout, we weren't able to continue running tests, even though the test itself wasn't supposed to timeout.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

All these changes are already thoroughly tested within testing PRs.

There still some bugs affecting the example Terraform configs for Azure, those are yet to be fixed in a follow up PR.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 