### PR TITLE
Add an option to skip specific Sonobuoy E2E tests

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -628,11 +628,11 @@ func waitKubeOneNodesReady(ctx context.Context, t *testing.T, k1 *kubeoneBin) {
 	}
 }
 
-func sonobuoyRun(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, proxyURL string) {
-	sonobuoyRunWithRunCount(ctx, t, k1, mode, t.TempDir(), 0, proxyURL)
+func sonobuoyRun(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, skipTests, proxyURL string) {
+	sonobuoyRunWithRunCount(ctx, t, k1, mode, skipTests, t.TempDir(), 0, proxyURL)
 }
 
-func sonobuoyRunWithRunCount(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, testDir string, runCount int, proxyURL string) {
+func sonobuoyRunWithRunCount(ctx context.Context, t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, skipTests, testDir string, runCount int, proxyURL string) {
 	kubeconfigPath, err := k1.kubeconfigPath(t.TempDir())
 	if err != nil {
 		t.Fatalf("fetching kubeconfig failed")
@@ -649,7 +649,7 @@ func sonobuoyRunWithRunCount(ctx context.Context, t *testing.T, k1 *kubeoneBin, 
 		rerunFailed = true
 	}
 
-	if err = retryFnWithBackoff(SonobuoyRetry, func() error { return sb.Run(ctx, mode, rerunFailed) }); err != nil {
+	if err = retryFnWithBackoff(SonobuoyRetry, func() error { return sb.Run(ctx, mode, skipTests, rerunFailed) }); err != nil {
 		t.Fatalf("sonobuoy run failed: %v", err)
 	}
 
@@ -690,7 +690,7 @@ func sonobuoyRunWithRunCount(ctx context.Context, t *testing.T, k1 *kubeoneBin, 
 			}
 
 			t.Logf("restarting failed e2e tests (try %d/%d)...", runCount+1, sonobuoyRunRetries)
-			sonobuoyRunWithRunCount(ctx, t, k1, mode, testDir, runCount+1, proxyURL)
+			sonobuoyRunWithRunCount(ctx, t, k1, mode, skipTests, testDir, runCount+1, proxyURL)
 		} else {
 			t.Fatalf("some e2e tests failed:\n%s", buf.String())
 		}

--- a/test/e2e/scenario_conformance.go
+++ b/test/e2e/scenario_conformance.go
@@ -28,6 +28,7 @@ type scenarioConformance struct {
 	Name                 string
 	HumanReadableName    string
 	ManifestTemplatePath string
+	SkipTests            string
 
 	versions []string
 	infra    Infra
@@ -146,5 +147,5 @@ func (scenario *scenarioConformance) test(ctx context.Context, t *testing.T) {
 	cpTests := newCloudProviderTests(client, scenario.infra.Provider())
 	cpTests.runWithCleanup(t)
 
-	sonobuoyRun(ctx, t, k1, sonobuoyConformance, proxyURL)
+	sonobuoyRun(ctx, t, k1, sonobuoyConformance, scenario.SkipTests, proxyURL)
 }

--- a/test/e2e/scenario_install.go
+++ b/test/e2e/scenario_install.go
@@ -32,6 +32,7 @@ type scenarioInstall struct {
 	Name                 string
 	HumanReadableName    string
 	ManifestTemplatePath string
+	SkipTests            string
 
 	versions    []string
 	infra       Infra
@@ -187,7 +188,7 @@ func (scenario *scenarioInstall) test(ctx context.Context, t *testing.T) {
 	cpTests := newCloudProviderTests(client, scenario.infra.Provider())
 	cpTests.runWithCleanup(t)
 
-	sonobuoyRun(ctx, t, k1, sonobuoyConformanceLite, proxyURL)
+	sonobuoyRun(ctx, t, k1, sonobuoyConformanceLite, scenario.SkipTests, proxyURL)
 }
 
 func (scenario *scenarioInstall) GenerateTests(wr io.Writer, generatorType GeneratorType, cfg ProwConfig) error {

--- a/test/e2e/scenario_migrate_csi_ccm.go
+++ b/test/e2e/scenario_migrate_csi_ccm.go
@@ -34,6 +34,7 @@ type scenarioMigrateCSIAndCCM struct {
 	HumanReadableName       string
 	OldManifestTemplatePath string
 	NewManifestTemplatePath string
+	SkipTests               string
 
 	versions []string
 	infra    Infra

--- a/test/e2e/scenario_upgrade.go
+++ b/test/e2e/scenario_upgrade.go
@@ -44,6 +44,7 @@ type scenarioUpgrade struct {
 	Name                 string
 	HumanReadableName    string
 	ManifestTemplatePath string
+	SkipTests            string
 
 	versions           []string
 	initKubeOneVersion string
@@ -191,7 +192,7 @@ func (scenario *scenarioUpgrade) test(ctx context.Context, t *testing.T) {
 	cpTests.runWithCleanup(t)
 
 	// sonobuoyRun(t, k1, sonobuoyConformanceLite, proxyURL)
-	sonobuoyRun(ctx, t, k1, sonobuoyQuick, proxyURL)
+	sonobuoyRun(ctx, t, k1, sonobuoyQuick, scenario.SkipTests, proxyURL)
 }
 
 func (scenario *scenarioUpgrade) GenerateTests(wr io.Writer, generatorType GeneratorType, cfg ProwConfig) error {

--- a/test/e2e/sonobuoy.go
+++ b/test/e2e/sonobuoy.go
@@ -58,9 +58,11 @@ type sonobuoyBin struct {
 	proxyURL   string
 }
 
-func (sbb *sonobuoyBin) Run(ctx context.Context, mode sonobuoyMode, rerunFailed bool) error {
+func (sbb *sonobuoyBin) Run(ctx context.Context, mode sonobuoyMode, skipTests string, rerunFailed bool) error {
 	if rerunFailed {
 		return sbb.run(ctx, "run", fmt.Sprintf("--rerun-failed=%s", sonobuoyResultsFile))
+	} else if skipTests != "" {
+		return sbb.run(ctx, "run", fmt.Sprintf("--mode=%s", mode), fmt.Sprintf("--e2e-skip=%s", skipTests))
 	}
 
 	return sbb.run(ctx, "run", fmt.Sprintf("--mode=%s", mode))

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -1178,6 +1178,7 @@ var (
 			Name:                 "cilium_containerd_external",
 			HumanReadableName:    "Cluster Provisioning (External, Cilium)",
 			ManifestTemplatePath: "testdata/containerd_cilium_external.yaml",
+			SkipTests:            "Services.should.have.session.affinity.work.for.service.with.type.clusterIP|Services.should.serve.endpoints.on.same.port.and.different.protocols|HostPort.validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol",
 		},
 		"upgrade_cilium_containerd_external": &scenarioUpgrade{
 			Name:                 "upgrade_cilium_containerd_external",


### PR DESCRIPTION
**What this PR does / why we need it**:

Some Sonobuoy/Kubernetes E2E tests are permanently failing on Cilium clusters:

```
    helpers.go:685: some e2e tests failed:
        [
          {
            "name": "[It] [sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]",
            "status": "failed",
            "details": {}
          },
          {
            "name": "[It] [sig-network] Services should serve endpoints on same port and different protocols [Conformance]",
            "status": "failed",
            "details": {}
          },
          {
            "name": "[It] [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]",
            "status": "failed",
            "details": {}
          }
        ]
```

This is a known issue for many years now, and we always ignored those failures. However, it's annoying to have the job being red, so this PR implements a mechanism that allows us to skip running tests that are known not to work. We use this mechanism only for those three tests on Cilium clusters.

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 