### PR TITLE
Add --all flag to config images list command (#3759)

### DIFF
--- a/pkg/cmd/config-images.go
+++ b/pkg/cmd/config-images.go
@@ -32,6 +32,7 @@ type listImagesOpts struct {
 	ManifestFile      string `longflag:"manifest" shortflag:"m"`
 	Filter            string `longflag:"filter"`
 	KubernetesVersion string `longflag:"kubernetes-version" shortflag:"k"`
+	AllImages         bool   `longflag:"all" shortflag:"a"`
 }
 
 func configImagesCmd(rootFlags *pflag.FlagSet) *cobra.Command {
@@ -51,8 +52,11 @@ func listImagesCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		Use:   "list",
 		Short: "List images that will be used",
 		Example: heredoc.Doc(`
-			# To see all images list
+			# To see default images list
 			kubeone config images list
+
+			# To see all images list for all Kubernetes versions
+			kubeone config images list --all
 
 			# To see base images list
 			kubeone config images list --filter base
@@ -90,6 +94,13 @@ func listImagesCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		"",
 		"filter images for a provided kubernetes version")
 
+	cmd.Flags().BoolVar(
+		&opts.AllImages,
+		longFlagName(opts, "AllImages"),
+		false,
+		"list all images, including optional ones",
+	)
+
 	return cmd
 }
 
@@ -115,7 +126,14 @@ func listImages(opts *listImagesOpts) error {
 		return err
 	}
 
-	for _, img := range imgResolver.List(listFilter) {
+	var images []string
+	if opts.AllImages {
+		images = imgResolver.ListAll()
+	} else {
+		images = imgResolver.List(listFilter)
+	}
+
+	for _, img := range images {
 		fmt.Println(img)
 	}
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -20,6 +20,8 @@ package images
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
@@ -494,6 +496,24 @@ func (r *Resolver) List(lf ListFilter) []string {
 			list = append(list, img)
 		}
 	}
+
+	sort.Strings(list)
+
+	return list
+}
+
+func (r *Resolver) ListAll() []string {
+	resources := allResources()
+
+	// create a bool map, to deduplicate the images
+	listMap := make(map[string]bool)
+	for res := range resources {
+		for _, img := range resources[res] {
+			listMap[img] = true
+		}
+	}
+
+	list := slices.Collect(maps.Keys(listMap))
 
 	sort.Strings(list)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This PR adds an `--all` flag to the `kubecone config image list` command

**Which issue(s) this PR fixes**:
Fixes #3759

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `--all` flag to `config images list` showing all images independent of Kubernetes version
```

**Documentation**:
```documentation
NONE
```
