### PR TITLE
Fix upgrading OCI releases and uninstalling them without reason

### DIFF
--- a/pkg/localhelm/helm3.go
+++ b/pkg/localhelm/helm3.go
@@ -249,24 +249,17 @@ func cleanManifest(manifest string) string {
 		return ""
 	}
 
-	var buf bytes.Buffer
-	lines := bytes.Split([]byte(manifest), []byte("\n"))
+	var buf strings.Builder
 
-	for _, line := range lines {
-		if bytes.HasPrefix(line, []byte("#")) {
+	for line := range strings.Lines(manifest) {
+		if strings.HasPrefix(line, "#") {
 			continue
 		}
-		buf.Write(line)
+		buf.WriteString(line)
 		buf.WriteByte('\n')
 	}
 
-	// Remove the trailing newline added after the last line
-	result := buf.Bytes()
-	if len(result) > 0 && result[len(result)-1] == '\n' {
-		result = result[:len(result)-1]
-	}
-
-	return string(result)
+	return strings.TrimSpace(buf.String())
 }
 
 func helmReleasesEqual(rel *helmrelease.Release, oldRels []*helmrelease.Release) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This PR avoids upgrading OCI helm releases and queuing them to be uninstalled without any reason! 
* We upgrade if the chart or values are changed! 
* We uninstall the release if it's not defined in the kubeone configuration 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix upgrading OCI helm releases and uninstalling them without reason
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
