### PR TITLE
add option to enable non root device usage in worker nodes by osm

### DIFF
--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -73,6 +73,9 @@ spec:
             {{ with .Config.Proxy.NoProxy }}
             - -node-no-proxy={{ . }}
             {{ end }}
+            {{ if .Config.OperatingSystemManager.EnableNonRootDeviceOwnership }}
+            - -device-ownership-from-security-context
+            {{ end }}
           env:
             - name: HTTPS_PROXY
               value: "{{ .Config.Proxy.HTTPS }}"

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2025-08-21T15:56:47+02:00
+date = 2025-08-21T16:58:51+02:00
 weight = 11
 +++
 ## v1beta2
@@ -695,7 +695,7 @@ OperatingSystemManagerConfig configures kubermatic operating-system-manager depl
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | deploy | Deploy | bool | false |
-| enableNonRootDeviceOwnership | \n # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime. | bool | false |
+| enableNonRootDeviceOwnership | EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime. | bool | false |
 
 [Back to Group](#v1beta2)
 

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2025-06-12T15:55:08+03:00
+date = 2025-08-21T15:56:47+02:00
 weight = 11
 +++
 ## v1beta2
@@ -695,6 +695,7 @@ OperatingSystemManagerConfig configures kubermatic operating-system-manager depl
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | deploy | Deploy | bool | false |
+| enableNonRootDeviceOwnership | \n # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime. | bool | false |
 
 [Back to Group](#v1beta2)
 

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2025-08-21T15:56:47+02:00
+date = 2025-08-21T16:58:51+02:00
 weight = 11
 +++
 ## v1beta3
@@ -697,7 +697,7 @@ OperatingSystemManagerConfig configures kubermatic operating-system-manager depl
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | deploy | Deploy | bool | false |
-| enableNonRootDeviceOwnership | \n # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime. | bool | false |
+| enableNonRootDeviceOwnership | EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime. | bool | false |
 
 [Back to Group](#v1beta3)
 

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2025-06-12T15:55:08+03:00
+date = 2025-08-21T15:56:47+02:00
 weight = 11
 +++
 ## v1beta3
@@ -697,6 +697,7 @@ OperatingSystemManagerConfig configures kubermatic operating-system-manager depl
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | deploy | Deploy | bool | false |
+| enableNonRootDeviceOwnership | \n # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime. | bool | false |
 
 [Back to Group](#v1beta3)
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -749,6 +749,8 @@ type MachineControllerConfig struct {
 type OperatingSystemManagerConfig struct {
 	// Deploy
 	Deploy bool `json:"deploy,omitempty"`
+	//  # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 
 // SystemPackages controls configurations of APT/YUM

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -749,7 +749,7 @@ type MachineControllerConfig struct {
 type OperatingSystemManagerConfig struct {
 	// Deploy
 	Deploy bool `json:"deploy,omitempty"`
-	//  # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	// EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
 	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -761,7 +761,7 @@ type MachineControllerConfig struct {
 type OperatingSystemManagerConfig struct {
 	// Deploy
 	Deploy bool `json:"deploy,omitempty"`
-	//  # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	// EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
 	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -761,6 +761,8 @@ type MachineControllerConfig struct {
 type OperatingSystemManagerConfig struct {
 	// Deploy
 	Deploy bool `json:"deploy,omitempty"`
+	//  # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 
 // SystemPackages controls configurations of APT/YUM

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -2015,6 +2015,7 @@ func Convert_kubeone_OpenstackSpec_To_v1beta2_OpenstackSpec(in *kubeone.Openstac
 
 func autoConvert_v1beta2_OperatingSystemManagerConfig_To_kubeone_OperatingSystemManagerConfig(in *OperatingSystemManagerConfig, out *kubeone.OperatingSystemManagerConfig, s conversion.Scope) error {
 	out.Deploy = in.Deploy
+	out.EnableNonRootDeviceOwnership = in.EnableNonRootDeviceOwnership
 	return nil
 }
 
@@ -2025,6 +2026,7 @@ func Convert_v1beta2_OperatingSystemManagerConfig_To_kubeone_OperatingSystemMana
 
 func autoConvert_kubeone_OperatingSystemManagerConfig_To_v1beta2_OperatingSystemManagerConfig(in *kubeone.OperatingSystemManagerConfig, out *OperatingSystemManagerConfig, s conversion.Scope) error {
 	out.Deploy = in.Deploy
+	out.EnableNonRootDeviceOwnership = in.EnableNonRootDeviceOwnership
 	return nil
 }
 

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -745,7 +745,7 @@ type MachineControllerConfig struct {
 type OperatingSystemManagerConfig struct {
 	// Deploy
 	Deploy bool `json:"deploy,omitempty"`
-	//  # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	// EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
 	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -745,6 +745,8 @@ type MachineControllerConfig struct {
 type OperatingSystemManagerConfig struct {
 	// Deploy
 	Deploy bool `json:"deploy,omitempty"`
+	//  # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 
 // SystemPackages controls configurations of APT/YUM

--- a/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
@@ -2042,6 +2042,7 @@ func Convert_kubeone_OpenstackSpec_To_v1beta3_OpenstackSpec(in *kubeone.Openstac
 
 func autoConvert_v1beta3_OperatingSystemManagerConfig_To_kubeone_OperatingSystemManagerConfig(in *OperatingSystemManagerConfig, out *kubeone.OperatingSystemManagerConfig, s conversion.Scope) error {
 	out.Deploy = in.Deploy
+	out.EnableNonRootDeviceOwnership = in.EnableNonRootDeviceOwnership
 	return nil
 }
 
@@ -2052,6 +2053,7 @@ func Convert_v1beta3_OperatingSystemManagerConfig_To_kubeone_OperatingSystemMana
 
 func autoConvert_kubeone_OperatingSystemManagerConfig_To_v1beta3_OperatingSystemManagerConfig(in *kubeone.OperatingSystemManagerConfig, out *OperatingSystemManagerConfig, s conversion.Scope) error {
 	out.Deploy = in.Deploy
+	out.EnableNonRootDeviceOwnership = in.EnableNonRootDeviceOwnership
 	return nil
 }
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -227,7 +227,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.4"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.62.0"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.7.2"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.7.4"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.7.5"},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This pr introduces the option to enable non root device usage in container runtime by configuring a new introduced flag of the operating system manager.
ref: https://github.com/kubermatic/kubermatic/issues/14352

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Non-root device usage on non-static worker nodes can now be enabled for containerd runtime by setting the value `operatingSystemManager.enableNonRootDeviceOwnership` to `true` when osm is enabled.

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
