### PR TITLE
Fix CSI snapshot webhook name for Nutanix

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -266,9 +266,8 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 	webhookNamespace := resources.GenericCSIWebhookNamespace
 	certNamePrefix := webhookCertsCSI
 
-	switch {
 	// Certs for vsphere-csi-webhook (deployed only if CSIMigration is enabled)
-	case s.Cluster.CloudProvider.Vsphere != nil:
+	if s.Cluster.CloudProvider.Vsphere != nil {
 		if err := webhookCerts(data.Certificates,
 			webhookCertsCSI,
 			webhookName,
@@ -287,8 +286,6 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 		if !csiMigration {
 			return nil
 		}
-	case s.Cluster.CloudProvider.Nutanix != nil:
-		webhookName = resources.NutanixCSIWebhookName
 	}
 
 	return webhookCerts(

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -105,7 +105,6 @@ const (
 	VsphereCSINamespace        = "vmware-system-csi"
 	VsphereCSIWebhookName      = "vsphere-webhook-svc"
 	VsphereCSIWebhookNamespace = "vmware-system-csi"
-	NutanixCSIWebhookName      = "csi-snapshot-webhook"
 	GenericCSIWebhookName      = "snapshot-validation-service"
 	GenericCSIWebhookNamespace = metav1.NamespaceSystem
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a fix for 
```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation-webhook.snapshot.storage.k8s.io": failed to call webhook: Post "[https://snapshot-validation-service.kube-system.svc:443/volumesnapshot?timeout=2s](https://snapshot-validation-service.kube-system.svc/volumesnapshot?timeout=2s)": tls: failed to verify certificate: x509: certificate is valid for csi-snapshot-webhook.kube-system.svc.cluster.local., csi-snapshot-webhook.kube-system.svc, not snapshot-validation-service.kube-system.svc
```

error

**Which issue(s) this PR fixes**:
Fixes #3762

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CSI snapshot webhook name for Nutanix
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
