### PR TITLE
Always  unlock system components versions during our changes.

### DIFF
--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -142,9 +142,7 @@ rm /tmp/k8s-binaries/kubectl
 {{- end }}
 
 {{ if .USE_KUBERNETES_REPO }}
-{{- if or .FORCE .UPGRADE }}
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
-{{- end }}
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 # Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
 # priority over the Kubernetes repos, so it's not possible to install cri-tools
@@ -165,8 +163,9 @@ sudo yum install -y --disableplugin=priorities \
 {{- end }}
 	kubernetes-cni \
 	cri-tools
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 {{- end }}
+
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
@@ -179,7 +178,7 @@ sudo systemctl restart kubelet
 	removeBinariesAmazonLinuxScriptTemplate = `
 sudo systemctl stop kubelet || true
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo yum remove -y \
 	kubelet \
 	kubeadm \

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -89,9 +89,7 @@ sudo systemctl enable --now iscsid
 {{ template "yum-containerd" . }}
 {{ end }}
 
-{{- if or .FORCE .UPGRADE }}
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
-{{- end }}
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo yum install -y \
 {{- if .KUBELET }}
@@ -114,7 +112,7 @@ sudo systemctl restart kubelet
 {{ end }}
 `
 	removeBinariesCentOSScriptTemplate = `
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo yum remove -y \
 	kubelet \
 	kubeadm \

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -82,9 +82,7 @@ sudo apt-get update
 
 kube_ver="{{ .KUBERNETES_VERSION }}-*"
 
-{{- if or .FORCE .UPGRADE }}
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
-{{- end }}
 
 {{ if .INSTALL_CONTAINERD }}
 {{ template "apt-containerd" . }}

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -174,6 +174,8 @@ rm /tmp/k8s-binaries/kubectl
 
 
 
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -174,6 +174,8 @@ rm /tmp/k8s-binaries/kubectl
 
 
 
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -174,6 +174,8 @@ rm /tmp/k8s-binaries/kubectl
 
 
 
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
@@ -174,6 +174,8 @@ rm /tmp/k8s-binaries/kubectl
 
 
 
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -128,6 +128,7 @@ mkdir -p /tmp/k8s-binaries
 cd /tmp/k8s-binaries
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 # Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
 # priority over the Kubernetes repos, so it's not possible to install cri-tools
@@ -142,6 +143,7 @@ sudo yum install -y --disableplugin=priorities \
 	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
+
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -128,6 +128,7 @@ mkdir -p /tmp/k8s-binaries
 cd /tmp/k8s-binaries
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 # Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
 # priority over the Kubernetes repos, so it's not possible to install cri-tools
@@ -142,6 +143,7 @@ sudo yum install -y --disableplugin=priorities \
 	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
+
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -130,6 +130,7 @@ mkdir -p /tmp/k8s-binaries
 cd /tmp/k8s-binaries
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 # Amazon Linux 2 repos include the cri-tools package. These AL2 repos have higher
 # priority over the Kubernetes repos, so it's not possible to install cri-tools
@@ -144,6 +145,7 @@ sudo yum install -y --disableplugin=priorities \
 	kubectl-1.30.0 \
 	kubernetes-cni \
 	cri-tools
+
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -132,6 +132,8 @@ sudo systemctl restart containerd
 
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo yum install -y \
 	kubelet-1.30.0 \
 	kubeadm-1.30.0 \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -135,6 +135,8 @@ sudo systemctl restart containerd
 
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo yum install -y \
 	kubelet-1.30.0 \
 	kubeadm-1.30.0 \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -132,6 +132,8 @@ sudo systemctl restart containerd
 
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo yum install -y \
 	kubelet-1.30.0 \
 	kubeadm-1.30.0 \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -134,6 +134,8 @@ sudo systemctl restart containerd
 
 
 
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo yum install -y \
 	kubelet-1.30.0 \
 	kubeadm-1.30.0 \

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -75,6 +75,8 @@ sudo apt-get update
 
 kube_ver="1.30.0-*"
 
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -78,6 +78,8 @@ sudo apt-get update
 
 kube_ver="1.30.0-*"
 
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -75,6 +75,8 @@ sudo apt-get update
 
 kube_ver="1.30.0-*"
 
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -75,6 +75,8 @@ sudo apt-get update
 
 kube_ver="1.30.0-*"
 
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
@@ -3,7 +3,7 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 sudo systemctl stop kubelet || true
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo yum remove -y \
 	kubelet \
 	kubeadm \

--- a/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
@@ -1,7 +1,7 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo yum remove -y \
 	kubelet \
 	kubeadm \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -136,5 +136,7 @@ rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
 
 
 
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -131,7 +131,8 @@ sudo systemctl enable containerd
 sudo systemctl restart containerd
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
+
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo yum install -y \
 	kubeadm-1.30.0 \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -74,6 +74,7 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 sudo apt-get update
 
 kube_ver="1.30.0-*"
+
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -169,6 +169,8 @@ rm /tmp/k8s-binaries/kubectl
 
 
 
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -131,7 +131,8 @@ sudo systemctl enable containerd
 sudo systemctl restart containerd
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
+
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo yum install -y \
 	kubelet-1.30.0 \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -74,6 +74,7 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 sudo apt-get update
 
 kube_ver="1.30.0-*"
+
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we moved to the [versioned repositories](https://github.com/kubermatic/kubeone/pull/2873) we don't need those locks to be only removed on upgrades (or force).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1578

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Always  unlock system components versions during our changes.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
