### PR TITLE
fix: add hubble-server-certs to cilium DaemonSet

### DIFF
--- a/addons/cni-cilium/Kustomization
+++ b/addons/cni-cilium/Kustomization
@@ -3,12 +3,12 @@ kind: Kustomization
 namespace: kube-system
 
 helmCharts:
-- name: cilium
-  repo: https://helm.cilium.io/
-  version: 1.17.3
-  releaseName: cilium
-  namespace: kube-system
-  valuesFile: helm-values
+  - name: cilium
+    repo: https://helm.cilium.io/
+    version: 1.17.3
+    releaseName: cilium
+    namespace: kube-system
+    valuesFile: helm-values
 
 patches:
   - patch: |-
@@ -55,6 +55,10 @@ patches:
                         name: cilium-config
                         key: KUBERNETES_SERVICE_PORT
                         optional: true
+                volumeMounts:
+                  - name: hubble-tls
+                    mountPath: /var/lib/cilium/tls/hubble
+                    readOnly: true
             initContainers:
               - name: config
                 image: '{{ .InternalImages.Get "Cilium" }}'
@@ -94,6 +98,21 @@ patches:
                         optional: true
               - name: install-cni-binaries
                 image: '{{ .InternalImages.Get "Cilium" }}'
+            volumes:
+              - name: hubble-tls
+                projected:
+                  defaultMode: 256
+                  sources:
+                  - secret:
+                      name: hubble-server-certs
+                      optional: true
+                      items:
+                      - key: tls.crt
+                        path: server.crt
+                      - key: tls.key
+                        path: server.key
+                      - key: ca.crt
+                        path: client-ca.crt
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -1198,6 +1198,9 @@ spec:
             successThreshold: 1
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
+            - mountPath: /var/lib/cilium/tls/hubble
+              name: hubble-tls
+              readOnly: true
             - mountPath: /var/run/cilium/envoy/sockets
               name: envoy-sockets
               readOnly: false
@@ -1429,6 +1432,20 @@ spec:
       tolerations:
         - operator: Exists
       volumes:
+        - name: hubble-tls
+          projected:
+            defaultMode: 256
+            sources:
+              - secret:
+                  items:
+                    - key: tls.crt
+                      path: server.crt
+                    - key: tls.key
+                      path: server.key
+                    - key: ca.crt
+                      path: client-ca.crt
+                  name: hubble-server-certs
+                  optional: true
         - emptyDir: {}
           name: tmp
         - hostPath:


### PR DESCRIPTION
Makes SSL connection from Hubble Relay possible and fixes the Hubble installation when  CNI is cilium and enableHubble: true

```yaml
clusterNetwork:
  cni:
    cilium:
      enableHubble: true
````
in kubeone.yaml

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3794

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes the Hubbele Relay Connection Issues with the Cilium Agent, SSL Connection is fixed by mounting the Server Certificates in the Cilium Agent Container
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE fixes a bug
```
