### PR TITLE
Fixes the vsphere-config-secret name misalignment across vSphere CSI driver components.

### DIFF
--- a/addons/csi-vsphere/secret.yaml
+++ b/addons/csi-vsphere/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-config-secret
+  name: vsphere-config-secret
   namespace: vmware-system-csi
 data:
   csi-vsphere.conf: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
The vSphere e2e tests was failing due to the `vsphere-csi-controller` pod being unable to mount its configuration volume. The kubelet reported the error: `MountVolume.SetUp failed for volume "vsphere-config-volume" : secret "vsphere-config-secret" not found`. 
The `vsphere-config-secret` was not created with the exact name expected by the CSI driver's deployment instead , a secret named `vsphere-csi-config-secret` was created.. This PR ensures the secret name is correctly aligned.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes the vsphere-config-secret name misalignment across vSphere CSI driver components.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
