### PR TITLE
Fix CABundle flag for OSM

### DIFF
--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -56,7 +56,7 @@ spec:
             - -external-cloud-provider
             {{ end }}
             {{ if .Config.CABundle -}}
-            - -ca-bundle={{ .Resources.CABundleSSLCertFilePath }}
+            - -host-ca-bundle={{ .Resources.CABundleSSLCertFilePath }}
             {{ end -}}
             {{ if .CSIMigrationFeatureGates }}
             - -node-kubelet-feature-gates={{ .CSIMigrationFeatureGates }}


### PR DESCRIPTION
Porting change from release/v1.8 https://github.com/kubermatic/kubeone/commit/fdfa048c6b7759d4c95030a9ffb529301aa6dc24

We forgot to merge this change into the main.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CABundle flag for OSM
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
