### PR TITLE
Make kubeone go installa-ble again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,10 +184,3 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.18.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 )
-
-// This is required because the Kubernetes code generator tools
-// require a specific gengo version, but Go toolchain is fetching
-// the latest available version. When the latest version is used,
-// the code generation tools are throwing errors on the compilation
-// time.
-replace k8s.io/gengo/v2 v2.0.0-20240826214909-a7b603a56eb7 => k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70


### PR DESCRIPTION
**What this PR does / why we need it**:
Latest KubeOne release fails to `go install` with the following 

```
$ go install -v k8c.io/kubeone@latest
go: downloading k8c.io/kubeone v1.10.0
go: k8c.io/kubeone@latest (in k8c.io/kubeone@v1.10.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```

There is no need in this `replace` anymore, seems like it was fixed upstream. Now all the codegen works perfectly fine. This change enables KubeOne to be `go install`-able again.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make kubeone go installa-ble again
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
