### PR TITLE
Add Support for Reading KubeVirt Infra Namespace in Cloud Provider Spec 

### DIFF
--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -54,6 +54,12 @@ spec:
             {{ end -}}
             - -join-cluster-timeout=15m
           env:
+  {{ with .Config.CloudProvider.Kubevirt -}}
+  {{ with .InfraNamespace }}
+            - name: POD_NAMESPACE
+              value: "{{ . }}"
+  {{ end }}
+  {{ end }}
             - name: HTTPS_PROXY
               value: "{{ .Config.Proxy.HTTPS }}"
             - name: NO_PROXY

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2024-10-25T14:43:23+02:00
+date = 2024-12-18T11:22:29+01:00
 weight = 11
 +++
 ## v1beta2
@@ -570,6 +570,7 @@ KubevirtSpec defines the Kubevirt provider
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| infraNamespace | InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster, such as VirtualMachines, VirtualMachineInstances, etc... | string | false |
 
 [Back to Group](#v1beta2)
 

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2024-10-25T14:43:23+02:00
+date = 2024-12-18T11:22:29+01:00
 weight = 11
 +++
 ## v1beta3
@@ -572,6 +572,7 @@ KubevirtSpec defines the Kubevirt provider
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| infraNamespace | InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster, such as VirtualMachines, VirtualMachineInstances, etc... | string | false |
 
 [Back to Group](#v1beta3)
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -439,7 +439,11 @@ type HetznerSpec struct {
 }
 
 // KubevirtSpec defines the Kubevirt provider
-type KubevirtSpec struct{}
+type KubevirtSpec struct {
+	// InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster,
+	// such as VirtualMachines, VirtualMachineInstances, etc...
+	InfraNamespace string `json:"infraNamespace,omitempty"`
+}
 
 // NutanixSpec defines the Nutanix provider
 type NutanixSpec struct{}

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -444,7 +444,11 @@ type HetznerSpec struct {
 }
 
 // KubevirtSpec defines the Kubevirt provider
-type KubevirtSpec struct{}
+type KubevirtSpec struct {
+	// InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster,
+	// such as VirtualMachines, VirtualMachineInstances, etc...
+	InfraNamespace string `json:"infraNamespace,omitempty"`
+}
 
 // NutanixSpec defines the Nutanix provider
 type NutanixSpec struct{}

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -1717,6 +1717,7 @@ func autoConvert_kubeone_KubeletConfig_To_v1beta2_KubeletConfig(in *kubeone.Kube
 }
 
 func autoConvert_v1beta2_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out *kubeone.KubevirtSpec, s conversion.Scope) error {
+	out.InfraNamespace = in.InfraNamespace
 	return nil
 }
 
@@ -1726,6 +1727,7 @@ func Convert_v1beta2_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out 
 }
 
 func autoConvert_kubeone_KubevirtSpec_To_v1beta2_KubevirtSpec(in *kubeone.KubevirtSpec, out *KubevirtSpec, s conversion.Scope) error {
+	out.InfraNamespace = in.InfraNamespace
 	return nil
 }
 

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -436,7 +436,11 @@ type HetznerSpec struct {
 }
 
 // KubevirtSpec defines the Kubevirt provider
-type KubevirtSpec struct{}
+type KubevirtSpec struct {
+	// InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster,
+	// such as VirtualMachines, VirtualMachineInstances, etc...
+	InfraNamespace string `json:"infraNamespace,omitempty"`
+}
 
 // NutanixSpec defines the Nutanix provider
 type NutanixSpec struct{}

--- a/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
@@ -1755,6 +1755,7 @@ func Convert_kubeone_KubeletConfig_To_v1beta3_KubeletConfig(in *kubeone.KubeletC
 }
 
 func autoConvert_v1beta3_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out *kubeone.KubevirtSpec, s conversion.Scope) error {
+	out.InfraNamespace = in.InfraNamespace
 	return nil
 }
 
@@ -1764,6 +1765,7 @@ func Convert_v1beta3_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out 
 }
 
 func autoConvert_kubeone_KubevirtSpec_To_v1beta3_KubevirtSpec(in *kubeone.KubevirtSpec, out *KubevirtSpec, s conversion.Scope) error {
+	out.InfraNamespace = in.InfraNamespace
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
Adding support for passing the underlying KubeVirt infra namespace where KubeVirt resources are going to be created in the infra cluster.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `InfraNamespace` field in the KubeOne API to control machine-controller KubeVirt provider resources 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
