### PR TITLE
goreleaser: replace --rm-dist flag with --clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
 	-X k8c.io/kubeone/pkg/cmd.commit=$(GITCOMMIT) \
 	-X k8c.io/kubeone/pkg/cmd.date=$(BUILD_DATE)
 
-# TODO(xmudrii): Rename the flag to "--clean" after updating goreleaser.
-GORELEASER_FLAGS ?= --rm-dist
+GORELEASER_FLAGS ?= --clean
 
 .PHONY: all
 all: install


### PR DESCRIPTION
**What this PR does / why we need it**:

As per [GoReleaser Deprecation Notices](https://goreleaser.com/deprecations/#-rm-dist), the `--rm-dist` flag was deprecated in favor of the `--clean` flag. Since the latest GoReleaser version, the `--rm-dist` flag is not available any longer:

```
goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
```

This PR ensures we use the correct flag in our release script/pipeline.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 