### PR TITLE
Add caBundle volume mounts to backups-restic addon

### DIFF
--- a/addons/backups-restic/backups-restic.yaml
+++ b/addons/backups-restic/backups-restic.yaml
@@ -50,6 +50,9 @@ spec:
           - name: host-pki
             hostPath:
               path: /etc/kubernetes/pki
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 10 }}
+{{ end }}
           initContainers:
           - name: snapshotter
             image: {{ Registry "gcr.io" }}/etcd-development/etcd:v3.5.16
@@ -104,6 +107,9 @@ spec:
               restic backup {{- with .Params.commonFlags }} {{.}}{{ end }} --tag=etcd --host=${ETCD_HOSTNAME} /backup
               restic forget {{- with .Params.commonFlags }} {{.}}{{ end }} --prune --keep-last 48
             env:
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
             - name: ETCD_HOSTNAME
               valueFrom:
                 fieldRef:
@@ -133,3 +139,6 @@ spec:
             - mountPath: /etc/kubernetes/pki
               name: host-pki
               readOnly: true
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
Adds forgotten caBundle automatic to backups-restic addon

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add caBundle volume mounts to backups-restic addon
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
