### PR TITLE
Remove Docker GPG key before dearmor-ing it

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -55,6 +55,7 @@ var containerRuntimeTemplates = map[string]string{
 			sudo apt-get update
 			sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 			sudo install -m 0755 -d /etc/apt/keyrings
+			sudo rm -f /etc/apt/keyrings/docker.gpg
 			curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 			sudo chmod a+r /etc/apt/keyrings/docker.gpg
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -79,6 +79,7 @@ kube_ver="1.30.0-*"
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
+sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -82,6 +82,7 @@ kube_ver="1.30.0-*"
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
+sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -79,6 +79,7 @@ kube_ver="1.30.0-*"
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
+sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -79,6 +79,7 @@ kube_ver="1.30.0-*"
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
+sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -80,6 +80,7 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
+sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -80,6 +80,7 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
+sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 


### PR DESCRIPTION
**What this PR does / why we need it**:

#3482 introduced a regression that prevents subsequent `kubeone apply` runs from succeeding because the Docker GPG key already exists and `gpg --dearmor` command is interactively asking for permission to overwrite it. Because there's no tty, this fails and hence KubeOne can't proceed past this step.

I opted in to remove the GPG key instead of using `gpg --dearmor --yes` because this is considered a more secure practice. GPG can fail for other reasons too (e.g. issues with the key) which should be fatal, i.e. KubeOne shouldn't proceed. Using the `--yes` flag would ignore these important errors.

**What type of PR is this?**
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 