### PR TITLE
Improve OS package handling on deb systems

### DIFF
--- a/pkg/scripts/testdata/TestDebScript-install_all.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all.golden
@@ -50,6 +50,16 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	apparmor-utils \
+	lsb-release \
+	rsync
+
 # Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
@@ -62,14 +72,6 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
-	apt-transport-https \
-	ca-certificates \
-	curl \
-	gnupg \
-	apparmor-utils \
-	lsb-release \
-	rsync
 
 kube_ver="1.30.0-*"
 

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
@@ -50,6 +50,16 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	apparmor-utils \
+	lsb-release \
+	rsync
+
 # Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
@@ -62,14 +72,6 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
-	apt-transport-https \
-	ca-certificates \
-	curl \
-	gnupg \
-	apparmor-utils \
-	lsb-release \
-	rsync
 
 kube_ver="1.30.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
@@ -50,6 +50,16 @@ Acquire::https::Proxy "http://proxy.tld";
 Acquire::http::Proxy "http://proxy.tld";
 EOF
 
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	apparmor-utils \
+	lsb-release \
+	rsync
+
 # Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
@@ -62,14 +72,6 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
-	apt-transport-https \
-	ca-certificates \
-	curl \
-	gnupg \
-	apparmor-utils \
-	lsb-release \
-	rsync
 
 kube_ver="1.30.0-*"
 

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
@@ -50,6 +50,16 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	apparmor-utils \
+	lsb-release \
+	rsync
+
 # Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
@@ -62,14 +72,6 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
-	apt-transport-https \
-	ca-certificates \
-	curl \
-	gnupg \
-	apparmor-utils \
-	lsb-release \
-	rsync
 
 kube_ver="1.30.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -50,6 +50,16 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	apparmor-utils \
+	lsb-release \
+	rsync
+
 # Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
@@ -62,14 +72,6 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
-	apt-transport-https \
-	ca-certificates \
-	curl \
-	gnupg \
-	apparmor-utils \
-	lsb-release \
-	rsync
 
 kube_ver="1.30.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
@@ -50,6 +50,16 @@ Acquire::https::Proxy "http://https.proxy";
 Acquire::http::Proxy "http://http.proxy";
 EOF
 
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	apparmor-utils \
+	lsb-release \
+	rsync
+
 # Removing deprecated Kubernetes repositories from apt sources is needed when upgrading from older KubeOne versions,
 # otherwise, apt-get update will fail to upgrade the packages.
 if sudo grep -q "deb http://apt.kubernetes.io/ kubernetes-xenial main" /etc/apt/sources.list.d/kubernetes.list; then
@@ -62,14 +72,6 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | 
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
-	apt-transport-https \
-	ca-certificates \
-	curl \
-	gnupg \
-	apparmor-utils \
-	lsb-release \
-	rsync
 
 kube_ver="1.30.0-*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools


### PR DESCRIPTION
**What this PR does / why we need it**:

The installer currently tries to install `curl` and `gnupg` after setting up the k8s repository. Preparing the signing key requires both `curl` and `gnupg`. 

This PR flips the order by installing all OS packages first, then downloading the pkgs.k8s.io key and setting up hte sources.list file. Once that is complete `apt-get update` is called again to make `apt` aware of the new repo.

**What type of PR is this?**

/kind cleanup


**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Improve OS package handling on deb systems
```

**Documentation**:

```documentation
NONE
```
