### PR TITLE
fix cilium-envoy image ref

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -393,7 +393,7 @@ func optionalResources() map[Resource]map[string]string {
 		// Cilium
 		Cilium:         {"*": "quay.io/cilium/cilium:v1.18.2@sha256:858f807ea4e20e85e3ea3240a762e1f4b29f1cb5bbd0463b8aa77e7b097c0667"},
 		CiliumOperator: {"*": "quay.io/cilium/operator-generic:v1.18.2@sha256:cb4e4ffc5789fd5ff6a534e3b1460623df61cba00f5ea1c7b40153b5efb81805"},
-		CiliumEnvoy:    {"*": "quay.io/cilium/v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324@sha256:7932d656b63f6f866b6732099d33355184322123cfe1182e6f05175a3bc2e0e0"},
+		CiliumEnvoy:    {"*": "quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324@sha256:7932d656b63f6f866b6732099d33355184322123cfe1182e6f05175a3bc2e0e0"},
 
 		// Hubble
 		HubbleRelay:     {"*": "quay.io/cilium/hubble-relay:v1.18.2@sha256:6079308ee15e44dff476fb522612732f7c5c4407a1017bc3470916242b0405ac"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The image `quay.io/cilium/v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324@sha256:7932d656b63f6f866b6732099d33355184322123cfe1182e6f05175a3bc2e0e0` referenced from https://github.com/kubermatic/kubeone/blob/7f5c982d32dbe2442c835e16af9ade4cbb56fb9c/pkg/templates/images/images.go#L396 doesn't exist.

Comparing to the previous Tag, the `cilium-envoy` part of the image was dropped https://github.com/kubermatic/kubeone/blob/db40d754ac8e7eea3d6bdad0515f418e3ae16cd0/pkg/templates/images/images.go#L387

This PR fixes the image reference

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3909

**What type of PR is this?**
/kind bug
/kind regression
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cilium-envoy image reference
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
