### PR TITLE
Update to Go 1.24.2, golangci-lint 2.x

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,106 +1,113 @@
+version: "2"
 run:
-  issues-exit-code: 1
   build-tags:
-  - e2e
-
+    - e2e
+  issues-exit-code: 1
 linters:
-  disable-all: true
+  default: none
   enable:
-  - asciicheck
-  - bidichk
-  - bodyclose
-  - copyloopvar
-  - dogsled
-  - durationcheck
-  - errcheck
-  - errchkjson
-  - errname
-  - errorlint
-  - exhaustive
-  - forcetypeassert
-  - gocritic
-  - gocyclo
-  - gofmt
-  - goimports
-  - gosec
-  - gosimple
-  - govet
-  - importas
-  - ineffassign
-  - intrange
-  - makezero
-  - misspell
-  - nakedret
-  - nilnil
-  - nlreturn
-  - noctx
-  - nolintlint
-  - predeclared
-  - revive
-  - staticcheck
-  - stylecheck
-  - tparallel
-  - unconvert
-  - unparam
-  - unused
-  # TODO: enable this back once we update to golangci-lint v1.64
-  # - usetesting
-  - wastedassign
-  - whitespace
-
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  goimports:
-    local-prefixes: k8c.io
-  importas:
-    no-unaliased: true
-    alias:
-    - pkg: k8c.io/kubeone/pkg/apis/kubeone
-      alias: kubeoneapi
-    - pkg: k8c.io/kubeone/pkg/apis/(\w+)/(v[\w\d]+)
-      alias: $1$2
-    - pkg: k8c.io/machine-controller/pkg/apis/cluster/v1alpha1
-      alias: clusterv1alpha1
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
-      alias: $1$2
-
-issues:
-  exclude:
-  - "G115: integer overflow conversion (.+)"
-
-  exclude-dirs:
-  - hack
-  - vendor
-  - pkg/apis/kubeadm
-
-  exclude-files:
-  - zz_generated.*.go
-
-  exclude-rules:
-  - path: pkg/apis/kubeone
-    text: "func SetDefaults_"
-
-  - path: pkg/apis/kubeone
-    text: "func Convert_"
-
-  - path: pkg/apis/kubeone
-    text: "type name will be used as kubeone.KubeOneCluster by other packages"
-
-  - path: test/e2e
-    text: "cyclomatic complexity 35 of func `TestClusterConformance` is high"
-
-  - path: pkg/scripts
-    text: "`registry` always receives `\"127.0.0.1:5000\"`"
-
-  - path: pkg/credentials
-    text: "cyclomatic complexity 36 of func `openstackValidationFunc` is high"
-
-  - path: pkg/apis/kubeone
-    text: "cyclomatic complexity 35 of func `ValidateCloudProviderSpec` is high"
-
-  - path: pkg/templates/kubeadm/v1beta3
-    text: "cyclomatic complexity 33 of func `NewConfig` is high"
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - dogsled
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - forcetypeassert
+    - gocritic
+    - gocyclo
+    - gosec
+    - govet
+    - importas
+    - ineffassign
+    - intrange
+    - makezero
+    - misspell
+    - nakedret
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - predeclared
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usetesting
+    - wastedassign
+    - whitespace
+  settings:
+    govet:
+      enable:
+        - shadow
+    importas:
+      alias:
+        - pkg: k8c.io/kubeone/pkg/apis/kubeone
+          alias: kubeoneapi
+        - pkg: k8c.io/kubeone/pkg/apis/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8c.io/machine-controller/pkg/apis/cluster/v1alpha1
+          alias: clusterv1alpha1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+      no-unaliased: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: pkg/apis/kubeone
+        text: func SetDefaults_
+      - path: pkg/apis/kubeone
+        text: func Convert_
+      - path: pkg/apis/kubeone
+        text: type name will be used as kubeone.KubeOneCluster by other packages
+      - path: test/e2e
+        text: cyclomatic complexity 35 of func `TestClusterConformance` is high
+      - path: pkg/scripts
+        text: '`registry` always receives `"127.0.0.1:5000"`'
+      - path: pkg/credentials
+        text: cyclomatic complexity 36 of func `openstackValidationFunc` is high
+      - path: pkg/apis/kubeone
+        text: cyclomatic complexity 35 of func `ValidateCloudProviderSpec` is high
+      - path: pkg/templates/kubeadm/v1beta3
+        text: cyclomatic complexity 33 of func `NewConfig` is high
+      - path: (.+)\.go$
+        text: 'G115: integer overflow conversion (.+)'
+    paths:
+      - zz_generated.*.go
+      - hack
+      - vendor
+      - pkg/apis/kubeadm
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - k8c.io
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*.go
+      - hack
+      - vendor
+      - pkg/apis/kubeadm
+      - third_party$
+      - builtin$
+      - examples$

--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -19,7 +19,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -45,7 +45,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -70,7 +70,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -95,7 +95,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -120,7 +120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -145,7 +145,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -172,7 +172,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -199,7 +199,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -227,7 +227,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -254,7 +254,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -279,7 +279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -304,7 +304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -329,7 +329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -354,7 +354,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -379,7 +379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -404,7 +404,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -429,7 +429,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -454,7 +454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -479,7 +479,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -506,7 +506,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -533,7 +533,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -560,7 +560,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -587,7 +587,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -614,7 +614,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -639,7 +639,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -665,7 +665,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -690,7 +690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -715,7 +715,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -740,7 +740,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -765,7 +765,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -792,7 +792,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -819,7 +819,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -847,7 +847,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -874,7 +874,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -899,7 +899,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -924,7 +924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -949,7 +949,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -974,7 +974,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -999,7 +999,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1024,7 +1024,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1049,7 +1049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1074,7 +1074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1099,7 +1099,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1126,7 +1126,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1153,7 +1153,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1180,7 +1180,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1207,7 +1207,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1234,7 +1234,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1260,7 +1260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1285,7 +1285,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1310,7 +1310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1337,7 +1337,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1364,7 +1364,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1389,7 +1389,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1414,7 +1414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1439,7 +1439,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1464,7 +1464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1489,7 +1489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1514,7 +1514,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1541,7 +1541,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1568,7 +1568,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1595,7 +1595,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1625,7 +1625,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1655,7 +1655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1685,7 +1685,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1715,7 +1715,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1745,7 +1745,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1775,7 +1775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1807,7 +1807,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1839,7 +1839,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1872,7 +1872,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1904,7 +1904,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1934,7 +1934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1964,7 +1964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1994,7 +1994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2024,7 +2024,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2054,7 +2054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2084,7 +2084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2114,7 +2114,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2144,7 +2144,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2176,7 +2176,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2208,7 +2208,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2240,7 +2240,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2272,7 +2272,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2304,7 +2304,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2336,7 +2336,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2366,7 +2366,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2396,7 +2396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2426,7 +2426,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2456,7 +2456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2488,7 +2488,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2520,7 +2520,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2550,7 +2550,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2580,7 +2580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2610,7 +2610,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2640,7 +2640,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2670,7 +2670,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2702,7 +2702,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2734,7 +2734,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2766,7 +2766,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2798,7 +2798,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2823,7 +2823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2848,7 +2848,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2873,7 +2873,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2898,7 +2898,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2923,7 +2923,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2950,7 +2950,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2977,7 +2977,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3005,7 +3005,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3032,7 +3032,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3057,7 +3057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3082,7 +3082,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3107,7 +3107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3132,7 +3132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3157,7 +3157,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3182,7 +3182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3207,7 +3207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3232,7 +3232,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3257,7 +3257,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3284,7 +3284,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3311,7 +3311,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3338,7 +3338,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3365,7 +3365,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3392,7 +3392,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3417,7 +3417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3442,7 +3442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3467,7 +3467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3492,7 +3492,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3517,7 +3517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3544,7 +3544,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3571,7 +3571,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3599,7 +3599,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3626,7 +3626,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3651,7 +3651,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3676,7 +3676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3701,7 +3701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3726,7 +3726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3751,7 +3751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3776,7 +3776,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3801,7 +3801,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3826,7 +3826,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3851,7 +3851,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3878,7 +3878,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3905,7 +3905,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3932,7 +3932,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3959,7 +3959,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3986,7 +3986,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4011,7 +4011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4036,7 +4036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4063,7 +4063,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4090,7 +4090,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4115,7 +4115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4140,7 +4140,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4165,7 +4165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4190,7 +4190,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4215,7 +4215,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4240,7 +4240,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4267,7 +4267,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4294,7 +4294,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4321,7 +4321,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4346,7 +4346,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4371,7 +4371,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4396,7 +4396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4421,7 +4421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4446,7 +4446,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4473,7 +4473,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4500,7 +4500,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4528,7 +4528,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4555,7 +4555,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4580,7 +4580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4605,7 +4605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4630,7 +4630,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4655,7 +4655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4680,7 +4680,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4705,7 +4705,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4730,7 +4730,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4755,7 +4755,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4780,7 +4780,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4807,7 +4807,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4834,7 +4834,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4861,7 +4861,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4888,7 +4888,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4915,7 +4915,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4940,7 +4940,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4965,7 +4965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4990,7 +4990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5015,7 +5015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5040,7 +5040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5067,7 +5067,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5094,7 +5094,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5122,7 +5122,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5149,7 +5149,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5174,7 +5174,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5199,7 +5199,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5224,7 +5224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5249,7 +5249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5274,7 +5274,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5299,7 +5299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5324,7 +5324,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5349,7 +5349,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5374,7 +5374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5401,7 +5401,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5428,7 +5428,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5455,7 +5455,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5482,7 +5482,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5509,7 +5509,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5534,7 +5534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5559,7 +5559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5586,7 +5586,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5613,7 +5613,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5638,7 +5638,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5663,7 +5663,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5688,7 +5688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5713,7 +5713,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5738,7 +5738,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5763,7 +5763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5790,7 +5790,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5817,7 +5817,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5844,7 +5844,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5869,7 +5869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5894,7 +5894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5919,7 +5919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5944,7 +5944,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5969,7 +5969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5996,7 +5996,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6023,7 +6023,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6051,7 +6051,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6078,7 +6078,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6103,7 +6103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6128,7 +6128,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6153,7 +6153,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6178,7 +6178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6203,7 +6203,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6228,7 +6228,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6253,7 +6253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6278,7 +6278,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6303,7 +6303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6330,7 +6330,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6357,7 +6357,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6384,7 +6384,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6411,7 +6411,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6438,7 +6438,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6463,7 +6463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6488,7 +6488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6513,7 +6513,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6538,7 +6538,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6563,7 +6563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6590,7 +6590,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6617,7 +6617,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6645,7 +6645,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6672,7 +6672,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6697,7 +6697,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6722,7 +6722,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6747,7 +6747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6772,7 +6772,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6797,7 +6797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6822,7 +6822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6847,7 +6847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6872,7 +6872,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6897,7 +6897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6924,7 +6924,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6951,7 +6951,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6978,7 +6978,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7005,7 +7005,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7032,7 +7032,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7057,7 +7057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7082,7 +7082,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7109,7 +7109,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7136,7 +7136,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7161,7 +7161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7186,7 +7186,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7211,7 +7211,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7236,7 +7236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7261,7 +7261,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7286,7 +7286,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7313,7 +7313,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7340,7 +7340,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7367,7 +7367,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7397,7 +7397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7427,7 +7427,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7457,7 +7457,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7487,7 +7487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7517,7 +7517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7549,7 +7549,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7581,7 +7581,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7614,7 +7614,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7646,7 +7646,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7676,7 +7676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7706,7 +7706,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7736,7 +7736,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7766,7 +7766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7796,7 +7796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7826,7 +7826,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7856,7 +7856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7886,7 +7886,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7918,7 +7918,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7950,7 +7950,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7982,7 +7982,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8014,7 +8014,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8046,7 +8046,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8078,7 +8078,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8108,7 +8108,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8138,7 +8138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8170,7 +8170,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8202,7 +8202,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8232,7 +8232,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8262,7 +8262,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8292,7 +8292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8322,7 +8322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8352,7 +8352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8384,7 +8384,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8416,7 +8416,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8448,7 +8448,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8480,7 +8480,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8505,7 +8505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8530,7 +8530,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8555,7 +8555,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8580,7 +8580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.24-node-20-0
+      image: quay.io/kubermatic/build:go-1.24-node-20-3
       imagePullPolicy: Always
       name: ""
       resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.25-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - /bin/bash
             - -c
@@ -38,7 +38,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -57,7 +57,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.25-6
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.0 as builder
+FROM docker.io/golang:1.24.2 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -407,7 +407,7 @@ func validateIPFamily(ipFamily kubeoneapi.IPFamily, prov kubeoneapi.CloudProvide
 		allErrs = append(allErrs, field.Forbidden(fldPath, "ipv6 and ipv6+ipv4 ip families are currently not supported"))
 	}
 
-	if ipFamily == kubeoneapi.IPFamilyIPv4IPv6 && !(prov.AWS != nil || prov.None != nil || prov.Vsphere != nil) {
+	if ipFamily == kubeoneapi.IPFamilyIPv4IPv6 && prov.AWS == nil && prov.None == nil && prov.Vsphere == nil {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "dualstack is currently supported only on AWS, vSphere and baremetal (none)"))
 	}
 

--- a/pkg/clusterstatus/clusterstatus.go
+++ b/pkg/clusterstatus/clusterstatus.go
@@ -138,10 +138,7 @@ func Fetch(s *state.State, preflightChecks bool) ([]NodeStatus, error) {
 				if err != nil {
 					errs = append(errs, err)
 				}
-				eStatus := false
-				if etcdStatus != nil && etcdStatus.Health && etcdStatus.Member {
-					eStatus = true
-				}
+				eStatus := etcdStatus != nil && etcdStatus.Health && etcdStatus.Member
 				etcdCh <- eStatus
 			}()
 
@@ -150,16 +147,13 @@ func Fetch(s *state.State, preflightChecks bool) ([]NodeStatus, error) {
 				if err != nil {
 					errs = append(errs, err)
 				}
-				aStatus := false
-				if apiserverStatus != nil && apiserverStatus.Health {
-					aStatus = true
-				}
+				aStatus := apiserverStatus != nil && apiserverStatus.Health
 				apiserverCh <- aStatus
 			}()
 
 			var kubeletVersion string
 			for _, node := range nodes.Items {
-				if node.ObjectMeta.Name == host.Hostname {
+				if node.Name == host.Hostname {
 					kubeletVersion = node.Status.NodeInfo.KubeletVersion
 				}
 			}

--- a/pkg/clusterstatus/preflightstatus/preflightstatus.go
+++ b/pkg/clusterstatus/preflightstatus/preflightstatus.go
@@ -88,7 +88,7 @@ func verifyMatchNodes(hosts []kubeoneapi.HostConfig, nodes corev1.NodeList, logg
 					case host.PrivateAddress, host.PublicAddress:
 						nodesFound[node.Name] = true
 						if verbose {
-							logger.Infof("Found endpoint %q (type %s) for the node %q.", addr.Address, addr.Type, node.ObjectMeta.Name)
+							logger.Infof("Found endpoint %q (type %s) for the node %q.", addr.Address, addr.Type, node.Name)
 						}
 					}
 				case corev1.NodeExternalDNS, corev1.NodeHostName, corev1.NodeInternalDNS:
@@ -121,7 +121,7 @@ func verifyNodesReady(nodes corev1.NodeList, logger logrus.FieldLogger, verbose 
 		for _, c := range n.Status.Conditions {
 			if c.Type == corev1.NodeReady {
 				if verbose {
-					logger.Infof("Node %q reporting %s=%s.", n.ObjectMeta.Name, c.Type, c.Status)
+					logger.Infof("Node %q reporting %s=%s.", n.Name, c.Type, c.Status)
 				}
 				if c.Status == corev1.ConditionTrue {
 					found = true
@@ -131,7 +131,7 @@ func verifyNodesReady(nodes corev1.NodeList, logger logrus.FieldLogger, verbose 
 
 		if !found {
 			errs = append(errs, fail.RuntimeError{
-				Op:  fmt.Sprintf("checking %q node readiness", n.ObjectMeta.Name),
+				Op:  fmt.Sprintf("checking %q node readiness", n.Name),
 				Err: errors.New("not ready"),
 			})
 		}
@@ -145,17 +145,17 @@ func verifyNoUpgradeLabels(nodes corev1.NodeList, logger logrus.FieldLogger, ver
 	var errs []error
 
 	for _, n := range nodes.Items {
-		_, ok := n.ObjectMeta.Labels[LabelUpgradeLock]
+		_, ok := n.Labels[LabelUpgradeLock]
 		if ok {
-			logger.Errorf("Upgrade is in progress on the node %q (label %q is present).", n.ObjectMeta.Name, LabelUpgradeLock)
+			logger.Errorf("Upgrade is in progress on the node %q (label %q is present).", n.Name, LabelUpgradeLock)
 			errs = append(errs, fail.RuntimeError{
-				Op:  fmt.Sprintf("checking presence of %q label on node %q", LabelUpgradeLock, n.ObjectMeta.Name),
+				Op:  fmt.Sprintf("checking presence of %q label on node %q", LabelUpgradeLock, n.Name),
 				Err: errors.New("label is present"),
 			})
 		}
 
 		if verbose && !ok {
-			logger.Infof("Label %q isn't present on the node %q.", LabelUpgradeLock, n.ObjectMeta.Name)
+			logger.Infof("Label %q isn't present on the node %q.", LabelUpgradeLock, n.Name)
 		}
 	}
 

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -97,7 +97,7 @@ type migrateCCMOptions struct {
 }
 
 func (opts *migrateCCMOptions) buildCCMMigrationState() (*state.State, error) {
-	s, err := opts.globalOptions.BuildState()
+	s, err := opts.BuildState()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -681,7 +681,7 @@ func vmwareCloudDirectorValidationFunc(creds map[string]string) error {
 	}
 
 	// Username and password are required when using default credentials i.e. username and password.
-	if !apiToken && !(username && password) {
+	if !apiToken && (!username || !password) {
 		return fail.CredentialsError{
 			Op:       "validating",
 			Provider: "VMware Cloud Director",

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -165,7 +165,7 @@ func getNodes(s *state.State) (*nodesResult, error) {
 	var result nodesResult
 
 	for _, currNode := range nodes.Items {
-		_, isControlPlane := currNode.ObjectMeta.Labels["node-role.kubernetes.io/control-plane"]
+		_, isControlPlane := currNode.Labels["node-role.kubernetes.io/control-plane"]
 		lastCondition := currNode.Status.Conditions[len(currNode.Status.Conditions)-1]
 
 		aNode := node{
@@ -280,7 +280,7 @@ func getMachines(state *state.State, md *clusterv1alpha1.MachineDeployment) ([]m
 			Kubelet:   currMachine.Spec.Versions.Kubelet,
 			Address:   address,
 			Age:       time.Since(currMachine.CreationTimestamp.Time).Truncate(time.Second),
-			Deleted:   !currMachine.ObjectMeta.DeletionTimestamp.IsZero(),
+			Deleted:   !currMachine.DeletionTimestamp.IsZero(),
 		})
 	}
 

--- a/pkg/tasks/preflight_checks.go
+++ b/pkg/tasks/preflight_checks.go
@@ -145,7 +145,7 @@ func verifyVersionSkew(s *state.State, nodes *corev1.NodeList, verbose bool) (bo
 			return false, fail.Runtime(apiserverErr, "parsing kube-apiserver container image")
 		}
 		if verbose {
-			fmt.Printf("Pod %s is running apiserver version %s\n", p.ObjectMeta.Name, ver.String())
+			fmt.Printf("Pod %s is running apiserver version %s\n", p.Name, ver.String())
 		}
 		if apiserverVersion == nil {
 			apiserverVersion = ver
@@ -170,7 +170,7 @@ func verifyVersionSkew(s *state.State, nodes *corev1.NodeList, verbose bool) (bo
 			return false, fail.Runtime(kubeletErr, "parsing %q node kubelet version", n.Name)
 		}
 		if verbose {
-			fmt.Printf("Node %s is running kubelet version %s\n", n.ObjectMeta.Name, kubeletVer.String())
+			fmt.Printf("Node %s is running kubelet version %s\n", n.Name, kubeletVer.String())
 		}
 		// Check is requested version different than current and ensure version skew policy
 		err = checkVersionSkew(reqVer, kubeletVer, 2)

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -243,9 +243,10 @@ func safeguardNodeSelectorsAndTolerations(s *state.State) error {
 			}
 			var foundMaster, foundControlPlane bool
 			for _, t := range pod.Spec.Tolerations {
-				if t.Key == nodeRoleMaster {
+				switch t.Key {
+				case nodeRoleMaster:
 					foundMaster = true
-				} else if t.Key == labelControlPlaneNode {
+				case labelControlPlaneNode:
 					foundControlPlane = true
 				}
 			}

--- a/pkg/tasks/util.go
+++ b/pkg/tasks/util.go
@@ -108,7 +108,7 @@ func labelNode(client dynclient.Client, host *kubeoneapi.HostConfig) error {
 		}
 
 		_, err := controllerutil.CreateOrUpdate(context.Background(), client, &node, func() error {
-			if node.ObjectMeta.CreationTimestamp.IsZero() {
+			if node.CreationTimestamp.IsZero() {
 				return errors.New("node not found")
 			}
 			node.Labels[labelUpgradeLock] = ""
@@ -129,10 +129,10 @@ func unlabelNode(client dynclient.Client, host *kubeoneapi.HostConfig) error {
 		}
 
 		_, err := controllerutil.CreateOrUpdate(context.Background(), client, &node, func() error {
-			if node.ObjectMeta.CreationTimestamp.IsZero() {
+			if node.CreationTimestamp.IsZero() {
 				return errors.New("node not found")
 			}
-			delete(node.ObjectMeta.Labels, labelUpgradeLock)
+			delete(node.Labels, labelUpgradeLock)
 
 			return nil
 		})

--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -573,10 +573,11 @@ func newNodeRegistration(s *state.State, host kubeoneapi.HostConfig) kubeadmv1be
 	// as the cloud provider will know what IPs to return.
 	if s.Cluster.ClusterNetwork.IPFamily.IsDualstack() {
 		if !s.Cluster.CloudProvider.External {
-			switch {
-			case s.Cluster.ClusterNetwork.IPFamily == kubeoneapi.IPFamilyIPv4IPv6:
+			//nolint:exhaustive
+			switch s.Cluster.ClusterNetwork.IPFamily {
+			case kubeoneapi.IPFamilyIPv4IPv6:
 				kubeletCLIFlags["node-ip"] = newNodeIP(host) + "," + host.IPv6Addresses[0]
-			case s.Cluster.ClusterNetwork.IPFamily == kubeoneapi.IPFamilyIPv6IPv4:
+			case kubeoneapi.IPFamilyIPv6IPv4:
 				kubeletCLIFlags["node-ip"] = host.IPv6Addresses[0] + "," + newNodeIP(host)
 			}
 		}
@@ -668,9 +669,10 @@ func mergeFeatureGates(featureGates string, additionalFeatureGates map[string]bo
 		if len(kv) == 2 {
 			key := strings.TrimSpace(kv[0])
 			value := strings.TrimSpace(kv[1])
-			if value == "true" {
+			switch value {
+			case "true":
 				featureGatesMap[key] = true
-			} else if value == "false" {
+			case "false":
 				featureGatesMap[key] = false
 			}
 		}

--- a/pkg/templates/kubeadm/v1beta4/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta4/kubeadm.go
@@ -499,10 +499,11 @@ func newNodeRegistration(s *state.State, host kubeoneapi.HostConfig) kubeadmv1be
 	//   - when IPv6 Dualstack is disabled
 	if s.Cluster.ClusterNetwork.IPFamily.IsDualstack() {
 		if !s.Cluster.CloudProvider.External {
-			switch {
-			case s.Cluster.ClusterNetwork.IPFamily == kubeoneapi.IPFamilyIPv4IPv6:
+			//nolint:exhaustive
+			switch s.Cluster.ClusterNetwork.IPFamily {
+			case kubeoneapi.IPFamilyIPv4IPv6:
 				kubeletCLIFlags = setAllArgsValue(kubeletCLIFlags, "node-ip", newNodeIP(host)+","+host.IPv6Addresses[0])
-			case s.Cluster.ClusterNetwork.IPFamily == kubeoneapi.IPFamilyIPv6IPv4:
+			case kubeoneapi.IPFamilyIPv6IPv4:
 				kubeletCLIFlags = setAllArgsValue(kubeletCLIFlags, "node-ip", host.IPv6Addresses[0]+","+newNodeIP(host))
 			}
 		}
@@ -614,9 +615,10 @@ func splitFeatureGates(featureGates string) map[string]bool {
 		if len(kv) == 2 {
 			key := strings.TrimSpace(kv[0])
 			value := strings.TrimSpace(kv[1])
-			if value == "true" {
+			switch value {
+			case "true":
 				featureGatesMap[key] = true
-			} else if value == "false" {
+			case "false":
 				featureGatesMap[key] = false
 			}
 		}

--- a/pkg/terraform/v1beta2/config.go
+++ b/pkg/terraform/v1beta2/config.go
@@ -243,7 +243,7 @@ func (output *Config) Apply(cluster *kubeonev1beta2.KubeOneCluster) error { //no
 	untainer := untainerHostConfigsOpts(cp.Untaint)
 
 	// build up a list of master nodes
-	cpHosts := cp.hostsSpec.toHostConfigs(idIncrementer, isLeader, untainer)
+	cpHosts := cp.toHostConfigs(idIncrementer, isLeader, untainer)
 
 	if len(cpHosts) > 0 {
 		cluster.ControlPlane.Hosts = cpHosts

--- a/pkg/terraform/v1beta3/config.go
+++ b/pkg/terraform/v1beta3/config.go
@@ -241,7 +241,7 @@ func (output *Config) Apply(cluster *kubeonev1beta3.KubeOneCluster) error {
 	untainer := untainerHostConfigsOpts(cp.Untaint)
 
 	// build up a list of master nodes
-	cpHosts := cp.hostsSpec.toHostConfigs(idIncrementer, isLeader, untainer)
+	cpHosts := cp.toHostConfigs(idIncrementer, isLeader, untainer)
 
 	if len(cpHosts) > 0 {
 		cluster.ControlPlane.Hosts = cpHosts

--- a/test/e2e/cloudprovider.go
+++ b/test/e2e/cloudprovider.go
@@ -348,7 +348,7 @@ func (c *cloudProviderTests) cleanUp(t *testing.T) {
 			return false, nil
 		}
 
-		if currentSvc.ObjectMeta.DeletionTimestamp == nil {
+		if currentSvc.DeletionTimestamp == nil {
 			if err := c.client.Delete(ctx, currentSvc); err != nil {
 				// Make error transient so that we try to remove it again and
 				// not leak any resources
@@ -382,7 +382,7 @@ func (c *cloudProviderTests) cleanUp(t *testing.T) {
 			return false, nil
 		}
 
-		if currentSts.ObjectMeta.DeletionTimestamp == nil {
+		if currentSts.DeletionTimestamp == nil {
 			if err := c.client.Delete(ctx, currentSts); err != nil {
 				// Make error transient so that we try to remove it again and
 				// not leak any resources
@@ -412,7 +412,7 @@ func (c *cloudProviderTests) cleanUp(t *testing.T) {
 
 		for _, pvc := range pvcs.Items {
 			p := pvc
-			if p.ObjectMeta.DeletionTimestamp != nil {
+			if p.DeletionTimestamp != nil {
 				continue
 			}
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowjobImage          = "quay.io/kubermatic/build:go-1.24-node-20-0"
+	prowjobImage          = "quay.io/kubermatic/build:go-1.24-node-20-3"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -50,7 +49,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
-	k8spath "k8s.io/utils/path"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -155,77 +153,6 @@ func kubeoneStableProwExtraRefs(baseRef string) []ProwRef {
 			PathAlias: "k8c.io/kubeone-stable",
 		},
 	}
-}
-
-func downloadKubeone(t *testing.T, version string) string { //nolint:deadcode,unused
-	binPath := filepath.Join(t.TempDir(), fmt.Sprintf("kubeone-%s", version))
-	zipPath := fmt.Sprintf("%s.zip", binPath)
-
-	exists, err := k8spath.Exists(k8spath.CheckSymlinkOnly, binPath)
-	if err != nil {
-		t.Fatalf("checking if kubeone already downloaded: %v", err)
-	}
-
-	if exists {
-		return binPath
-	}
-
-	const urlTemplate = "https://github.com/kubermatic/kubeone/releases/download/v%s/kubeone_%s_linux_amd64.zip"
-	downloadURL := fmt.Sprintf(urlTemplate, version, version)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
-	if err != nil {
-		t.Fatalf("building http request to download kubeone: %v", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("http request to download kubeone: %v", err)
-	}
-	defer resp.Body.Close()
-
-	zipBin, err := os.OpenFile(zipPath, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		t.Fatalf("open kubeone destination file: %v", err)
-	}
-	defer zipBin.Close()
-
-	_, err = io.Copy(zipBin, resp.Body)
-	if err != nil {
-		t.Fatalf("downloading kubeone: %v", err)
-	}
-
-	fi, err := zipBin.Stat()
-	if err != nil {
-		t.Fatalf("file stat: %v", err)
-	}
-
-	unzip, err := zip.NewReader(zipBin, fi.Size())
-	if err != nil {
-		t.Fatalf("opening zip file for reading: %v", err)
-	}
-
-	unzipK1Bin, err := unzip.Open("kubeone")
-	if err != nil {
-		t.Fatalf("opening kubeone file from zip archive: %v", err)
-	}
-	defer unzipK1Bin.Close()
-
-	k1Bin, err := os.OpenFile(binPath, os.O_CREATE|os.O_WRONLY, 0o750)
-	if err != nil {
-		t.Fatalf("open kubeone destination file: %v", err)
-	}
-	defer k1Bin.Close()
-
-	_, err = io.Copy(k1Bin, unzipK1Bin)
-	if err != nil {
-		t.Fatalf("extracting kubeone from zip: %v", err)
-	}
-
-	return binPath
 }
 
 type kubeoneBinOpts func(*kubeoneBin)
@@ -587,7 +514,7 @@ func waitMachinesHasNodes(t *testing.T, k1 *kubeoneBin, client ctrlruntimeclient
 
 		t.Logf("checking %d machines for node reference", len(machineList.Items))
 		for _, machine := range machineList.Items {
-			if machine.ObjectMeta.DeletionTimestamp != nil {
+			if machine.DeletionTimestamp != nil {
 				t.Logf("machine %q is being deleted", machine.Name)
 				someMachinesLacksTheNode = true
 			}
@@ -644,10 +571,7 @@ func sonobuoyRunWithRunCount(ctx context.Context, t *testing.T, k1 *kubeoneBin, 
 		proxyURL:   proxyURL,
 	}
 
-	rerunFailed := false
-	if runCount > 0 {
-		rerunFailed = true
-	}
+	rerunFailed := runCount > 0
 
 	if err = retryFnWithBackoff(sonobuoyBackoff, func() error { return sb.Run(ctx, mode, rerunFailed) }); err != nil {
 		t.Fatalf("sonobuoy run failed: %v", err)

--- a/test/e2e/scenario_migrate_csi_ccm.go
+++ b/test/e2e/scenario_migrate_csi_ccm.go
@@ -139,11 +139,11 @@ func (scenario *scenarioMigrateCSIAndCCM) forceRolloutMachinedeployments(t *test
 		mdOld := md.DeepCopy()
 		mdNew := md
 
-		if mdNew.Spec.Template.Spec.ObjectMeta.Annotations == nil {
-			mdNew.Spec.Template.Spec.ObjectMeta.Annotations = map[string]string{}
+		if mdNew.Spec.Template.Spec.Annotations == nil {
+			mdNew.Spec.Template.Spec.Annotations = map[string]string{}
 		}
 
-		mdNew.Spec.Template.Spec.ObjectMeta.Annotations["forceRestart"] = time.Now().String()
+		mdNew.Spec.Template.Spec.Annotations["forceRestart"] = time.Now().String()
 
 		err := retryFn(func() error {
 			return client.Patch(context.Background(), &mdNew, ctrlruntimeclient.MergeFrom(mdOld))


### PR DESCRIPTION
**What this PR does / why we need it**:
Pretty much what it says on the tin. I also removed the "let's keep this just in case" code from #2304. We haven't needed it since 2022, I'd say we can let it go.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.24.2
```

**Documentation**:
```documentation
NONE
```
