### PR TITLE
Mirror Images: Fix CoreDNS image retagging for kubeadm compatibility 🐳

### DIFF
--- a/pkg/cmd/mirror-images_test.go
+++ b/pkg/cmd/mirror-images_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestRetagImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		registry string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "coredns special case",
+			source:   "registry.k8s.io/coredns/coredns:v1.8.6",
+			registry: "myregistry",
+			want:     "myregistry/coredns:v1.8.6",
+		},
+		{
+			name:     "regular image",
+			source:   "nginx:latest",
+			registry: "myregistry",
+			want:     "myregistry/library/nginx:latest",
+		},
+		{
+			name:     "Default kube-api-server image",
+			source:   "registry.k8s.io/api-server:tag",
+			registry: "myregistry",
+			want:     "myregistry/api-server:tag",
+		},
+		{
+			name:     "invalid image",
+			source:   "invalid_image%%%_ref",
+			registry: "myregistry",
+			wantErr:  true,
+		},
+	}
+
+	log := logrus.New()
+	log.Out = io.Discard
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := retagImage(log, tt.source, tt.registry)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("retagImage() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("retagImage() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adjusts the repository path from `coredns/coredns` to `coredns` when mirroring to custom registries. Ensures seamless CoreDNS deployment with user-specified registries in Kubernetes clusters.

Take a look here! : [kubeadm/GetDNSImage()](https://github.com/kubernetes/kubernetes/blob/v1.33.1/cmd/kubeadm/app/images/images.go#L51-L54)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
