### PR TITLE
Fix KubeVirt zoneAndRegionEnabled for Kubevirt cloud spec

### DIFF
--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2025-05-29T15:53:42+03:00
+date = 2025-06-11T12:48:35+02:00
 weight = 11
 +++
 ## v1beta2
@@ -587,7 +587,7 @@ KubevirtSpec defines the Kubevirt provider
 | ----- | ----------- | ------ | -------- |
 | infraNamespace | InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster, such as VirtualMachines, VirtualMachineInstances, etc... | string | true |
 | infraClusterKubeconfig | InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed). This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes. | string | true |
-| ZoneAndRegionEnabled | ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider | bool | true |
+| zoneAndRegionEnabled | ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider | bool | false |
 | loadBalancerEnabled | LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers. | bool | false |
 
 [Back to Group](#v1beta2)

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2025-05-29T15:53:42+03:00
+date = 2025-06-11T12:48:35+02:00
 weight = 11
 +++
 ## v1beta3
@@ -589,7 +589,7 @@ KubevirtSpec defines the Kubevirt provider
 | ----- | ----------- | ------ | -------- |
 | infraNamespace | InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster, such as VirtualMachines, VirtualMachineInstances, etc... | string | true |
 | infraClusterKubeconfig | InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed). This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes. | string | true |
-| ZoneAndRegionEnabled | ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider | bool | true |
+| zoneAndRegionEnabled | ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider | bool | false |
 | loadBalancerEnabled | LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers. | bool | false |
 
 [Back to Group](#v1beta3)

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -464,7 +464,7 @@ type KubevirtSpec struct {
 	// This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes.
 	InfraClusterKubeconfig string `json:"infraClusterKubeconfig"`
 	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
-	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled,omitempty"`
+	ZoneAndRegionEnabled bool `json:"zoneAndRegionEnabled,omitempty"`
 	// LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers.
 	LoadBalancerEnabled bool `json:"loadBalancerEnabled,omitempty"`
 }

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -469,7 +469,7 @@ type KubevirtSpec struct {
 	// This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes.
 	InfraClusterKubeconfig string `json:"infraClusterKubeconfig"`
 	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
-	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled,omitempty"`
+	ZoneAndRegionEnabled bool `json:"zoneAndRegionEnabled,omitempty"`
 	// LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers.
 	LoadBalancerEnabled bool `json:"loadBalancerEnabled,omitempty"`
 }

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -461,7 +461,7 @@ type KubevirtSpec struct {
 	// This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes.
 	InfraClusterKubeconfig string `json:"infraClusterKubeconfig"`
 	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
-	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled,omitempty"`
+	ZoneAndRegionEnabled bool `json:"zoneAndRegionEnabled,omitempty"`
 	// LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers.
 	LoadBalancerEnabled bool `json:"loadBalancerEnabled,omitempty"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
Setting the field zoneAndRegionEnabled  to a json encoding instead of yaml
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
