### PR TITLE
return empty list instead of nil to not break the ui

### DIFF
--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -193,6 +193,11 @@ func getMachineDeployments(state *state.State) ([]machineDeployment, error) {
 		return nil, fail.NoKubeClient()
 	}
 
+	result := []machineDeployment{}
+	if !state.Cluster.MachineController.Deploy {
+		return result, nil
+	}
+
 	machineDeployments := clusterv1alpha1.MachineDeploymentList{}
 	err := state.DynamicClient.List(
 		state.Context,
@@ -203,7 +208,6 @@ func getMachineDeployments(state *state.State) ([]machineDeployment, error) {
 		return nil, err
 	}
 
-	result := []machineDeployment{}
 	for i := range machineDeployments.Items {
 		currMachineDeployment := &machineDeployments.Items[i]
 		machines, err := getMachines(state, currMachineDeployment)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

If a kubeone cluster is only configured with static workers the ui is not rendered properly because the machinedeployment struct used for templating is nil. Instead an empty list should be returned by the function which fetches the machinedeployment list.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bug: fixed ui rendering when only static workers configured
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
