### PR TITLE
Fix digitalocean terraform dpkg lock file issue

### DIFF
--- a/addons/ccm-digitalocean/Kustomization
+++ b/addons/ccm-digitalocean/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.59.yml
+  - https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.56.yml
 
 patches:
   - patch: |-

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -19,6 +19,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 | Name | Version |
 |------|---------|
 | <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | ~> 2.9.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 
@@ -32,6 +33,7 @@ No modules.
 | [digitalocean_loadbalancer.control_plane](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/loadbalancer) | resource |
 | [digitalocean_ssh_key.deployer](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/ssh_key) | resource |
 | [digitalocean_tag.kube_cluster_tag](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/tag) | resource |
+| [time_sleep.wait_60_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs
 

--- a/examples/terraform/digitalocean/main.tf
+++ b/examples/terraform/digitalocean/main.tf
@@ -60,6 +60,11 @@ resource "digitalocean_droplet" "control_plane" {
 }
 
 resource "digitalocean_loadbalancer" "control_plane" {
+  depends_on = [
+    digitalocean_droplet.control_plane,
+    time_sleep.wait_60_seconds,
+  ]
+
   count = local.loadbalancer_count
 
   name   = "${var.cluster_name}-lb"
@@ -81,3 +86,8 @@ resource "digitalocean_loadbalancer" "control_plane" {
   droplet_tag = local.kube_cluster_tag
 }
 
+# Hack to ensure apt update has released the lock file
+resource "time_sleep" "wait_60_seconds" {
+  depends_on      = [digitalocean_droplet.control_plane]
+  create_duration = "60s"
+}

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -276,7 +276,7 @@ func optionalResources() map[Resource]map[string]string {
 		AzureDiskCSISnapshotter:        {"*": "mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v8.2.0"},
 
 		// DigitalOcean CCM
-		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.59"},
+		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56"},
 
 		// DigitalOcean CSI
 		DigitalOceanCSI:                   {"*": "digitalocean/do-csi-plugin:v4.13.0"},


### PR DESCRIPTION
**What this PR does / why we need it**:

* When DO droplets are started they automatically try to `apt update`, at the same time kubeone also doing just they effectively causing race-condition. This PR introduces a timeout to wait before kubeone kicks in.
* Downgrade digitalocean CCM to v0.1.56
Since v0.1.57 this CCM requires kubelet flag --provider-id=digitalocean://<droplet ID>
See more: https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/v0.1.59/docs/getting-started.md#--provider-iddigitaloceandroplet-id


**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Fix digitalocean terraform dpkg lock file issue
* Downgrade digitalocean CCM to v0.1.56
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
