### PR TITLE
Fix kubevirt csi addon template

### DIFF
--- a/addons/csi-kubevirt/1-kubevirt-csi-driver.yaml
+++ b/addons/csi-kubevirt/1-kubevirt-csi-driver.yaml
@@ -159,7 +159,7 @@ spec:
               memory: 20Mi
               cpu: 5m
         - name: csi-liveness-probe
-          image: '{{ .InternalImages.Get "KubeVirtCSILivenessprobe" }}'
+          image: '{{ .InternalImages.Get "KubeVirtCSILivenessProbe" }}'
           args:
             - "--csi-address=/csi/csi.sock"
             - "--probe-timeout=3s"

--- a/addons/csi-kubevirt/1-kubevirt-csi-driver.yaml
+++ b/addons/csi-kubevirt/1-kubevirt-csi-driver.yaml
@@ -96,7 +96,7 @@ spec:
             privileged: true
             allowPrivilegeEscalation: true
           imagePullPolicy: Always
-          image: '{{ .InternalImages.Get "KubeVirtCSIDriver" }}'
+          image: '{{ .InternalImages.Get "KubeVirtCSI" }}'
           args:
             - "--endpoint=unix:/csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"

--- a/addons/csi-kubevirt/1-kubevirt-csi-driver.yaml
+++ b/addons/csi-kubevirt/1-kubevirt-csi-driver.yaml
@@ -61,7 +61,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: driver-config
-  namespace: kubevirt-csi-driver
+  namespace: kube-system
 data:
 {{ with .Config.CloudProvider.Kubevirt -}}
 {{ with .InfraNamespace }}

--- a/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
+++ b/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
@@ -163,7 +163,7 @@ spec:
               memory: 50Mi
               cpu: 10m
         - name: csi-provisioner
-          image: '{{ .InternalImages.Get "KubeVirtCSIExternalProvisioner" }}'
+          image: '{{ .InternalImages.Get "KubeVirtCSIProvisioner" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -177,7 +177,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image:  '{{ .InternalImages.Get "KubeVirtCSIExternalAttacher" }}'
+          image:  '{{ .InternalImages.Get "KubeVirtCSIAttacher" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -194,7 +194,7 @@ spec:
               memory: 50Mi
               cpu: 10m
         - name: csi-liveness-probe
-          image: '{{ .InternalImages.Get "KubeVirtCSILivenessprobe" }}'
+          image: '{{ .InternalImages.Get "KubeVirtCSILivenessProbe" }}'
           args:
             - "--csi-address=/csi/csi.sock"
             - "--probe-timeout=3s"

--- a/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
+++ b/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
@@ -117,7 +117,7 @@ spec:
       containers:
         - name: csi-driver
           imagePullPolicy: Always
-          image: '{{ .InternalImages.Get "KubeVirtCSIDriver" }}'
+          image: '{{ .InternalImages.Get "KubeVirtCSI" }}'
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"

--- a/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
+++ b/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
@@ -80,7 +80,7 @@ data:
 kind: Secret
 metadata:
     labels:
-    app: kubevirt-csi-driver
+      app: kubevirt-csi-driver
   name: infra-kubeconfig
   namespace: kube-system
 type: Opaque

--- a/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
+++ b/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
@@ -104,7 +104,7 @@ spec:
       labels:
         app: kubevirt-csi-driver
     spec:
-      serviceAccount: kubevirt-csi
+      serviceAccount: kubevirt-csi-controller-sa
       priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""

--- a/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
+++ b/addons/csi-kubevirt/2-kubevirt-csi-controller.yaml
@@ -79,8 +79,8 @@ data:
     value: "{{ . }}"
 kind: Secret
 metadata:
-    labels:
-      app: kubevirt-csi-driver
+  labels:
+    app: kubevirt-csi-driver
   name: infra-kubeconfig
   namespace: kube-system
 type: Opaque


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This PR fixes a typo in kubevirt csi addon! in the template, we are looking for the  `KubeVirtCSI` image but we are typing `KubeVirtCSIDriver` which does not exist

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
