### PR TITLE
Drop kubevirt infraClusterKubeconfig API fields 

### DIFF
--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2025-06-11T12:48:35+02:00
+date = 2025-06-12T15:55:08+03:00
 weight = 11
 +++
 ## v1beta2
@@ -586,7 +586,6 @@ KubevirtSpec defines the Kubevirt provider
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | infraNamespace | InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster, such as VirtualMachines, VirtualMachineInstances, etc... | string | true |
-| infraClusterKubeconfig | InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed). This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes. | string | true |
 | zoneAndRegionEnabled | ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider | bool | false |
 | loadBalancerEnabled | LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers. | bool | false |
 

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2025-06-11T12:48:35+02:00
+date = 2025-06-12T15:55:08+03:00
 weight = 11
 +++
 ## v1beta3
@@ -588,7 +588,6 @@ KubevirtSpec defines the Kubevirt provider
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | infraNamespace | InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster, such as VirtualMachines, VirtualMachineInstances, etc... | string | true |
-| infraClusterKubeconfig | InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed). This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes. | string | true |
 | zoneAndRegionEnabled | ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider | bool | false |
 | loadBalancerEnabled | LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers. | bool | false |
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -460,9 +460,6 @@ type KubevirtSpec struct {
 	// InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster,
 	// such as VirtualMachines, VirtualMachineInstances, etc...
 	InfraNamespace string `json:"infraNamespace"`
-	// InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed).
-	// This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes.
-	InfraClusterKubeconfig string `json:"infraClusterKubeconfig"`
 	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
 	ZoneAndRegionEnabled bool `json:"zoneAndRegionEnabled,omitempty"`
 	// LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers.

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -465,9 +465,6 @@ type KubevirtSpec struct {
 	// InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster,
 	// such as VirtualMachines, VirtualMachineInstances, etc...
 	InfraNamespace string `json:"infraNamespace"`
-	// InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed).
-	// This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes.
-	InfraClusterKubeconfig string `json:"infraClusterKubeconfig"`
 	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
 	ZoneAndRegionEnabled bool `json:"zoneAndRegionEnabled,omitempty"`
 	// LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers.

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -1793,7 +1793,6 @@ func autoConvert_kubeone_KubeletConfig_To_v1beta2_KubeletConfig(in *kubeone.Kube
 
 func autoConvert_v1beta2_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out *kubeone.KubevirtSpec, s conversion.Scope) error {
 	out.InfraNamespace = in.InfraNamespace
-	out.InfraClusterKubeconfig = in.InfraClusterKubeconfig
 	out.ZoneAndRegionEnabled = in.ZoneAndRegionEnabled
 	out.LoadBalancerEnabled = in.LoadBalancerEnabled
 	return nil
@@ -1806,7 +1805,6 @@ func Convert_v1beta2_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out 
 
 func autoConvert_kubeone_KubevirtSpec_To_v1beta2_KubevirtSpec(in *kubeone.KubevirtSpec, out *KubevirtSpec, s conversion.Scope) error {
 	out.InfraNamespace = in.InfraNamespace
-	out.InfraClusterKubeconfig = in.InfraClusterKubeconfig
 	out.ZoneAndRegionEnabled = in.ZoneAndRegionEnabled
 	out.LoadBalancerEnabled = in.LoadBalancerEnabled
 	return nil

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -457,9 +457,6 @@ type KubevirtSpec struct {
 	// InfraNamespace is the namespace that KubeVirt provider will use to create and manage resources in the infra cluster,
 	// such as VirtualMachines, VirtualMachineInstances, etc...
 	InfraNamespace string `json:"infraNamespace"`
-	// InfraClusterKubeconfig is a base64-encoded kubeconfig file that points to a KubeVirt infra cluster (a cluster where KubeVirt is installed).
-	// This Kubeconfig will be used to create and manage KubeVirt specific resources such as DataVolumes.
-	InfraClusterKubeconfig string `json:"infraClusterKubeconfig"`
 	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
 	ZoneAndRegionEnabled bool `json:"zoneAndRegionEnabled,omitempty"`
 	// LoadBalancerEnabled indicates if the ccm should create and manage the clusters load balancers.

--- a/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
@@ -1820,7 +1820,6 @@ func Convert_kubeone_KubeletConfig_To_v1beta3_KubeletConfig(in *kubeone.KubeletC
 
 func autoConvert_v1beta3_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out *kubeone.KubevirtSpec, s conversion.Scope) error {
 	out.InfraNamespace = in.InfraNamespace
-	out.InfraClusterKubeconfig = in.InfraClusterKubeconfig
 	out.ZoneAndRegionEnabled = in.ZoneAndRegionEnabled
 	out.LoadBalancerEnabled = in.LoadBalancerEnabled
 	return nil
@@ -1833,7 +1832,6 @@ func Convert_v1beta3_KubevirtSpec_To_kubeone_KubevirtSpec(in *KubevirtSpec, out 
 
 func autoConvert_kubeone_KubevirtSpec_To_v1beta3_KubevirtSpec(in *kubeone.KubevirtSpec, out *KubevirtSpec, s conversion.Scope) error {
 	out.InfraNamespace = in.InfraNamespace
-	out.InfraClusterKubeconfig = in.InfraClusterKubeconfig
 	out.ZoneAndRegionEnabled = in.ZoneAndRegionEnabled
 	out.LoadBalancerEnabled = in.LoadBalancerEnabled
 	return nil

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -19,7 +19,6 @@ package validation
 import (
 	"bytes"
 	"crypto/x509"
-	"encoding/base64"
 	"fmt"
 	"net"
 	"os"
@@ -217,15 +216,6 @@ func ValidateCloudProviderSpec(cluster kubeoneapi.KubeOneCluster, fldPath *field
 			allErrs = append(allErrs, field.Forbidden(kubevirtFld, "only one provider can be used at the same time"))
 		}
 		providerFound = true
-		switch providerSpec.Kubevirt.InfraClusterKubeconfig {
-		case "":
-			allErrs = append(allErrs, field.Required(kubevirtFld.Child("infraClusterKubeconfig"), "is required for kubevirt provider"))
-		default:
-			_, err := base64.StdEncoding.DecodeString(providerSpec.Kubevirt.InfraClusterKubeconfig)
-			if err != nil {
-				allErrs = append(allErrs, field.Forbidden(kubevirtFld.Child("infraClusterKubeconfig"), "must be base64-encoded"))
-			}
-		}
 		if providerSpec.Kubevirt.InfraNamespace == "" {
 			allErrs = append(allErrs, field.Required(kubevirtFld.Child("infraNamespace"), "is required for kubevirt provider"))
 		}

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -515,27 +515,15 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 			name: "valid Kubevirt provider config",
 			providerConfig: kubeoneapi.CloudProviderSpec{
 				Kubevirt: &kubeoneapi.KubevirtSpec{
-					InfraClusterKubeconfig: "YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMU1hZWgogICAgc2VydmVyOiBodHRwczovL3h5ei5leGFtcGxlLmNvbTo2NDQzCiAgbmFtZTogeHl6CmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiB4eXoKICAgIHVzZXI6IGRlZmF1bHQKICBuYW1lOiB4eXoKY3VycmVudC1jb250ZXh0OiB4eXoKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBkZWZhdWx0CiAgdXNlcjoKICAgIHRva2VuOiB4eXphdzI1Lnh5ego=",
-					InfraNamespace:         "tenant-xyz",
+					InfraNamespace: "tenant-xyz",
 				},
 			},
 			expectedError: false,
 		},
 		{
-			name: "Kubevirt provider config missing InfraClusterKubeconfig",
-			providerConfig: kubeoneapi.CloudProviderSpec{
-				Kubevirt: &kubeoneapi.KubevirtSpec{
-					InfraNamespace: "tenant-xyz",
-				},
-			},
-			expectedError: true,
-		},
-		{
 			name: "Kubevirt provider config missing InfraNamespace",
 			providerConfig: kubeoneapi.CloudProviderSpec{
-				Kubevirt: &kubeoneapi.KubevirtSpec{
-					InfraClusterKubeconfig: "YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMU1hZWgogICAgc2VydmVyOiBodHRwczovL3h5ei5leGFtcGxlLmNvbTo2NDQzCiAgbmFtZTogeHl6CmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiB4eXoKICAgIHVzZXI6IGRlZmF1bHQKICBuYW1lOiB4eXoKY3VycmVudC1jb250ZXh0OiB4eXoKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBkZWZhdWx0CiAgdXNlcjoKICAgIHRva2VuOiB4eXphdzI1Lnh5ego=",
-				},
+				Kubevirt: &kubeoneapi.KubevirtSpec{},
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
As it's not needed. This kubeconfig is covered by the credentials validation, the field been a duplicate of that, and not used anywhere.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drop kubevirt infraClusterKubeconfig API fields 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
