### PR TITLE
Fix cloud config defaulting before terraform config apply

### DIFF
--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -18,7 +18,6 @@ package v1beta2
 
 import (
 	"crypto/tls"
-	"fmt"
 	"strings"
 	"time"
 
@@ -74,7 +73,6 @@ func SetDefaults_KubeOneCluster(obj *KubeOneCluster) {
 	SetDefaults_HelmReleases(obj)
 	SetDefaults_SystemPackages(obj)
 	SetDefaults_Features(obj)
-	SetDefaults_CloudConfig(obj)
 	SetDefaults_TLSCipherSuites(obj)
 }
 
@@ -93,14 +91,6 @@ func SetDefaults_CloudProvider(obj *KubeOneCluster) {
 		// there will be no CCM to initialize the Node
 		if obj.CloudProvider.Kubevirt == nil && obj.CloudProvider.VMwareCloudDirector == nil {
 			obj.CloudProvider.External = true
-		}
-	}
-}
-
-func SetDefaults_CloudConfig(obj *KubeOneCluster) {
-	if obj.CloudProvider.AWS != nil && obj.CloudProvider.External {
-		if obj.CloudProvider.CloudConfig == "" {
-			obj.CloudProvider.CloudConfig = defaultAWSCCMCloudConfig(obj.Name, obj.ClusterNetwork.IPFamily)
 		}
 	}
 }
@@ -347,28 +337,6 @@ func defaultHostConfig(obj *HostConfig) {
 	obj.SSHPort = defaults(obj.SSHPort, 22)
 	obj.BastionPort = defaults(obj.BastionPort, 22)
 	obj.BastionUser = defaults(obj.BastionUser, obj.SSHUsername)
-}
-
-func defaultAWSCCMCloudConfig(name string, ipFamily IPFamily) string {
-	lines := []string{
-		"[global]",
-		fmt.Sprintf("KubernetesClusterID=%q", name),
-	}
-
-	switch ipFamily {
-	case IPFamilyIPv4:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv4"))
-	case IPFamilyIPv6:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv6"))
-	case IPFamilyIPv4IPv6:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv4"))
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv6"))
-	case IPFamilyIPv6IPv4:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv6"))
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv4"))
-	}
-
-	return strings.Join(lines, "\n")
 }
 
 func defaults[T comparable](input, defaultValue T) T {

--- a/pkg/apis/kubeone/v1beta3/defaults.go
+++ b/pkg/apis/kubeone/v1beta3/defaults.go
@@ -18,7 +18,6 @@ package v1beta3
 
 import (
 	"crypto/tls"
-	"fmt"
 	"strings"
 	"time"
 
@@ -74,7 +73,6 @@ func SetDefaults_KubeOneCluster(obj *KubeOneCluster) {
 	SetDefaults_Addons(obj)
 	SetDefaults_SystemPackages(obj)
 	SetDefaults_Features(obj)
-	SetDefaults_CloudConfig(obj)
 	SetDefaults_TLSCipherSuites(obj)
 }
 
@@ -93,14 +91,6 @@ func SetDefaults_CloudProvider(obj *KubeOneCluster) {
 		// there will be no CCM to initialize the Node
 		if obj.CloudProvider.Kubevirt == nil && obj.CloudProvider.VMwareCloudDirector == nil {
 			obj.CloudProvider.External = true
-		}
-	}
-}
-
-func SetDefaults_CloudConfig(obj *KubeOneCluster) {
-	if obj.CloudProvider.AWS != nil && obj.CloudProvider.External {
-		if obj.CloudProvider.CloudConfig == "" {
-			obj.CloudProvider.CloudConfig = defaultAWSCCMCloudConfig(obj.Name, obj.ClusterNetwork.IPFamily)
 		}
 	}
 }
@@ -345,28 +335,6 @@ func defaultHostConfig(obj *HostConfig) {
 	obj.SSHPort = defaults(obj.SSHPort, 22)
 	obj.BastionPort = defaults(obj.BastionPort, 22)
 	obj.BastionUser = defaults(obj.BastionUser, obj.SSHUsername)
-}
-
-func defaultAWSCCMCloudConfig(name string, ipFamily IPFamily) string {
-	lines := []string{
-		"[global]",
-		fmt.Sprintf("KubernetesClusterID=%q", name),
-	}
-
-	switch ipFamily {
-	case IPFamilyIPv4:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv4"))
-	case IPFamilyIPv6:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv6"))
-	case IPFamilyIPv4IPv6:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv4"))
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv6"))
-	case IPFamilyIPv6IPv4:
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv6"))
-		lines = append(lines, fmt.Sprintf("NodeIPFamilies=%q", "ipv4"))
-	}
-
-	return strings.Join(lines, "\n")
 }
 
 func defaults[T comparable](input, defaultValue T) T {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This PR adjusts the execution flow of the function responsible for generating the default cloud configuration. Previously, this function was executed before parsing the Terraform configuration, which could result in conflicts when the cluster name specified in the YAML manifest differed from the name provided in the Terraform configuration. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3533

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resolve clusterID conflicts in cloud config by prioritizing the cluster name from Terraform configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
