### PR TITLE
fix: set kubernetes-apt-keyring.gpg file permissions explicitly

### DIFF
--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -71,6 +71,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KUBERNETES_MAJOR_MINOR }}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestDebScript-install_all.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all.golden
@@ -69,6 +69,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
@@ -69,6 +69,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
@@ -69,6 +69,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
@@ -69,6 +69,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -69,6 +69,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
@@ -69,6 +69,7 @@ fi
 sudo install -m 0755 -d /etc/apt/keyrings
 LATEST_STABLE=$(curl -sL https://dl.k8s.io/release/stable.txt | sed 's/\.[0-9]*$//')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/${LATEST_STABLE}/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update


### PR DESCRIPTION
Using a system with a tighter umask (027) reading the gpg keys fails. For unknown to me reasons apt needs the keyring to be others readable even when running as root. This is on Ubuntu 24.

```
root@node:~# ls -l /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-rw-r----- 1 root root 1200 Dec 15 15:50 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
```

```
root@node:~# apt update
Hit:1 http://security.ubuntu.com/ubuntu noble-security InRelease
Hit:2 https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/core:/stable:/v1.33/deb  InRelease
Err:2 https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/core:/stable:/v1.33/deb  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 234654DA9A296436
Get:3 https://pkgs.tailscale.com/stable/ubuntu noble InRelease
Hit:4 http://gn2b.clouds.archive.ubuntu.com/ubuntu noble InRelease
Hit:5 http://gn2b.clouds.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:6 http://gn2b.clouds.archive.ubuntu.com/ubuntu noble-backports InRelease
Fetched 6581 B in 2s (4151 B/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/core:/stable:/v1.33/deb  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 234654DA9A296436
W: Failed to fetch https://pkgs.k8s.io/core:/stable:/v1.33/deb/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 234654DA9A296436
W: Some index files failed to download. They have been ignored, or old ones used instead.
```

Setting the 0644 perms:
```
root@sandbox-controlplane-node-gn2b:~# chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
```

```
root@sandbox-controlplane-node-gn2b:~# apt update
Hit:1 http://security.ubuntu.com/ubuntu noble-security InRelease
Hit:2 https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/core:/stable:/v1.33/deb  InRelease
Get:3 https://pkgs.tailscale.com/stable/ubuntu noble InRelease
Hit:4 http://gn2b.clouds.archive.ubuntu.com/ubuntu noble InRelease
Hit:5 http://gn2b.clouds.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:6 http://gn2b.clouds.archive.ubuntu.com/ubuntu noble-backports InRelease
Fetched 6581 B in 1s (5122 B/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
```

```
root@sandbox-controlplane-node-gn2b:~# id
uid=0(root) gid=0(root) groups=0(root)
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: set kubernetes-apt-keyring.gpg file permissions explicitly
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
