### PR TITLE
Always update MachineDeployment to the indicated kubernetes version

### DIFF
--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -56,6 +56,10 @@ func upgradeMachineDeployments(s *state.State) error {
 		return nil
 	}
 
+	if !s.Cluster.MachineController.Deploy {
+		return nil
+	}
+
 	s.Logger.Info("Upgrade MachineDeployments...")
 
 	machineDeployments := clusterv1alpha1.MachineDeploymentList{}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -326,6 +326,12 @@ func WithResources(t Tasks) Tasks {
 				Operation: "waiting for operating-system-manager",
 				Predicate: func(s *state.State) bool { return s.Cluster.OperatingSystemManager.Deploy },
 			},
+			{
+				Fn:          upgradeMachineDeployments,
+				Operation:   "upgrading MachineDeployments",
+				Description: "upgrade MachineDeployments",
+				Predicate:   func(s *state.State) bool { return s.UpgradeMachineDeployments },
+			},
 		}...,
 	)
 }
@@ -373,12 +379,6 @@ func WithUpgrade(t Tasks, followers ...kubeoneapi.HostConfig) Tasks {
 					// Run operation only when upgrading to Kubernetes 1.31.
 					return targetVersion.Minor() == 31 && liveCP[0].Kubelet.Version.Minor() == 30
 				},
-			},
-			Task{
-				Fn:          upgradeMachineDeployments,
-				Operation:   "upgrading MachineDeployments",
-				Description: "upgrade MachineDeployments",
-				Predicate:   func(s *state.State) bool { return s.UpgradeMachineDeployments },
 			},
 			Task{
 				Fn:          pruneImagesOnAllNodes,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
In This PR, we moved UpgradeMachineDeployments Task into WithResources TaskSet, since it's used in all the paths (init, refresh, upgrade), So we will ensure that the machine deployments is updated with the flag `--upgrade-machine-deployments` is given
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3373

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Always update MachineDeployment to the indicated kubernetes version when --upgrade-machine-deployments is in use
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
