### PR TITLE
Repair cluster if etcd member count has exceeded control plane VM count

### DIFF
--- a/pkg/clusterstatus/etcdstatus/etcdstatus.go
+++ b/pkg/clusterstatus/etcdstatus/etcdstatus.go
@@ -145,3 +145,16 @@ func memberHealth(ctx context.Context, t http.RoundTripper, nodeAddress string) 
 
 	return b, fail.Etcd(err, "parsing JSON reply")
 }
+
+func HasEtcdMemberCountExceededControlPlane(s *state.State) (bool, error) {
+	s.Logger.Info("Check if the count for etcd members is higher than the declared control plane nodes...")
+	etcdRing, err := MemberList(s)
+	if err != nil {
+		return false, err
+	}
+	if len(etcdRing.Members) > len(s.Cluster.ControlPlane.Hosts) {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"k8c.io/kubeone/pkg/clusterstatus/etcdstatus"
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
@@ -182,6 +183,12 @@ func runApply(st *state.State, opts *applyOpts) error {
 
 	// Reconcile the cluster based on the probe status
 	if !st.LiveCluster.IsProvisioned() {
+		return runApplyInstall(st, opts)
+	}
+
+	if val, _ := etcdstatus.HasEtcdMemberCountExceededControlPlane(st); val {
+		st.Logger.Warnf("The count for etcd members and control plane nodes are not the same, repairing the cluster...")
+
 		return runApplyInstall(st, opts)
 	}
 

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -408,6 +408,12 @@ func WithReset(t Tasks) Tasks {
 	}...)
 }
 
+func WithRemoveExtraEtcdMembers(t Tasks) Tasks {
+	return t.append(Tasks{
+		{Fn: repairClusterIfNeeded, Operation: "repairing cluster"},
+	}...)
+}
+
 func WithContainerDMigration(t Tasks) Tasks {
 	return WithHostnameOS(t).
 		append(Tasks{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
Through #3577, we found out that if a control plane VM is removed from terraform and the corresponding node from the cluster, the subsequent run for KubeOne wouldn't necessarily remove the etcd member by running [repairClusterIfNeeded](https://github.com/kubermatic/kubeone/blob/main/pkg/tasks/etcd.go#L35). This leads to a situation where the etcd cluster has more members than the control plane nodes and eventually can lead to etcd errors and corruption. The reason is that since the VM has been removed from terraform configuration, it's not accounted for in the [cluster health](https://github.com/kubermatic/kubeone/blob/main/pkg/cmd/apply.go#L184-L188) conditions that triggers a full installation.   

As a remedy, we should repair the cluster if needed during apply/upgrade phase as well.  

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3577

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
My first take on this was https://github.com/kubermatic/kubeone/pull/3584/commits/1a11fa62fbeb543bf11f4ac8bce708ea46beffba; complete installation in case of mismatch but that seems overstretched and not necessary here.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeOne will remove orphaned etcd members when control plane count is less than the etc ring members
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
