### PR TITLE
Update addons to support k8s 1.34

### DIFF
--- a/addons/ccm-azure/Kustomization
+++ b/addons/ccm-azure/Kustomization
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
 - name: cloud-provider-azure
   repo: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
-  version: v1.33.3
+  version: v1.34.1
   releaseName: cloud-provider-azure
   namespace: kube-system
   valuesFile: helm-values

--- a/addons/ccm-digitalocean/Kustomization
+++ b/addons/ccm-digitalocean/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.63.yml
+  - https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.64.yml
 
 patches:
   - patch: |-

--- a/addons/ccm-hetzner/Kustomization
+++ b/addons/ccm-hetzner/Kustomization
@@ -5,7 +5,7 @@ namespace: kube-system
 helmCharts:
 - name: hcloud-cloud-controller-manager
   repo: https://charts.hetzner.cloud
-  version: 1.26.0
+  version: 1.27.0
   releaseName: hccm
   namespace: kube-system
   valuesFile: generate-values-ccm

--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -43,6 +43,7 @@ spec:
             - --allow-untagged-cloud
             - --cloud-provider=hcloud
             - --configure-cloud-routes=false
+            - --feature-gates=CloudControllerManagerWatchBasedRoutesReconciliation=false
             - --route-reconciliation-period=30s
             - --webhook-secure-port=0
             - --leader-elect=false

--- a/addons/csi-aws-ebs/aws-csi.yaml
+++ b/addons/csi-aws-ebs/aws-csi.yaml
@@ -8,8 +8,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,8 +29,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -44,8 +44,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -58,8 +58,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 # Do not modify the rules below manually, see `make update-sidecar-dependencies`
@@ -87,8 +87,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -110,8 +110,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 # Do not modify the rules below manually, see `make update-sidecar-dependencies`
@@ -167,8 +167,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 # Do not modify the rules below manually, see `make update-sidecar-dependencies`
@@ -208,8 +208,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 # Do not modify the rules below manually, see `make update-sidecar-dependencies`
@@ -253,8 +253,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -274,8 +274,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -295,8 +295,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -316,8 +316,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -337,8 +337,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -359,8 +359,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -377,8 +377,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -399,8 +399,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -420,8 +420,8 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.49.1
-        app.kubernetes.io/version: "1.49.0"
+        helm.sh/chart: aws-ebs-csi-driver-2.51.0
+        app.kubernetes.io/version: "1.51.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -601,8 +601,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -623,8 +623,8 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.49.1
-        app.kubernetes.io/version: "1.49.0"
+        helm.sh/chart: aws-ebs-csi-driver-2.51.0
+        app.kubernetes.io/version: "1.51.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -906,8 +906,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.49.1
-    app.kubernetes.io/version: "1.49.0"
+    helm.sh/chart: aws-ebs-csi-driver-2.51.0
+    app.kubernetes.io/version: "1.51.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/addons/csi-hetzner/Kustomization
+++ b/addons/csi-hetzner/Kustomization
@@ -5,7 +5,7 @@ namespace: kube-system
 helmCharts:
 - name: hcloud-csi
   repo: https://charts.hetzner.cloud
-  version: 2.17.0
+  version: 2.18.0
   releaseName: hcloud-csi
   namespace: kube-system
   valuesFile: generate-values-csi

--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: hcloud-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.17.0
+    helm.sh/chart: hcloud-csi-2.18.0
   name: hcloud-csi-controller
   namespace: kube-system
 ---
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/instance: hcloud-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.17.0
+    helm.sh/chart: hcloud-csi-2.18.0
   name: hcloud-csi-controller
 rules:
   - apiGroups:
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/instance: hcloud-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.17.0
+    helm.sh/chart: hcloud-csi-2.18.0
   name: hcloud-csi-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -181,7 +181,7 @@ metadata:
     app.kubernetes.io/instance: hcloud-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.17.0
+    helm.sh/chart: hcloud-csi-2.18.0
   name: hcloud-csi-controller
   namespace: kube-system
 spec:
@@ -200,7 +200,7 @@ spec:
         app.kubernetes.io/instance: hcloud-csi
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: hcloud-csi
-        helm.sh/chart: hcloud-csi-2.17.0
+        helm.sh/chart: hcloud-csi-2.18.0
     spec:
       affinity:
         nodeAffinity:
@@ -312,7 +312,7 @@ metadata:
     app.kubernetes.io/instance: hcloud-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hcloud-csi
-    helm.sh/chart: hcloud-csi-2.17.0
+    helm.sh/chart: hcloud-csi-2.18.0
   name: hcloud-csi-node
   namespace: kube-system
 spec:
@@ -328,7 +328,7 @@ spec:
         app.kubernetes.io/instance: hcloud-csi
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: hcloud-csi
-        helm.sh/chart: hcloud-csi-2.17.0
+        helm.sh/chart: hcloud-csi-2.18.0
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -245,7 +245,7 @@ func optionalResources() map[Resource]map[string]string {
 		CSISnapshotWebhook:    {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.1"},
 
 		// AWS EBS CSI driver
-		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.49.0"},
+		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.51.0"},
 		AwsEbsCSIAttacher:            {"*": "public.ecr.aws/csi-components/csi-attacher:v4.9.0-eksbuild.4"},
 		AwsEbsCSILivenessProbe:       {"*": "public.ecr.aws/csi-components/livenessprobe:v2.16.0-eksbuild.5"},
 		AwsEbsCSINodeDriverRegistrar: {"*": "public.ecr.aws/csi-components/csi-node-driver-registrar:v2.14.0-eksbuild.5"},
@@ -257,12 +257,12 @@ func optionalResources() map[Resource]map[string]string {
 		AzureCCM: {
 			"1.32.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.32.8",
 			"1.33.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.33.3",
-			">= 1.34.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.33.1",
+			">= 1.34.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.1",
 		},
 		AzureCNM: {
 			"1.32.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.32.8",
 			"1.33.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.33.3",
-			">= 1.33.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.1",
+			">= 1.34.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.1",
 		},
 
 		// AzureFile CSI driver
@@ -283,7 +283,7 @@ func optionalResources() map[Resource]map[string]string {
 		AzureDiskCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.3.0"},
 
 		// DigitalOcean CCM
-		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.63"},
+		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.64"},
 
 		// DigitalOcean CSI
 		DigitalOceanCSI:                   {"*": "digitalocean/do-csi-plugin:v4.14.0"},
@@ -295,15 +295,15 @@ func optionalResources() map[Resource]map[string]string {
 		DigitalOceanCSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0"},
 
 		// Hetzner CCM
-		HetznerCCM: {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.26.0"},
+		HetznerCCM: {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.27.0"},
 
 		// Hetzner CSI
-		HetznerCSI:                   {"*": "docker.io/hetznercloud/hcloud-csi-driver:v2.17.0"},
-		HetznerCSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v4.9.0"},
+		HetznerCSI:                   {"*": "docker.io/hetznercloud/hcloud-csi-driver:v2.18.0"},
+		HetznerCSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v4.10.0"},
 		HetznerCSIResizer:            {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.14.0"},
 		HetznerCSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0"},
-		HetznerCSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.16.0"},
-		HetznerCSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0"},
+		HetznerCSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.17.0"},
+		HetznerCSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0"},
 
 		// OpenStack CCM
 		OpenstackCCM: {
@@ -396,7 +396,8 @@ func optionalResources() map[Resource]map[string]string {
 		// Cluster-autoscaler addon
 		ClusterAutoscaler: {
 			"1.32.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.3",
-			">= 1.33.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.1",
+			"1.33.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.1",
+			">= 1.34.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.1",
 		},
 
 		// CSI Vault Secret Provider


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This PR updates few cloud providers CCM and CSI to latest releases that brings support for k8s 1.34. 
Update Azure CCM to v1.34.1
Update DigitalOcean CCM to v0.1.64
Update Hetzner CCM and CSI to v2.18.0
Update AWS EBS CSI to v1.51.0
Update ClusterAutoscaler to v1.34.1

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Azure CCM to v1.34.1
Update DigitalOcean CCM to v0.1.64
Update Hetzner CCM and CSI to v2.18.0
Update AWS EBS CSI to v1.51.0
Update ClusterAutoscaler to v1.34.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
