### PR TITLE
Update docs links to v1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ See [the list of releases][changelog] to find out about feature changes.
 [machine-controller]: https://github.com/kubermatic/machine-controller
 [operating-system-manager]: https://github.com/kubermatic/operating-system-manager
 [docs]: https://docs.kubermatic.com/kubeone/
-[docs-architecture]: https://docs.kubermatic.com/kubeone/v1.9/architecture/
-[docs-concepts]: https://docs.kubermatic.com/kubeone/v1.9/architecture/concepts/
-[docs-compatibility]: https://docs.kubermatic.com/kubeone/v1.9/architecture/compatibility/
-[docs-getting-kubeone]: https://docs.kubermatic.com/kubeone/v1.9/getting-kubeone/
-[docs-provisioning]: https://docs.kubermatic.com/kubeone/v1.9/tutorials/creating-clusters/
+[docs-architecture]: https://docs.kubermatic.com/kubeone/v1.10/architecture/
+[docs-concepts]: https://docs.kubermatic.com/kubeone/v1.10/architecture/concepts/
+[docs-compatibility]: https://docs.kubermatic.com/kubeone/v1.10/architecture/compatibility/
+[docs-getting-kubeone]: https://docs.kubermatic.com/kubeone/v1.10/getting-kubeone/
+[docs-provisioning]: https://docs.kubermatic.com/kubeone/v1.10/tutorials/creating-clusters/
 [contributing-guide]: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
 [k8s-slack-kubeone]: https://kubernetes.slack.com/messages/CNEV2UMT7
 [k8s-slack]: http://slack.k8s.io/

--- a/addons/README.md
+++ b/addons/README.md
@@ -7,6 +7,6 @@ how to use the KubeOne Addons, consider the [KubeOne documentation][addons-docs]
 
 * [Cluster backups (with Restic)][backups-addon]
 
-[addons-docs]: (https://docs.kubermatic.com/kubeone/v1.9/guides/addons/)
+[addons-docs]: (https://docs.kubermatic.com/kubeone/v1.10/guides/addons/)
 [backups-addon]: (./backups-restic)
 [restic]: (https://restic.net/)

--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -138,11 +138,11 @@ You can find more information about deploying addons in the
 [addon]: ./cluster-autoscaler.yaml
 [autoscaler]: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 [machine-controller]: https://github.com/kubermatic/machine-controller
-[docs-concepts]: https://docs.kubermatic.com/kubeone/v1.9/architecture/concepts/
-[docs-machinedeployment]: https://docs.kubermatic.com/kubeone/v1.9/architecture/concepts/#machinedeployments
+[docs-concepts]: https://docs.kubermatic.com/kubeone/v1.10/architecture/concepts/
+[docs-machinedeployment]: https://docs.kubermatic.com/kubeone/v1.10/architecture/concepts/#machinedeployments
 [recommended-autoscaler-versions]: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases
 [autoscaler-releases]: https://github.com/kubernetes/autoscaler/releases
-[using-addons]: https://docs.kubermatic.com/kubeone/v1.9/guides/addons/
+[using-addons]: https://docs.kubermatic.com/kubeone/v1.10/guides/addons/
 [autoscaler-faq]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md
 [enforce-node-group-min-size]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#my-cluster-is-below-minimum--above-maximum-number-of-nodes-but-ca-did-not-fix-that-why
 [balance-similar-node-groups]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#im-running-cluster-with-nodes-in-multiple-zones-for-ha-purposes-is-that-supported-by-cluster-autoscaler

--- a/addons/cni-cilium/README.md
+++ b/addons/cni-cilium/README.md
@@ -6,7 +6,7 @@ This addon is used to deploy [Cilium CNI](https://cilium.io/).
 
 This section what [addon parameters][params] can be used with this addon.
 
-[params]: https://docs.kubermatic.com/kubeone/v1.9/guides/addons/#parameters
+[params]: https://docs.kubermatic.com/kubeone/v1.10/guides/addons/#parameters
 
 * `HubbleUI` - used to enable/disable Hubble UI listening on an IPv6 interface
   * `true` (default): enable listening on IPv6

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## User Documentation
 
-KubeOne user documentation can be found at [KubeOne docs website](https://docs.kubermatic.com/kubeone/v1.9/)
+KubeOne user documentation can be found at [KubeOne docs website](https://docs.kubermatic.com/kubeone/v1.10/)
 
 ## Development Documentation
 

--- a/docs/proposals/20200224-apply.md
+++ b/docs/proposals/20200224-apply.md
@@ -259,6 +259,6 @@ the specific operation.
 * Write and/or update documentation
 
 [etcd-quorum]: https://etcd.io/docs/v3.5/faq/#why-an-odd-number-of-cluster-members
-[manual-cluster-repair]: https://docs.kubermatic.com/kubeone/v1.9/guides/manual-cluster-repair/
+[manual-cluster-repair]: https://docs.kubermatic.com/kubeone/v1.10/guides/manual-cluster-repair/
 [automated-cluster-repairs]: https://github.com/kubermatic/kubeone/pull/888
-[disaster-recovery]: https://docs.kubermatic.com/kubeone/v1.9/guides/manual-cluster-recovery/
+[disaster-recovery]: https://docs.kubermatic.com/kubeone/v1.10/guides/manual-cluster-recovery/

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -87,5 +87,5 @@ It's recommended to try to download to the release from GitHub after it's
 available and compare the checksums, as well as, confirm that `kubeone version`
 shows the correct version.
 
-[docs-compatibility]: https://docs.kubermatic.com/kubeone/v1.9/architecture/compatibility/
+[docs-compatibility]: https://docs.kubermatic.com/kubeone/v1.10/architecture/compatibility/
 [changelog]: https://github.com/kubermatic/kubeone/blob/main/CHANGELOG.md

--- a/examples/terraform/aws-dualstack/README.md
+++ b/examples/terraform/aws-dualstack/README.md
@@ -5,11 +5,11 @@ infrastructure for a Kubernetes HA cluster with dualstack (IPv4+IPv6) support. C
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## AWS external CCM cloud-config
 KubeOne will use following cloud-config when provisioning the cluster using external AWS CCM.
-You can [override](https://docs.kubermatic.com/kubeone/v1.9/references/kubeone-cluster-v1beta2/#cloudproviderspec) the cloud-config
+You can [override](https://docs.kubermatic.com/kubeone/v1.10/references/kubeone-cluster-v1beta2/#cloudproviderspec) the cloud-config
 but you must specify all the options shown below. Otherwise CCM fails to initialize nodes with proper IP addresses
 and host network pods don't get dualstack IPs.
 

--- a/examples/terraform/aws-dualstack/README.md.in
+++ b/examples/terraform/aws-dualstack/README.md.in
@@ -5,11 +5,11 @@ infrastructure for a Kubernetes HA cluster with dualstack (IPv4+IPv6) support. C
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## AWS external CCM cloud-config
 KubeOne will use following cloud-config when provisioning the cluster using external AWS CCM.
-You can [override](https://docs.kubermatic.com/kubeone/v1.9/references/kubeone-cluster-v1beta2/#cloudproviderspec) the cloud-config
+You can [override](https://docs.kubermatic.com/kubeone/v1.10/references/kubeone-cluster-v1beta2/#cloudproviderspec) the cloud-config
 but you must specify all the options shown below. Otherwise CCM fails to initialize nodes with proper IP addresses
 and host network pods don't get dualstack IPs.
 

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## Requirements
 

--- a/examples/terraform/aws/README.md.in
+++ b/examples/terraform/aws/README.md.in
@@ -5,5 +5,5 @@ infrastructure for a Kubernetes HA cluster. Check out the
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## Requirements
 

--- a/examples/terraform/azure/README.md.in
+++ b/examples/terraform/azure/README.md.in
@@ -5,5 +5,5 @@ infrastructure for a Kubernetes HA cluster. Check out the
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## Requirements
 

--- a/examples/terraform/digitalocean/README.md.in
+++ b/examples/terraform/digitalocean/README.md.in
@@ -5,5 +5,5 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 

--- a/examples/terraform/equinixmetal/README.md
+++ b/examples/terraform/equinixmetal/README.md
@@ -9,8 +9,8 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 
 ## Requirements
 

--- a/examples/terraform/equinixmetal/README.md.in
+++ b/examples/terraform/equinixmetal/README.md.in
@@ -9,6 +9,6 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## GCE Provider configuration
 

--- a/examples/terraform/gce/README.md.in
+++ b/examples/terraform/gce/README.md.in
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## GCE Provider configuration
 

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## Requirements
 

--- a/examples/terraform/hetzner/README.md.in
+++ b/examples/terraform/hetzner/README.md.in
@@ -5,5 +5,5 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 

--- a/examples/terraform/nutanix/README.md
+++ b/examples/terraform/nutanix/README.md
@@ -9,8 +9,8 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 
 ## Requirements
 

--- a/examples/terraform/nutanix/README.md.in
+++ b/examples/terraform/nutanix/README.md.in
@@ -9,6 +9,6 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -9,8 +9,8 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 
 ## Requirements
 

--- a/examples/terraform/openstack/README.md.in
+++ b/examples/terraform/openstack/README.md.in
@@ -9,6 +9,6 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 

--- a/examples/terraform/vmware-cloud-director/README.md
+++ b/examples/terraform/vmware-cloud-director/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## Setup
 

--- a/examples/terraform/vmware-cloud-director/README.md.in
+++ b/examples/terraform/vmware-cloud-director/README.md.in
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
 
 ## Setup
 

--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -13,7 +13,7 @@ guide.
 We also provide Terraform configs for [CentOS-based operating systems](../vsphere_centos)
 and [Flatcar Linux](../vsphere_flatcar).
 
-[Ubuntu Template VM]: https://docs.kubermatic.com/kubeone/v1.9/guides/vsphere-template-vm/ubuntu/
+[Ubuntu Template VM]: https://docs.kubermatic.com/kubeone/v1.10/guides/vsphere-template-vm/ubuntu/
 
 ## Required environment variables
 
@@ -36,8 +36,8 @@ Based on IP assignment in terraform, we assume that the first IP would be IPv4 a
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 
 ## Requirements
 

--- a/examples/terraform/vsphere/README.md.in
+++ b/examples/terraform/vsphere/README.md.in
@@ -13,7 +13,7 @@ guide.
 We also provide Terraform configs for [CentOS-based operating systems](../vsphere_centos)
 and [Flatcar Linux](../vsphere_flatcar).
 
-[Ubuntu Template VM]: https://docs.kubermatic.com/kubeone/v1.9/guides/vsphere-template-vm/ubuntu/
+[Ubuntu Template VM]: https://docs.kubermatic.com/kubeone/v1.10/guides/vsphere-template-vm/ubuntu/
 
 ## Required environment variables
 
@@ -36,6 +36,6 @@ Based on IP assignment in terraform, we assume that the first IP would be IPv4 a
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 

--- a/examples/terraform/vsphere_centos/README.md
+++ b/examples/terraform/vsphere_centos/README.md
@@ -20,7 +20,7 @@ these configs, check out our [CentOS 7 Template VM] guide.
 We also provide Terraform configs for [Debian-based operating systems](../vsphere)
 and [Flatcar Linux](../vsphere_flatcar).
 
-[CentOS 7 Template VM]: https://docs.kubermatic.com/kubeone/v1.9/guides/vsphere-template-vm/centos/
+[CentOS 7 Template VM]: https://docs.kubermatic.com/machine-controller/main/cloud-providers/vsphere/template-vm/rockylinux/
 [guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
 
 ## Required environment variables
@@ -38,8 +38,8 @@ See <https://github.com/kubermatic/machine-controller/blob/main/docs/vsphere.md>
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 
 ## Requirements
 

--- a/examples/terraform/vsphere_centos/README.md.in
+++ b/examples/terraform/vsphere_centos/README.md.in
@@ -20,7 +20,7 @@ these configs, check out our [CentOS 7 Template VM] guide.
 We also provide Terraform configs for [Debian-based operating systems](../vsphere)
 and [Flatcar Linux](../vsphere_flatcar).
 
-[CentOS 7 Template VM]: https://docs.kubermatic.com/kubeone/v1.9/guides/vsphere-template-vm/centos/
+[CentOS 7 Template VM]: https://docs.kubermatic.com/machine-controller/main/cloud-providers/vsphere/template-vm/rockylinux/
 [guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
 
 ## Required environment variables
@@ -38,6 +38,6 @@ See <https://github.com/kubermatic/machine-controller/blob/main/docs/vsphere.md>
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 

--- a/examples/terraform/vsphere_flatcar/README.md
+++ b/examples/terraform/vsphere_flatcar/README.md
@@ -25,8 +25,8 @@ See <https://github.com/kubermatic/machine-controller/blob/main/docs/vsphere.md>
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 
 ## Requirements
 

--- a/examples/terraform/vsphere_flatcar/README.md.in
+++ b/examples/terraform/vsphere_flatcar/README.md.in
@@ -25,6 +25,6 @@ See <https://github.com/kubermatic/machine-controller/blob/main/docs/vsphere.md>
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.9/guides/using-terraform-configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.9/examples/ha-load-balancing/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.10/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.10/examples/ha-load-balancing/
 

--- a/pkg/cmd/example-manifest.tmpl.yaml
+++ b/pkg/cmd/example-manifest.tmpl.yaml
@@ -279,7 +279,7 @@ addons:
   # available addons.
   # Check out the documentation to find more information about what are embedded
   # addons and how to use them:
-  # https://docs.kubermatic.com/kubeone/v1.9/guides/addons/
+  # https://docs.kubermatic.com/kubeone/v1.10/guides/addons/
   addons:
     # name of the addon to be enabled/deployed (e.g. backups-restic)
     - name: ""

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -139,7 +139,7 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			    done after all worker nodes managed by machine-controller are rolled-out.
 
 			Make sure to familiarize yourself with the CCM/CSI migration requirements by checking the following document:
-			https://docs.kubermatic.com/kubeone/v1.9/guides/ccm-csi-migration/
+			https://docs.kubermatic.com/kubeone/v1.10/guides/ccm-csi-migration/
 		`),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(fs)
@@ -205,7 +205,7 @@ func runMigrateToCCMCSI(opts *migrateCCMOptions) error {
 
 	s.Logger.Warnln("This command will migrate your cluster from in-tree cloud provider to the external CCM and CSI plugin.")
 	s.Logger.Warnln("Make sure to familiarize yourself with the process by checking the following document:")
-	s.Logger.Warnln("https://docs.kubermatic.com/kubeone/v1.9/guides/ccm-csi-migration/")
+	s.Logger.Warnln("https://docs.kubermatic.com/kubeone/v1.10/guides/ccm-csi-migration/")
 	if s.Cluster.CloudProvider.Openstack != nil {
 		s.Logger.Warnln("The OpenStack external CCM uses Octavia Load Balancers by default.")
 		s.Logger.Warnln("If you currently use Neutron Load Balancers, migrating to the external CCM/CSI will cause *ALL* Load Balancers to be recreated!")

--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	machineDeploymentsDocsLink = `https://docs.kubermatic.com/kubeone/v1.9/guides/machine-controller/`
+	machineDeploymentsDocsLink = `https://docs.kubermatic.com/kubeone/v1.10/guides/machine-controller/`
 )
 
 func createMachineDeployments(s *state.State) error {

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -330,7 +330,7 @@ func safeguardFlatcarMachineDeployments(s *state.State) error {
 		s.Logger.Warnf("cloud-init provisioning utility is not supported on Flatcar with Operating System Manager (OSM) enabled.")
 		s.Logger.Warnf("Please migrate your MachineDeployments to \"ignition\" provisioning utility after kubeone apply is done.")
 		s.Logger.Warnf("Not doing so will cause your Machines to never join the cluster.")
-		s.Logger.Warnf("For more details, check out the following document: https://docs.kubermatic.com/kubeone/v1.9/architecture/operating-system-manager/usage/")
+		s.Logger.Warnf("For more details, check out the following document: https://docs.kubermatic.com/kubeone/v1.1000/architecture/operating-system-manager/usage/")
 	}
 
 	return nil

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -440,7 +440,7 @@ func WithContainerDMigration(t Tasks) Tasks {
 			{
 				Fn: func(s *state.State) error {
 					s.Logger.Warn("Now please rolling restart your machineDeployments to get containerd")
-					s.Logger.Warn("see more at: https://docs.kubermatic.com/kubeone/v1.9/cheat-sheets/rollout-machinedeployment/")
+					s.Logger.Warn("see more at: https://docs.kubermatic.com/kubeone/v1.10/cheat-sheets/rollout-machinedeployment/")
 
 					return nil
 				},
@@ -625,7 +625,7 @@ func WithCCMCSIMigration(t Tasks) Tasks {
 			Task{
 				Fn: func(s *state.State) error {
 					s.Logger.Warn("Now please rolling restart your machineDeployments to migrate to ccm/csi")
-					s.Logger.Warn("see more at: https://docs.kubermatic.com/kubeone/v1.9/cheat-sheets/rollout-machinedeployment/")
+					s.Logger.Warn("see more at: https://docs.kubermatic.com/kubeone/v1.10/cheat-sheets/rollout-machinedeployment/")
 					s.Logger.Warn("Once you're done, please run this command again with the '--complete' flag to finish migration")
 
 					return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates all v1.9 docs links to v1.10.

**This PR must be merged prior to the release! The v1.10 docs are not live yet.**

**Which issue(s) this PR fixes**:
xref #3637 

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg 