### PR TITLE
Make machine-controller -join-cluster-timeout configurable

### DIFF
--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -52,7 +52,7 @@ spec:
             {{ if CABundle -}}
             - -ca-bundle={{ .Resources.CABundleSSLCertFilePath }}
             {{ end -}}
-            - -join-cluster-timeout=15m
+            - -join-cluster-timeout={{ default "15m" .Params.JOIN_TIMEOUT }}
           env:
   {{ with .Config.CloudProvider.Kubevirt -}}
   {{ with .InfraNamespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Some people need this timeout even longed compared to what we had hardcoded.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3777

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make machine-controller -join-cluster-timeout configurable
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
