### PR TITLE
Use mirror.gcr.io as a default mirror for docker.io

### DIFF
--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -156,6 +156,17 @@ func SetDefaults_ContainerRuntime(obj *KubeOneCluster) {
 	if obj.ContainerRuntime.Containerd == nil {
 		obj.ContainerRuntime.Containerd = &ContainerRuntimeContainerd{}
 	}
+
+	if obj.ContainerRuntime.Containerd.Registries == nil {
+		obj.ContainerRuntime.Containerd.Registries = map[string]ContainerdRegistry{}
+	}
+
+	if _, found := obj.ContainerRuntime.Containerd.Registries["docker.io"]; !found {
+		obj.ContainerRuntime.Containerd.Registries["docker.io"] = ContainerdRegistry{
+			Mirrors: []string{"https://mirror.gcr.io"},
+		}
+	}
+
 	if obj.ContainerRuntime.Containerd.DeviceOwnershipFromSecurityContext == nil {
 		obj.ContainerRuntime.Containerd.DeviceOwnershipFromSecurityContext = ptr.To(false)
 	}

--- a/pkg/apis/kubeone/v1beta3/defaults.go
+++ b/pkg/apis/kubeone/v1beta3/defaults.go
@@ -148,6 +148,17 @@ func SetDefaults_ContainerRuntime(obj *KubeOneCluster) {
 	if obj.ContainerRuntime.Containerd == nil {
 		obj.ContainerRuntime.Containerd = &ContainerRuntimeContainerd{}
 	}
+
+	if obj.ContainerRuntime.Containerd.Registries == nil {
+		obj.ContainerRuntime.Containerd.Registries = map[string]ContainerdRegistry{}
+	}
+
+	if _, found := obj.ContainerRuntime.Containerd.Registries["docker.io"]; !found {
+		obj.ContainerRuntime.Containerd.Registries["docker.io"] = ContainerdRegistry{
+			Mirrors: []string{"https://mirror.gcr.io"},
+		}
+	}
+
 	if obj.ContainerRuntime.Containerd.DeviceOwnershipFromSecurityContext == nil {
 		obj.ContainerRuntime.Containerd.DeviceOwnershipFromSecurityContext = ptr.To(true)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Docker registry is about to introduce new limitation: https://www.docker.com/blog/revisiting-docker-hub-policies-prioritizing-developer-experience/. 

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use mirror.gcr.io as a default mirror for docker.io
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
