### PR TITLE
Use CertificateAuthority.Bundle everywhere

### DIFF
--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -86,9 +86,9 @@ func (a *applier) getManifestsFromDirectory(st *state.State, fsys fs.FS, addonNa
 	)
 
 	if !disableTemplating && addonsToMutate.Has(addonName) {
-		if st.Cluster.CABundle != "" {
+		if st.Cluster.CertificateAuthority.Bundle != "" {
 			if err = mutatePodTemplateSpec(manifests, func(podTpl *corev1.PodTemplateSpec) {
-				cabundle.Inject(st.Cluster.CABundle, podTpl)
+				cabundle.Inject(st.Cluster.CertificateAuthority.Bundle, podTpl)
 			}); err != nil {
 				return "", err
 			}

--- a/pkg/tasks/certs.go
+++ b/pkg/tasks/certs.go
@@ -154,7 +154,7 @@ func ensureCABundleConfigMap(s *state.State) error {
 
 	s.Logger.Infoln("Creating ca-bundle configMap...")
 
-	cm := cabundle.ConfigMap(s.Cluster.CABundle, metav1.NamespaceSystem)
+	cm := cabundle.ConfigMap(s.Cluster.CertificateAuthority.Bundle, metav1.NamespaceSystem)
 
 	return clientutil.CreateOrUpdate(s.Context, s.DynamicClient, cm)
 }
@@ -170,13 +170,13 @@ func ensureVsphereCSICABundleConfigMap(s *state.State) error {
 	}
 	s.Logger.Infoln("Creating ca-bundle configmap for vSphere CSI...")
 
-	cm := cabundle.ConfigMap(s.Cluster.CABundle, resources.VsphereCSINamespace)
+	cm := cabundle.ConfigMap(s.Cluster.CertificateAuthority.Bundle, resources.VsphereCSINamespace)
 
 	return clientutil.CreateOrUpdate(s.Context, s.DynamicClient, cm)
 }
 
 func saveCABundle(s *state.State) error {
-	s.Configuration.AddFile("ca-certs/"+cabundle.FileName, s.Cluster.CABundle)
+	s.Configuration.AddFile("ca-certs/"+cabundle.FileName, s.Cluster.CertificateAuthority.Bundle)
 
 	return s.RunTaskOnControlPlane(saveCABundleOnControlPlane, state.RunParallel)
 }

--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -241,7 +241,7 @@ func patchStaticPods(s *state.State) error {
 		}
 
 		cacertDir := cabundle.OriginalCertsDir
-		if s.Cluster.CABundle != "" {
+		if s.Cluster.CertificateAuthority.Bundle != "" {
 			cacertDir = cabundle.CustomCertsDir
 		}
 

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -225,7 +225,7 @@ func WithResources(t Tasks) Tasks {
 			{
 				Fn: saveCABundle,
 				Predicate: func(s *state.State) bool {
-					return s.Cluster.CABundle != ""
+					return s.Cluster.CertificateAuthority.Bundle != ""
 				},
 			},
 			{
@@ -278,7 +278,7 @@ func WithResources(t Tasks) Tasks {
 				Fn:          ensureCABundleConfigMap,
 				Operation:   "ensuring caBundle configMap",
 				Description: "ensure caBundle configMap",
-				Predicate:   func(s *state.State) bool { return s.Cluster.CABundle != "" },
+				Predicate:   func(s *state.State) bool { return s.Cluster.CertificateAuthority.Bundle != "" },
 			},
 			{
 				Fn:          labelNodes,
@@ -321,7 +321,7 @@ func WithResources(t Tasks) Tasks {
 				Operation:   "ensure vSphere CSI caBundle configMap",
 				Description: "ensure vSphere CSI caBundle configMap",
 				Predicate: func(s *state.State) bool {
-					return s.Cluster.CABundle != "" && s.Cluster.CloudProvider.Vsphere != nil && s.Cluster.CloudProvider.External && !s.Cluster.CloudProvider.DisableBundledCSIDrivers
+					return s.Cluster.CertificateAuthority.Bundle != "" && s.Cluster.CloudProvider.Vsphere != nil && s.Cluster.CloudProvider.External && !s.Cluster.CloudProvider.DisableBundledCSIDrivers
 				},
 			},
 			{
@@ -427,7 +427,8 @@ func WithReset(t Tasks) Tasks {
 			Operation: "remove load balancer services",
 			Predicate: func(s *state.State) bool {
 				return s.RemoveLBServices
-			}},
+			},
+		},
 		{
 			Fn:        RemoveVolumes,
 			Operation: "remove dynamically provisioned and unretained volumes",


### PR DESCRIPTION
**What this PR does / why we need it**:
Since CABundle has been deprecated, use `CertificateAuthority.Bundle` in the code instead of `CABundle`.

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
