### PR TITLE
Remove machine-controller update from v1.10.1 changelog

### DIFF
--- a/CHANGELOG/CHANGELOG-1.10.md
+++ b/CHANGELOG/CHANGELOG-1.10.md
@@ -20,12 +20,6 @@
 
 - Fix incorrect CABundle flag in the operating-system-manager (OSM) Deployment ([#3644](https://github.com/kubermatic/kubeone/pull/3644), [@kubermatic-bot](https://github.com/kubermatic-bot))
 
-### Updates
-
-#### machine-controller
-
-- Update machine-controller to v1.61.3 ([#3673](https://github.com/kubermatic/kubeone/pull/3673), [@xmudrii](https://github.com/xmudrii))
-
 # [v1.10.0](https://github.com/kubermatic/kubeone/releases/tag/v1.10.0) - 2025-04-15
 
 We're happy to announce a new KubeOne minor release — KubeOne 1.10! Please


### PR DESCRIPTION
**What this PR does / why we need it**:

The machine-controller didn't get merged and hence is not included in the v1.10.1 release.

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @moadqassem @kron4eg 