### PR TITLE
Remove software-properties-common dependency

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -53,7 +53,7 @@ var containerRuntimeTemplates = map[string]string{
 	"apt-containerd": heredoc.Docf(`
 			{{ if .CONFIGURE_REPOSITORIES }}
 			sudo apt-get update
-			sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+			sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 			sudo install -m 0755 -d /etc/apt/keyrings
 			sudo rm -f /etc/apt/keyrings/docker.gpg
 			curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/pkg/scripts/testdata/TestDebScript-install_all.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all.golden
@@ -76,7 +76,7 @@ kube_ver="1.30.0-*"
 
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
@@ -77,7 +77,7 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
@@ -76,7 +76,7 @@ kube_ver="1.30.0-*"
 
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
@@ -77,7 +77,7 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -77,7 +77,7 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
@@ -77,7 +77,7 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+sudo apt-get install -y apt-transport-https ca-certificates curl lsb-release
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo rm -f /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]')/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes the dependency on `software-properies-common`, which was removed from the Debian Trixie distribution.

**Which issue(s) this PR fixes**:

Fixes #3832 

**What type of PR is this?**

/kind bug

```release-note
Don't install software-properties-common on deb systems
```

```documentation
NONE
```