### PR TITLE
Fix wrong infrastructure name for openstack_rockylinux_stable

### DIFF
--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -2518,14 +2518,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.29-to-v1.30
+  name: pull-kubeone-e2e-openstack-rockylinux-stable-upgrade-containerd-external-from-v1.29-to-v1.30
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_29_ToV1_30
+      - TestOpenstackRockylinuxStableUpgradeContainerdExternalFromV1_29_ToV1_30
       env:
       - name: PROVIDER
         value: openstack
@@ -3259,14 +3259,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.30-to-v1.31
+  name: pull-kubeone-e2e-openstack-rockylinux-stable-upgrade-containerd-external-from-v1.30-to-v1.31
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_30_ToV1_31
+      - TestOpenstackRockylinuxStableUpgradeContainerdExternalFromV1_30_ToV1_31
       env:
       - name: PROVIDER
         value: openstack
@@ -9316,14 +9316,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-cilium-containerd-external-from-v1.29-to-v1.30
+  name: pull-kubeone-e2e-openstack-rockylinux-stable-upgrade-cilium-containerd-external-from-v1.29-to-v1.30
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_29_ToV1_30
+      - TestOpenstackRockylinuxStableUpgradeCiliumContainerdExternalFromV1_29_ToV1_30
       env:
       - name: PROVIDER
         value: openstack
@@ -10027,14 +10027,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-cilium-containerd-external-from-v1.30-to-v1.31
+  name: pull-kubeone-e2e-openstack-rockylinux-stable-upgrade-cilium-containerd-external-from-v1.30-to-v1.31
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_30_ToV1_31
+      - TestOpenstackRockylinuxStableUpgradeCiliumContainerdExternalFromV1_30_ToV1_31
       env:
       - name: PROVIDER
         value: openstack

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -906,7 +906,7 @@ var (
 			},
 		},
 		"openstack_rockylinux_stable": {
-			name:   "openstack_rockylinux",
+			name:   "openstack_rockylinux_stable",
 			osName: "Rocky Linux",
 			labels: map[string]string{
 				"preset-goproxy":   "true",

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -1126,9 +1126,9 @@ func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_29_ToV1_30(t *testin
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_29_ToV1_30(t *testing.T) {
+func TestOpenstackRockylinuxStableUpgradeContainerdExternalFromV1_29_ToV1_30(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_rockylinux"]
+	infra := Infrastructures["openstack_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29", "v1.30")
@@ -1414,9 +1414,9 @@ func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_30_ToV1_31(t *testin
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_30_ToV1_31(t *testing.T) {
+func TestOpenstackRockylinuxStableUpgradeContainerdExternalFromV1_30_ToV1_31(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_rockylinux"]
+	infra := Infrastructures["openstack_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30", "v1.31")
@@ -4174,9 +4174,9 @@ func TestOpenstackRhelStableUpgradeCiliumContainerdExternalFromV1_29_ToV1_30(t *
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_29_ToV1_30(t *testing.T) {
+func TestOpenstackRockylinuxStableUpgradeCiliumContainerdExternalFromV1_29_ToV1_30(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_rockylinux"]
+	infra := Infrastructures["openstack_rockylinux_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.29", "v1.30")
@@ -4450,9 +4450,9 @@ func TestOpenstackRhelStableUpgradeCiliumContainerdExternalFromV1_30_ToV1_31(t *
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeCiliumContainerdExternalFromV1_30_ToV1_31(t *testing.T) {
+func TestOpenstackRockylinuxStableUpgradeCiliumContainerdExternalFromV1_30_ToV1_31(t *testing.T) {
 	ctx := NewSignalContext(t.Logf)
-	infra := Infrastructures["openstack_rockylinux"]
+	infra := Infrastructures["openstack_rockylinux_stable"]
 	scenario := Scenarios["upgrade_cilium_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.30", "v1.31")


### PR DESCRIPTION
**What this PR does / why we need it**:

The `openstack_rockylinux_stable` infrastructure definition had a wrong `name` property, which caused the relevant jobs to have an incorrect name.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 