### PR TITLE
Undeprecate KubeOneCluster v1beta2 API

### DIFF
--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -56,7 +56,7 @@ var (
 
 	// DeprecatedAPIs contains APIs which are deprecated
 	DeprecatedAPIs = map[string]string{
-		kubeonev1beta2.SchemeGroupVersion.String(): "",
+		// kubeonev1beta2.SchemeGroupVersion.String(): "",
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We decided not to ship v1beta3 API in KubeOne 1.9, so let's un-deprecate the v1beta2 for the time being.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 