### PR TITLE
Fix Terraform OpenStack bastion host floating ip assignment

### DIFF
--- a/examples/terraform/openstack/bastion.tf
+++ b/examples/terraform/openstack/bastion.tf
@@ -49,4 +49,6 @@ resource "openstack_networking_floatingip_v2" "bastion" {
 resource "openstack_networking_floatingip_associate_v2" "bastion" {
   floating_ip = openstack_networking_floatingip_v2.bastion.address
   port_id     = openstack_networking_port_v2.bastion.id
+
+  depends_on = [openstack_networking_router_interface_v2.router_subnet_link]
 }


### PR DESCRIPTION
The L3 router needs to be connected to the self-service network before assigning a floating IP to the bastion host. Otherwise, Neutron does not find a solution how to DNAT floating IP to bastion host and assignment fails.

**What this PR does / why we need it**:
When using your example for the OpenStack Terraform Quickstart assigning the floating IP to the bastion host might fail, if the L3 router is not yet connected to the self-service network.

**What type of PR is this?**
/kind bug

Does this PR introduce a user-facing change? Then add your Release Note here:
```release-notes
Fixed an issue in the OpenStack Terraform Quickstart configs that Neutron can not assign the floating IP to the basion host.
```

**Documentation**:
```documentation
NONE
```
