### PR TITLE
Migrate external selector matchLabels selector

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -437,6 +437,9 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 	if !unknownProvider {
 		addonsToDeploy = append(addonsToDeploy, addonAction{
 			name: resources.AddonCSIExternalSnapshotter,
+			supportFn: func() error {
+				return migrateExternalSnapshotterController(s)
+			},
 		})
 	}
 

--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -66,6 +66,9 @@ var (
 		"app":     "openstack-cinder-csi",
 		"release": "cinder-csi",
 	}
+	expectedExternalSnapshotterSelectors = map[string]string{
+		"app.kubernetes.io/name": "snapshot-controller",
+	}
 )
 
 func migrateCiliumHubbleCertsJob(s *state.State) error {
@@ -131,6 +134,15 @@ func migrateOpenStackCCM(s *state.State) error {
 	}
 
 	return migrateDaemonsetIfPodSelectorDifferent(s, key, expectedOpenStackCCMPodSelectors)
+}
+
+func migrateExternalSnapshotterController(st *state.State) error {
+	key := client.ObjectKey{
+		Name:      "snapshot-controller",
+		Namespace: metav1.NamespaceSystem,
+	}
+
+	return migrateDeploymentIfPodSelectorDifferent(st, key, expectedExternalSnapshotterSelectors)
 }
 
 func migrateOpenStackCSIDriver(s *state.State) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrate MatchLabels since they been changed but this slipped under and we didn't noticed.

Fixes the issue:
```
The Deployment "snapshot-controller" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"snapshot-controller"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
