### PR TITLE
Also configure inotify instances

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -54,7 +54,7 @@ var libraryTemplate = heredoc.Doc(`
 		sudo mkdir -p /etc/sysctl.d
 		cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 		fs.inotify.max_user_watches         = 1048576
-        fs.inotify.max_user_instances       = 8192
+		fs.inotify.max_user_instances       = 8192
 		kernel.panic                        = 10
 		kernel.panic_on_oops                = 1
 		net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -54,6 +54,7 @@ var libraryTemplate = heredoc.Doc(`
 		sudo mkdir -p /etc/sysctl.d
 		cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 		fs.inotify.max_user_watches         = 1048576
+        fs.inotify.max_user_instances       = 8192
 		kernel.panic                        = 10
 		kernel.panic_on_oops                = 1
 		net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestAmazonLinuxScript-install_all.golden
+++ b/pkg/scripts/testdata/TestAmazonLinuxScript-install_all.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestAmazonLinuxScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestAmazonLinuxScript-install_all_with_force.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestAmazonLinuxScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestAmazonLinuxScript-install_all_with_proxy.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestAmazonLinuxScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestAmazonLinuxScript-upgrade_kubeadm_and_kubectl.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestAmazonLinuxScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestAmazonLinuxScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestAmazonLinuxScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestAmazonLinuxScript-upgrade_kubelet.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestDebScript-install_all.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all.golden
@@ -24,6 +24,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
@@ -24,6 +24,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
@@ -24,6 +24,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
@@ -24,6 +24,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -24,6 +24,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
@@ -24,6 +24,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
@@ -35,6 +35,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
@@ -35,6 +35,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
@@ -35,6 +35,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
@@ -35,6 +35,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -35,6 +35,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
@@ -35,6 +35,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestRHELLikeScript-install_all.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-install_all.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_force.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_proxy.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1

--- a/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubelet.golden
@@ -26,6 +26,7 @@ fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576
+fs.inotify.max_user_instances       = 8192
 kernel.panic                        = 10
 kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a quick fix, which sets fs.inotify.max_user_instances to 8192 as sysctl value. This is usefull as dynamic workers have this limit already increased [example ubuntu](https://github.com/kubermatic/operating-system-manager/blob/main/deploy/osps/default/osp-ubuntu.yaml#L509)

**Which issue(s) this PR fixes**:
-

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Controlplane nodes will now have the fs.inotify.max_user_instances limit increased aswell
```

**Documentation**:

```documentation
NONE
```
