### PR TITLE
Make sure no slash at the end of vcenterPrefix

### DIFF
--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -211,6 +211,7 @@ func vsphereSecret(credentials map[string]string) *corev1.Secret {
 	vscreds := map[string]string{}
 
 	vcenterPrefix := strings.ReplaceAll(credentials[VSphereAddressMC], "https://", "")
+	vcenterPrefix, _ = strings.CutSuffix(vcenterPrefix, "/")
 	// Save credentials in Secret and configure vSphere cloud controller
 	// manager to read it, in replace of storing those in /etc/kubernates/cloud-config
 	// see more: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/k8s-secret.html


### PR DESCRIPTION
**What this PR does / why we need it**:
Drops the slash at the `VSPHERE_SERVER`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3473

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make sure no slash at the end of VSPHERE_SERVER
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
