### PR TITLE
Fix flatcar 1.31.x CNI plugins directory permissions

### DIFF
--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -36,6 +36,7 @@ source /etc/kubeone/proxy-env
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v{{ . }}/cni-plugins-linux-${HOST_ARCH}-v{{ . }}.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 {{- end }}
 {{- with .CRITOOLS_VERSION }}
 CRI_TOOLS_RELEASE="v{{ . }}"

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
@@ -56,6 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
@@ -56,6 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
@@ -56,6 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
@@ -56,6 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -56,6 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
@@ -56,6 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-${HOST_ARCH}-v1.4.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
+sudo chown -R root:root /opt/cni/bin
 CRI_TOOLS_RELEASE="v1.30.1"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz


### PR DESCRIPTION
**What this PR does / why we need it**:
When we upgraded to using CNI per kubernetes version on Flatcar in #3632, turns out that CNI plugins tar archive for 1.31 (v1.5.1) contained incorrect owner permissions on the root directory, which caused cilium init container `mount-cgroup` to fail with `permission denied` error message.

The same already been fixed in https://github.com/kubermatic/operating-system-manager/pull/379

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix flatcar 1.31.x CNI plugins directory permissions
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
