### PR TITLE
fix: Respect customized Addons manifests

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -206,7 +206,7 @@ func EnsureUserAddons(s *state.State) error {
 		}
 	}
 
-	for _, embeddedAddon := range s.Cluster.Addons.OnlyAddons() {
+	for _, embeddedAddon := range s.Cluster.Addons.DeclaredAddonsOnly() {
 		if _, ok := embeddedAddons[embeddedAddon.Name]; ok {
 			continue
 		}

--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -359,7 +359,7 @@ func EmbeddedAddonsOnly(addons *kubeoneapi.Addons) (bool, error) {
 	}
 
 	// Iterate over addons specified in the KubeOneCluster object
-	for _, addon := range addons.OnlyAddons() {
+	for _, addon := range addons.DeclaredAddonsOnly() {
 		embedded := false
 		// Iterate over embedded addons directory to check if the addon exists
 		for _, embeddedAddon := range embeddedAddons {

--- a/pkg/addons/list.go
+++ b/pkg/addons/list.go
@@ -107,7 +107,7 @@ func List(s *state.State, outputFormat string) error {
 			}
 		}
 
-		for _, embeddedAddon := range s.Cluster.Addons.OnlyAddons() {
+		for _, embeddedAddon := range s.Cluster.Addons.DeclaredAddonsOnly() {
 			combinedAddons[embeddedAddon.Name] = addonItem{
 				Name:   embeddedAddon.Name,
 				Status: addonStatusInstall,

--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -61,7 +61,7 @@ func (a *applier) getManifestsFromDirectory(st *state.State, fsys fs.FS, addonNa
 		disableTemplating = false
 	)
 	if st.Cluster.Addons.Enabled() {
-		for _, addon := range st.Cluster.Addons.OnlyAddons() {
+		for _, addon := range st.Cluster.Addons.DeclaredAddonsOnly() {
 			if addon.Name == addonName {
 				addonParams = addon.Params
 				disableTemplating = addon.DisableTemplating

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -402,11 +402,15 @@ func (r *RegistryConfiguration) InsecureRegistryAddress() string {
 	return insecureRegistry
 }
 
+// Enabled returns whether addons are enabled.
+// this is true when either an addonsPath is provided or the addonsRef are provided
 func (ads *Addons) Enabled() bool {
-	return ads != nil && len(ads.Addons) > 0
+	return ads != nil && (ads.Path != "" || len(ads.Addons) > 0)
 }
 
-func (ads *Addons) OnlyAddons() []Addon {
+// DeclaredAddonsOnly returns a slice of Addons which are declared in the kubeone config manifest
+// it does not return any addons which might exist in the addons' path.
+func (ads *Addons) DeclaredAddonsOnly() []Addon {
 	if ads == nil {
 		return nil
 	}

--- a/pkg/apis/kubeone/helpers_test.go
+++ b/pkg/apis/kubeone/helpers_test.go
@@ -271,3 +271,69 @@ func TestDefaultAssetConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestAddons_Enabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		addons *Addons
+		want   bool
+	}{
+		{
+			name:   "nil addons",
+			addons: nil,
+			want:   false,
+		},
+		{
+			name:   "empty addons struct",
+			addons: &Addons{},
+			want:   false,
+		},
+		{
+			name: "only path set",
+			addons: &Addons{
+				Path: "addons/",
+			},
+			want: true,
+		},
+		{
+			name: "one addon reference (Addon)",
+			addons: &Addons{
+				Addons: []AddonRef{
+					{Addon: &Addon{}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "one addon reference (HelmRelease)",
+			addons: &Addons{
+				Addons: []AddonRef{
+					{HelmRelease: &HelmRelease{}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "path + addon ref",
+			addons: &Addons{
+				Path: "addons/",
+				Addons: []AddonRef{
+					{Addon: &Addon{Name: "addon1"}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.addons.Enabled()
+			if got != tc.want {
+				t.Errorf("Enabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/local.go
+++ b/pkg/cmd/local.go
@@ -92,13 +92,13 @@ func (opts *localOpts) BuildState() (*state.State, error) {
 		}
 
 		// Check if only embedded addons are being used; path is not required for embedded addons and no validation is required
-		embeddedAddonsOnly, err := addons.EmbeddedAddonsOnly(s.Cluster.Addons)
+		_, err = addons.EmbeddedAddonsOnly(s.Cluster.Addons)
 		if err != nil {
 			return nil, err
 		}
 
-		// If custom addons are being used then addons path is required and should be a valid directory
-		if !embeddedAddonsOnly {
+		// If an addons path is provided, that should be a valid directory
+		if addonsPath != "" {
 			if _, err := os.Stat(addonsPath); os.IsNotExist(err) {
 				return nil, fail.Runtime(err, "checking addons directory")
 			}

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -86,13 +86,13 @@ func (opts *globalOptions) BuildState() (*state.State, error) {
 		}
 
 		// Check if only embedded addons are being used; path is not required for embedded addons and no validation is required
-		embeddedAddonsOnly, err := addons.EmbeddedAddonsOnly(s.Cluster.Addons)
+		_, err = addons.EmbeddedAddonsOnly(s.Cluster.Addons)
 		if err != nil {
 			return nil, err
 		}
 
-		// If custom addons are being used then addons path is required and should be a valid directory
-		if !embeddedAddonsOnly {
+		// If an addons path is provided, that should be a valid directory
+		if addonsPath != "" {
 			if _, err := os.Stat(addonsPath); os.IsNotExist(err) {
 				return nil, fail.Runtime(err, "checking addons directory")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
As stated in the related issue, since KO 1.9.x, user provided addons do not overwrite embedded addons no longer. This breaks existing behavior. Workaround is to fill `addons.addons` spec to config, which is not wanted in most cases.

The rootcause was introduced in #3248 changing the `Enabled()` func on the addons struct. I can understand where this is coming from as the `.enabled` fields is being removed in `v1beta3`. However, addons are enabled when a path is provided, or when a list of embedded addons is provided. That is now reflected correctly in this pr.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3629

**What type of PR is this?**
<!--
Add one of the following kinds:
-->
/kind bug

**Special notes for your reviewer**:
Please backport / cherrypick to 1.9 / 1.10 / 1.11 

**Changes**:

* Addons are enabled when either .path or list of addons is provided
* Adds godoc to related funcs
* Always check filepath when provided in config, not dependent on outcome of `EmbeddedAddonsOnly`
* Renames `OnlyAddons()` to `DeclaredAddonsOnly()` to be more descriptive. Feel free to find a more appropriate name if needed.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Respect customised addon manifests

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE

```