### PR TITLE
CNI Version on Flatcar now depends on the kubernetes version

### DIFF
--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -133,8 +133,8 @@ func FlatcarScript(cluster *kubeoneapi.KubeOneCluster, params Params) (string, e
 		"KUBEADM":                params.Kubeadm,
 		"FORCE":                  params.Force,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CRITOOLS_VERSION":       criToolsVersion(cluster),
+		"KUBERNETES_CNI_VERSION": flatcarCNIVersion(cluster.Versions.Kubernetes),
+		"CRITOOLS_VERSION":       criToolsVersion(cluster.Versions.Kubernetes),
 		"PROXY":                  proxy,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 		"IPV6_ENABLED":           cluster.ClusterNetwork.HasIPv6(),
@@ -155,22 +155,33 @@ func RemoveBinariesFlatcar() (string, error) {
 	return result, fail.Runtime(err, "rendering removeBinariesFlatcarScriptTemplate script")
 }
 
-const defaultKubernetesCNIVersion = "1.3.0"
-
-func criToolsVersion(cluster *kubeoneapi.KubeOneCluster) string {
-	// Validation passed at this point so we know that version is valid
-	kubeSemVer := semver.MustParse(cluster.Versions.Kubernetes)
+func flatcarCNIVersion(kubeVersion string) string {
+	kubeSemVer := semver.MustParse(kubeVersion)
 
 	switch kubeSemVer.Minor() {
-	case 29:
-		return "1.29.0"
+	case 30:
+		return "1.4.0"
+	case 31:
+		return "1.5.1"
+	case 32:
+		return "1.6.0"
+	default:
+		return "1.6.0"
+	}
+}
+
+func criToolsVersion(kubeVersion string) string {
+	// Validation passed at this point so we know that version is valid
+	kubeSemVer := semver.MustParse(kubeVersion)
+
+	switch kubeSemVer.Minor() {
 	case 30:
 		return "1.30.1"
 	case 31:
 		return "1.31.1"
 	case 32:
 		return "1.32.0"
+	default:
+		return "1.32.0"
 	}
-
-	return ""
 }

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-${HOST_ARCH}-v1.3.0.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CNI Version on Flatcar now depends on the kubernetes version
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
