### PR TITLE
Cluster wide KubeletConfig

### DIFF
--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2025-10-08T17:27:45+03:00
+date = 2025-10-14T16:55:58+03:00
 weight = 11
 +++
 ## v1beta2
@@ -535,6 +535,7 @@ KubeOneCluster is KubeOne Cluster API Schema
 | ----- | ----------- | ------ | -------- |
 | name | Name is the name of the cluster. | string | true |
 | controlPlane | ControlPlane describes the control plane nodes and how to access them. | [ControlPlaneConfig](#controlplaneconfig) | true |
+| kubeletConfig | KubeletConfig used to generate cluster's KubeletConfiguration that will be used along with kubeadm | [KubeletConfig](#kubeletconfig) | false |
 | apiEndpoint | APIEndpoint are pairs of address and port used to communicate with the Kubernetes API. | [APIEndpoint](#apiendpoint) | true |
 | cloudProvider | CloudProvider configures the cloud provider specific features. | [CloudProviderSpec](#cloudproviderspec) | true |
 | versions | Versions defines which Kubernetes version will be installed. | [VersionConfig](#versionconfig) | true |
@@ -580,6 +581,10 @@ KubeletConfig provides some kubelet configuration options
 | kubeReserved | KubeReserved configure --kube-reserved command-line flag of the kubelet. See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ | map[string]string | false |
 | evictionHard | EvictionHard configure --eviction-hard command-line flag of the kubelet. See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ | map[string]string | false |
 | maxPods | MaxPods configures maximum number of pods per node. If not provided, default value provided by kubelet will be used (max. 110 pods per node) | *int32 | false |
+| imageGCHighThresholdPercent | ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive. When specified, the value must be greater than imageGCLowThresholdPercent. Default: 85 | *int32 | false |
+| imageGCLowThresholdPercent | ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the field value must be between 0 and 100, inclusive. When specified, the value must be less than imageGCHighThresholdPercent. Default: 80 | *int32 | false |
+| imageMinimumGCAge | ImageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: \"2m\" | metav1.Duration | false |
+| imageMaximumGCAge | ImageMaximumGCAge is the maximum age an image can be unused before it is garbage collected. The default of this field is \"0s\", which disables this field--meaning images won't be garbage collected based on being unused for too long. Default: \"0s\" (disabled) | metav1.Duration | false |
 
 [Back to Group](#v1beta2)
 

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2025-10-08T17:27:45+03:00
+date = 2025-10-14T16:55:58+03:00
 weight = 11
 +++
 ## v1beta3
@@ -539,6 +539,7 @@ KubeOneCluster is KubeOne Cluster API Schema
 | controlPlane | ControlPlane describes the control plane nodes and how to access them. | [ControlPlaneConfig](#controlplaneconfig) | true |
 | apiEndpoint | APIEndpoint are pairs of address and port used to communicate with the Kubernetes API. | [APIEndpoint](#apiendpoint) | true |
 | cloudProvider | CloudProvider configures the cloud provider specific features. | [CloudProviderSpec](#cloudproviderspec) | true |
+| kubeletConfig | KubeletConfig used to generate cluster's KubeletConfiguration that will be used along with kubeadm | [KubeletConfig](#kubeletconfig) | false |
 | versions | Versions defines which Kubernetes version will be installed. | [VersionConfig](#versionconfig) | true |
 | containerRuntime | ContainerRuntime defines which container runtime will be installed | [ContainerRuntimeConfig](#containerruntimeconfig) | false |
 | clusterNetwork | ClusterNetwork configures the in-cluster networking. | [ClusterNetworkConfig](#clusternetworkconfig) | false |
@@ -582,6 +583,10 @@ KubeletConfig provides some kubelet configuration options
 | evictionHard | EvictionHard configure --eviction-hard command-line flag of the kubelet. See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ | map[string]string | false |
 | maxPods | MaxPods configures maximum number of pods per node. If not provided, default value provided by kubelet will be used (max. 110 pods per node) | *int32 | false |
 | podPidsLimit | PodPidsLimit configures the maximum number of processes running in a Pod If not provided, default value provided by kubelet will be used -1 See more about pid-limiting at: https://kubernetes.io/docs/concepts/policy/pid-limiting/ | *int64 | false |
+| imageGCHighThresholdPercent | ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive. When specified, the value must be greater than imageGCLowThresholdPercent. Default: 85 | *int32 | false |
+| imageGCLowThresholdPercent | ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the field value must be between 0 and 100, inclusive. When specified, the value must be less than imageGCHighThresholdPercent. Default: 80 | *int32 | false |
+| imageMinimumGCAge | ImageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: \"2m\" | metav1.Duration | false |
+| imageMaximumGCAge | ImageMaximumGCAge is the maximum age an image can be unused before it is garbage collected. The default of this field is \"0s\", which disables this field--meaning images won't be garbage collected based on being unused for too long. Default: \"0s\" (disabled) | metav1.Duration | false |
 
 [Back to Group](#v1beta3)
 

--- a/examples/terraform/aws-dualstack/output.tf
+++ b/examples/terraform/aws-dualstack/output.tf
@@ -51,10 +51,14 @@ output "kubeone_hosts" {
       # uncomment to following to set those kubelet parameters. More into at:
       # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
       # kubelet            = {
-      #   system_reserved = "cpu=200m,memory=200Mi"
-      #   kube_reserved   = "cpu=200m,memory=300Mi"
-      #   eviction_hard   = ""
-      #   max_pods        = 110
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
       # }
     }
   }
@@ -110,10 +114,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -173,10 +181,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -236,10 +248,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -51,10 +51,14 @@ output "kubeone_hosts" {
       # uncomment to following to set those kubelet parameters. More into at:
       # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
       # kubelet            = {
-      #   system_reserved = "cpu=200m,memory=200Mi"
-      #   kube_reserved   = "cpu=200m,memory=300Mi"
-      #   eviction_hard   = ""
-      #   max_pods        = 110
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
       # }
     }
   }
@@ -112,10 +116,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -174,10 +182,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -236,10 +248,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -39,6 +39,16 @@ output "kubeone_hosts" {
       ssh_user             = local.ssh_username
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -76,10 +86,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -38,6 +38,16 @@ output "kubeone_hosts" {
       ssh_user             = local.ssh_username
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -69,10 +79,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -39,6 +39,16 @@ output "kubeone_hosts" {
       ssh_user             = var.ssh_username
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -70,10 +80,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -44,6 +44,16 @@ output "kubeone_hosts" {
       ssh_user             = local.ssh_username
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -75,10 +85,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/nutanix/output.tf
+++ b/examples/terraform/nutanix/output.tf
@@ -44,6 +44,16 @@ output "kubeone_hosts" {
       bastion_user         = var.bastion_user
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -75,10 +85,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -50,6 +50,16 @@ output "kubeone_hosts" {
       bastion_user         = var.bastion_user
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -83,10 +93,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/vmware-cloud-director/output.tf
+++ b/examples/terraform/vmware-cloud-director/output.tf
@@ -47,6 +47,16 @@ output "kubeone_hosts" {
       bastion              = var.enable_bastion_host ? local.external_network_ip : null
       bastion_port         = var.enable_bastion_host ? var.bastion_host_ssh_port : null
       bastion_user         = var.enable_bastion_host ? var.ssh_username : null
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -78,10 +88,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -44,6 +44,16 @@ output "kubeone_hosts" {
       bastion_user         = var.bastion_username
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -75,10 +85,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/vsphere_flatcar/outputs.tf
+++ b/examples/terraform/vsphere_flatcar/outputs.tf
@@ -42,6 +42,16 @@ output "kubeone_hosts" {
       bastion_user         = var.bastion_username
       ssh_hosts_keys       = var.ssh_hosts_keys
       bastion_host_key     = var.bastion_host_key
+      # kubelet            = {
+      #   system_reserved                 = "cpu=200m,memory=200Mi"
+      #   kube_reserved                   = "cpu=200m,memory=300Mi"
+      #   eviction_hard                   = ""
+      #   max_pods                        = 110
+      #   image_gc_high_threshold_percent = 85
+      #   image_gc_low_threshold_percent  = 80
+      #   image_minimum_gc_age            = "2m"
+      #   image_maximum_gc_age            = "0"
+      # }
     }
   }
 }
@@ -75,10 +85,14 @@ output "kubeone_workers" {
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
         # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -35,6 +35,9 @@ type KubeOneCluster struct {
 	// ControlPlane describes the control plane nodes and how to access them.
 	ControlPlane ControlPlaneConfig `json:"controlPlane"`
 
+	// KubeletConfig used to generate cluster's KubeletConfiguration that will be used along with kubeadm
+	KubeletConfig KubeletConfig `json:"kubeletConfig,omitempty"`
+
 	// APIEndpoint are pairs of address and port used to communicate with the Kubernetes API.
 	APIEndpoint APIEndpoint `json:"apiEndpoint"`
 
@@ -381,6 +384,25 @@ type KubeletConfig struct {
 	// If not provided, default value provided by kubelet will be used -1
 	// See more about pid-limiting at: https://kubernetes.io/docs/concepts/policy/pid-limiting/
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty"`
+
+	// ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The
+	// percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive.
+	// When specified, the value must be greater than imageGCLowThresholdPercent. Default: 85
+	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty"`
+
+	// ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run.
+	// Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the
+	// field value must be between 0 and 100, inclusive. When specified, the value must be less than
+	// imageGCHighThresholdPercent. Default: 80
+	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty"`
+
+	// ImageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
+	ImageMinimumGCAge metav1.Duration `json:"imageMinimumGCAge,omitempty"`
+
+	// ImageMaximumGCAge is the maximum age an image can be unused before it is garbage collected. The default of this
+	// field is "0s", which disables this field--meaning images won't be garbage collected based on being unused for too
+	// long. Default: "0s" (disabled)
+	ImageMaximumGCAge metav1.Duration `json:"imageMaximumGCAge,omitempty"`
 }
 
 // APIEndpoint is the endpoint used to communicate with the Kubernetes API

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -35,6 +35,9 @@ type KubeOneCluster struct {
 	// ControlPlane describes the control plane nodes and how to access them.
 	ControlPlane ControlPlaneConfig `json:"controlPlane"`
 
+	// KubeletConfig used to generate cluster's KubeletConfiguration that will be used along with kubeadm
+	KubeletConfig KubeletConfig `json:"kubeletConfig,omitempty"`
+
 	// APIEndpoint are pairs of address and port used to communicate with the Kubernetes API.
 	APIEndpoint APIEndpoint `json:"apiEndpoint"`
 
@@ -386,6 +389,25 @@ type KubeletConfig struct {
 	// If not provided, default value provided by kubelet will be used
 	// (max. 110 pods per node)
 	MaxPods *int32 `json:"maxPods,omitempty"`
+
+	// ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The
+	// percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive.
+	// When specified, the value must be greater than imageGCLowThresholdPercent. Default: 85
+	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty"`
+
+	// ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run.
+	// Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the
+	// field value must be between 0 and 100, inclusive. When specified, the value must be less than
+	// imageGCHighThresholdPercent. Default: 80
+	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty"`
+
+	// ImageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
+	ImageMinimumGCAge metav1.Duration `json:"imageMinimumGCAge,omitempty"`
+
+	// ImageMaximumGCAge is the maximum age an image can be unused before it is garbage collected. The default of this
+	// field is "0s", which disables this field--meaning images won't be garbage collected based on being unused for too
+	// long. Default: "0s" (disabled)
+	ImageMaximumGCAge metav1.Duration `json:"imageMaximumGCAge,omitempty"`
 }
 
 // APIEndpoint is the endpoint used to communicate with the Kubernetes API

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -1643,6 +1643,9 @@ func autoConvert_v1beta2_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneClu
 	if err := Convert_v1beta2_ControlPlaneConfig_To_kubeone_ControlPlaneConfig(&in.ControlPlane, &out.ControlPlane, s); err != nil {
 		return err
 	}
+	if err := Convert_v1beta2_KubeletConfig_To_kubeone_KubeletConfig(&in.KubeletConfig, &out.KubeletConfig, s); err != nil {
+		return err
+	}
 	if err := Convert_v1beta2_APIEndpoint_To_kubeone_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
 		return err
 	}
@@ -1699,6 +1702,9 @@ func autoConvert_v1beta2_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneClu
 func autoConvert_kubeone_KubeOneCluster_To_v1beta2_KubeOneCluster(in *kubeone.KubeOneCluster, out *KubeOneCluster, s conversion.Scope) error {
 	out.Name = in.Name
 	if err := Convert_kubeone_ControlPlaneConfig_To_v1beta2_ControlPlaneConfig(&in.ControlPlane, &out.ControlPlane, s); err != nil {
+		return err
+	}
+	if err := Convert_kubeone_KubeletConfig_To_v1beta2_KubeletConfig(&in.KubeletConfig, &out.KubeletConfig, s); err != nil {
 		return err
 	}
 	if err := Convert_kubeone_APIEndpoint_To_v1beta2_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
@@ -1783,6 +1789,10 @@ func autoConvert_v1beta2_KubeletConfig_To_kubeone_KubeletConfig(in *KubeletConfi
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.EvictionHard = *(*map[string]string)(unsafe.Pointer(&in.EvictionHard))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
+	out.ImageGCHighThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCHighThresholdPercent))
+	out.ImageGCLowThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCLowThresholdPercent))
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return nil
 }
 
@@ -1797,6 +1807,10 @@ func autoConvert_kubeone_KubeletConfig_To_v1beta2_KubeletConfig(in *kubeone.Kube
 	out.EvictionHard = *(*map[string]string)(unsafe.Pointer(&in.EvictionHard))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	// WARNING: in.PodPidsLimit requires manual conversion: does not exist in peer-type
+	out.ImageGCHighThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCHighThresholdPercent))
+	out.ImageGCLowThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCLowThresholdPercent))
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return nil
 }
 

--- a/pkg/apis/kubeone/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.deepcopy.go
@@ -948,6 +948,7 @@ func (in *KubeOneCluster) DeepCopyInto(out *KubeOneCluster) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ControlPlane.DeepCopyInto(&out.ControlPlane)
+	in.KubeletConfig.DeepCopyInto(&out.KubeletConfig)
 	in.APIEndpoint.DeepCopyInto(&out.APIEndpoint)
 	in.CloudProvider.DeepCopyInto(&out.CloudProvider)
 	out.Versions = in.Versions
@@ -1079,6 +1080,18 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ImageGCHighThresholdPercent != nil {
+		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ImageGCLowThresholdPercent != nil {
+		in, out := &in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent
+		*out = new(int32)
+		**out = **in
+	}
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return
 }
 

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -41,6 +41,9 @@ type KubeOneCluster struct {
 	// CloudProvider configures the cloud provider specific features.
 	CloudProvider CloudProviderSpec `json:"cloudProvider"`
 
+	// KubeletConfig used to generate cluster's KubeletConfiguration that will be used along with kubeadm
+	KubeletConfig KubeletConfig `json:"kubeletConfig,omitempty"`
+
 	// Versions defines which Kubernetes version will be installed.
 	Versions VersionConfig `json:"versions"`
 
@@ -378,6 +381,25 @@ type KubeletConfig struct {
 	// If not provided, default value provided by kubelet will be used -1
 	// See more about pid-limiting at: https://kubernetes.io/docs/concepts/policy/pid-limiting/
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty"`
+
+	// ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The
+	// percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive.
+	// When specified, the value must be greater than imageGCLowThresholdPercent. Default: 85
+	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty"`
+
+	// ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run.
+	// Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the
+	// field value must be between 0 and 100, inclusive. When specified, the value must be less than
+	// imageGCHighThresholdPercent. Default: 80
+	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty"`
+
+	// ImageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
+	ImageMinimumGCAge metav1.Duration `json:"imageMinimumGCAge,omitempty"`
+
+	// ImageMaximumGCAge is the maximum age an image can be unused before it is garbage collected. The default of this
+	// field is "0s", which disables this field--meaning images won't be garbage collected based on being unused for too
+	// long. Default: "0s" (disabled)
+	ImageMaximumGCAge metav1.Duration `json:"imageMaximumGCAge,omitempty"`
 }
 
 // APIEndpoint is the endpoint used to communicate with the Kubernetes API

--- a/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
@@ -1682,6 +1682,9 @@ func autoConvert_v1beta3_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneClu
 	if err := Convert_v1beta3_CloudProviderSpec_To_kubeone_CloudProviderSpec(&in.CloudProvider, &out.CloudProvider, s); err != nil {
 		return err
 	}
+	if err := Convert_v1beta3_KubeletConfig_To_kubeone_KubeletConfig(&in.KubeletConfig, &out.KubeletConfig, s); err != nil {
+		return err
+	}
 	if err := Convert_v1beta3_VersionConfig_To_kubeone_VersionConfig(&in.Versions, &out.Versions, s); err != nil {
 		return err
 	}
@@ -1728,6 +1731,9 @@ func Convert_v1beta3_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneCluster
 func autoConvert_kubeone_KubeOneCluster_To_v1beta3_KubeOneCluster(in *kubeone.KubeOneCluster, out *KubeOneCluster, s conversion.Scope) error {
 	out.Name = in.Name
 	if err := Convert_kubeone_ControlPlaneConfig_To_v1beta3_ControlPlaneConfig(&in.ControlPlane, &out.ControlPlane, s); err != nil {
+		return err
+	}
+	if err := Convert_kubeone_KubeletConfig_To_v1beta3_KubeletConfig(&in.KubeletConfig, &out.KubeletConfig, s); err != nil {
 		return err
 	}
 	if err := Convert_kubeone_APIEndpoint_To_v1beta3_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
@@ -1805,6 +1811,10 @@ func autoConvert_v1beta3_KubeletConfig_To_kubeone_KubeletConfig(in *KubeletConfi
 	out.EvictionHard = *(*map[string]string)(unsafe.Pointer(&in.EvictionHard))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	out.PodPidsLimit = (*int64)(unsafe.Pointer(in.PodPidsLimit))
+	out.ImageGCHighThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCHighThresholdPercent))
+	out.ImageGCLowThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCLowThresholdPercent))
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return nil
 }
 
@@ -1819,6 +1829,10 @@ func autoConvert_kubeone_KubeletConfig_To_v1beta3_KubeletConfig(in *kubeone.Kube
 	out.EvictionHard = *(*map[string]string)(unsafe.Pointer(&in.EvictionHard))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	out.PodPidsLimit = (*int64)(unsafe.Pointer(in.PodPidsLimit))
+	out.ImageGCHighThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCHighThresholdPercent))
+	out.ImageGCLowThresholdPercent = (*int32)(unsafe.Pointer(in.ImageGCLowThresholdPercent))
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return nil
 }
 

--- a/pkg/apis/kubeone/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.deepcopy.go
@@ -943,6 +943,7 @@ func (in *KubeOneCluster) DeepCopyInto(out *KubeOneCluster) {
 	in.ControlPlane.DeepCopyInto(&out.ControlPlane)
 	in.APIEndpoint.DeepCopyInto(&out.APIEndpoint)
 	in.CloudProvider.DeepCopyInto(&out.CloudProvider)
+	in.KubeletConfig.DeepCopyInto(&out.KubeletConfig)
 	out.Versions = in.Versions
 	in.ContainerRuntime.DeepCopyInto(&out.ContainerRuntime)
 	in.ClusterNetwork.DeepCopyInto(&out.ClusterNetwork)
@@ -1070,6 +1071,18 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ImageGCHighThresholdPercent != nil {
+		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ImageGCLowThresholdPercent != nil {
+		in, out := &in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent
+		*out = new(int32)
+		**out = **in
+	}
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return
 }
 

--- a/pkg/apis/kubeone/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/zz_generated.deepcopy.go
@@ -997,6 +997,7 @@ func (in *KubeOneCluster) DeepCopyInto(out *KubeOneCluster) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ControlPlane.DeepCopyInto(&out.ControlPlane)
+	in.KubeletConfig.DeepCopyInto(&out.KubeletConfig)
 	in.APIEndpoint.DeepCopyInto(&out.APIEndpoint)
 	in.CloudProvider.DeepCopyInto(&out.CloudProvider)
 	out.Versions = in.Versions
@@ -1127,6 +1128,18 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ImageGCHighThresholdPercent != nil {
+		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ImageGCLowThresholdPercent != nil {
+		in, out := &in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent
+		*out = new(int32)
+		**out = **in
+	}
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	return
 }
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -228,9 +228,9 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:             {"*": "quay.io/calico/node:v3.30.3"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.26.4"},
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.4"},
-		MachineController:      {"*": "quay.io/kubermatic/machine-controller:1b7f31166cf4827955e52acb8581a7aa48eebba4"},
+		MachineController:      {"*": "quay.io/kubermatic/machine-controller:b362a3a0fa305092e0142f638aa3c817c1c31c75"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.8.0"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:6ee458b6ff4783518bd77b80b0bef859b2e7c44f"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:dce3c22c3382254ba536f2cdcb7f78a605da2be6"},
 	}
 }
 

--- a/pkg/templates/kubeadm/v1beta4/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta4/kubeadm.go
@@ -538,6 +538,20 @@ func newNodeRegistration(s *state.State, host kubeoneapi.HostConfig) kubeadmv1be
 		kubeletCLIFlags = setAllArgsValue(kubeletCLIFlags, "pod-max-pids", strconv.Itoa(-1))
 	}
 
+	if m := host.Kubelet.ImageGCHighThresholdPercent; m != nil {
+		kubeletCLIFlags = setAllArgsValue(kubeletCLIFlags, "image-gc-high-threshold", strconv.Itoa(int(*m)))
+	}
+
+	if m := host.Kubelet.ImageGCLowThresholdPercent; m != nil {
+		kubeletCLIFlags = setAllArgsValue(kubeletCLIFlags, "image-gc-low-threshold", strconv.Itoa(int(*m)))
+	}
+
+	if m := host.Kubelet.ImageMinimumGCAge.Duration; m != 0 {
+		kubeletCLIFlags = setAllArgsValue(kubeletCLIFlags, "minimum-image-ttl-duration", m.String())
+	}
+
+	// unfortunately there is no CLI flag for ImageMaximumGCAge
+
 	return kubeadmv1beta4.NodeRegistrationOptions{
 		Name:             host.Hostname,
 		Taints:           host.Taints,

--- a/pkg/terraform/v1beta2/config.go
+++ b/pkg/terraform/v1beta2/config.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Config represents configuration in the terraform output format
@@ -108,10 +109,14 @@ type hostsSpec struct {
 }
 
 type kubeletSpec struct {
-	SystemReserved string `json:"system_reserved"`
-	KubeReserved   string `json:"kube_reserved"`
-	EvictionHard   string `json:"eviction_hard"`
-	MaxPods        *int32 `json:"max_pods,omitempty"`
+	SystemReserved              string          `json:"system_reserved"`
+	KubeReserved                string          `json:"kube_reserved"`
+	EvictionHard                string          `json:"eviction_hard"`
+	MaxPods                     *int32          `json:"max_pods,omitempty"`
+	ImageGCHighThresholdPercent *int32          `json:"image_gc_high_threshold_percent,omitempty"`
+	ImageGCLowThresholdPercent  *int32          `json:"image_gc_low_threshold_percent,omitempty"`
+	ImageMinimumGCAge           metav1.Duration `json:"image_minimum_gc_age,omitempty"`
+	ImageMaximumGCAge           metav1.Duration `json:"image_maximum_gc_age,omitempty"`
 }
 
 type hostConfigsOpts func([]kubeonev1beta2.HostConfig)
@@ -458,7 +463,7 @@ func setWorkersetFlag(w *kubeonev1beta2.DynamicWorkerConfig, name string, value 
 func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta2.KubeletConfig) {
 	if len(ks.KubeReserved) > 0 {
 		kc.KubeReserved = map[string]string{}
-		for _, krPair := range strings.Split(ks.KubeReserved, ",") {
+		for krPair := range strings.SplitSeq(ks.KubeReserved, ",") {
 			krKV := strings.SplitN(krPair, "=", 2)
 			if len(krKV) != 2 {
 				continue
@@ -469,7 +474,7 @@ func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta2.KubeletConfig
 
 	if len(ks.SystemReserved) > 0 {
 		kc.SystemReserved = map[string]string{}
-		for _, srPair := range strings.Split(ks.SystemReserved, ",") {
+		for srPair := range strings.SplitSeq(ks.SystemReserved, ",") {
 			srKV := strings.SplitN(srPair, "=", 2)
 			if len(srKV) != 2 {
 				continue
@@ -480,7 +485,7 @@ func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta2.KubeletConfig
 
 	if len(ks.EvictionHard) > 0 {
 		kc.EvictionHard = map[string]string{}
-		for _, ehPair := range strings.Split(ks.EvictionHard, ",") {
+		for ehPair := range strings.SplitSeq(ks.EvictionHard, ",") {
 			ehKV := strings.SplitN(ehPair, "<", 2)
 			if len(ehKV) != 2 {
 				continue
@@ -490,4 +495,8 @@ func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta2.KubeletConfig
 	}
 
 	kc.MaxPods = ks.MaxPods
+	kc.ImageGCHighThresholdPercent = ks.ImageGCHighThresholdPercent
+	kc.ImageGCLowThresholdPercent = ks.ImageGCLowThresholdPercent
+	kc.ImageMaximumGCAge = ks.ImageMaximumGCAge
+	kc.ImageMinimumGCAge = ks.ImageMinimumGCAge
 }

--- a/pkg/terraform/v1beta3/config.go
+++ b/pkg/terraform/v1beta3/config.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Config represents configuration in the terraform output format
@@ -108,10 +109,14 @@ type hostsSpec struct {
 }
 
 type kubeletSpec struct {
-	SystemReserved string `json:"system_reserved"`
-	KubeReserved   string `json:"kube_reserved"`
-	EvictionHard   string `json:"eviction_hard"`
-	MaxPods        *int32 `json:"max_pods,omitempty"`
+	SystemReserved              string          `json:"system_reserved"`
+	KubeReserved                string          `json:"kube_reserved"`
+	EvictionHard                string          `json:"eviction_hard"`
+	MaxPods                     *int32          `json:"max_pods,omitempty"`
+	ImageGCHighThresholdPercent *int32          `json:"image_gc_high_threshold_percent,omitempty"`
+	ImageGCLowThresholdPercent  *int32          `json:"image_gc_low_threshold_percent,omitempty"`
+	ImageMinimumGCAge           metav1.Duration `json:"image_minimum_gc_age,omitempty"`
+	ImageMaximumGCAge           metav1.Duration `json:"image_maximum_gc_age,omitempty"`
 }
 
 type hostConfigsOpts func([]kubeonev1beta3.HostConfig)
@@ -456,7 +461,7 @@ func setWorkersetFlag(w *kubeonev1beta3.DynamicWorkerConfig, name string, value 
 func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta3.KubeletConfig) {
 	if len(ks.KubeReserved) > 0 {
 		kc.KubeReserved = map[string]string{}
-		for _, krPair := range strings.Split(ks.KubeReserved, ",") {
+		for krPair := range strings.SplitSeq(ks.KubeReserved, ",") {
 			krKV := strings.SplitN(krPair, "=", 2)
 			if len(krKV) != 2 {
 				continue
@@ -467,7 +472,7 @@ func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta3.KubeletConfig
 
 	if len(ks.SystemReserved) > 0 {
 		kc.SystemReserved = map[string]string{}
-		for _, srPair := range strings.Split(ks.SystemReserved, ",") {
+		for srPair := range strings.SplitSeq(ks.SystemReserved, ",") {
 			srKV := strings.SplitN(srPair, "=", 2)
 			if len(srKV) != 2 {
 				continue
@@ -478,7 +483,7 @@ func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta3.KubeletConfig
 
 	if len(ks.EvictionHard) > 0 {
 		kc.EvictionHard = map[string]string{}
-		for _, ehPair := range strings.Split(ks.EvictionHard, ",") {
+		for ehPair := range strings.SplitSeq(ks.EvictionHard, ",") {
 			ehKV := strings.SplitN(ehPair, "<", 2)
 			if len(ehKV) != 2 {
 				continue
@@ -488,4 +493,8 @@ func parseKubeletResourceParams(ks kubeletSpec, kc *kubeonev1beta3.KubeletConfig
 	}
 
 	kc.MaxPods = ks.MaxPods
+	kc.ImageGCHighThresholdPercent = ks.ImageGCHighThresholdPercent
+	kc.ImageGCLowThresholdPercent = ks.ImageGCLowThresholdPercent
+	kc.ImageMaximumGCAge = ks.ImageMaximumGCAge
+	kc.ImageMinimumGCAge = ks.ImageMinimumGCAge
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster wide KubeletConfig helps to generate KubeletConfiguration that will be used by the kubeadm (for control-plane and static workers.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3654

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cluster wide KubeletConfig
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
API docs
```
