### PR TITLE
Include the infra namespace as a pod namespace env var for machine controller webhook

### DIFF
--- a/addons/machinecontroller/webhook.yaml
+++ b/addons/machinecontroller/webhook.yaml
@@ -101,6 +101,12 @@ spec:
               value: "{{ .Config.Proxy.HTTPS }}"
             - name: NO_PROXY
               value: "{{ .Config.Proxy.NoProxy }}"
+{{ with .Config.CloudProvider.Kubevirt -}}
+{{ with .InfraNamespace }}
+            - name: POD_NAMESPACE
+              value: "{{ . }}"
+{{ end }}
+{{ end }}
 {{ .MachineControllerCredentialsEnvVars | indent 12 }}
 {{ if .Config.CABundle }}
 {{ caBundleEnvVar | indent 12 }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
When KubeVirt namespaced mode is enabled in KubeOne, the POD_NAMESPACE env var for machine controller webhook must be included as well similar how it is done in the machine controller deployment. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Configure the POD_NAMESPACE env var for machine controller webhook.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
