### PR TITLE
Fix cluster-name in KubeVirt CCM args

### DIFF
--- a/addons/ccm-kubevirt/Kustomization
+++ b/addons/ccm-kubevirt/Kustomization
@@ -55,7 +55,7 @@ patches:
                 args:
                   - --cloud-config=/etc/cloud/cloud-config
                   - --cloud-provider=kubevirt
-                  - --cluster-name='{{ .Config.Name }}'
+                  - "--cluster-name={{ .Config.Name }}"
                 volumeMounts:
                   - mountPath: /etc/kubernetes/kubeconfig
                     name: kubeconfig

--- a/addons/ccm-kubevirt/ccm-kubevirt.yaml
+++ b/addons/ccm-kubevirt/ccm-kubevirt.yaml
@@ -152,7 +152,7 @@ spec:
         - args:
             - --cloud-config=/etc/cloud/cloud-config
             - --cloud-provider=kubevirt
-            - --cluster-name='{{ .Config.Name }}'
+            - --cluster-name={{ .Config.Name }}
           command:
             - /bin/kubevirt-cloud-controller-manager
           image: '{{ .InternalImages.Get "KubeVirtCCM" }}'


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
CCM is not able to parse cluster name correctly, leading to errors like this:

> kubevirt-cloud-controller-manager-585648b5f5-g4v96 kubevirt-cloud-controller-manager I0203 11:30:52.031500       1 event.go:307] "Event occurred" object="default/nginx-lb-service" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: Service \"af56ae75afad145f5be10e3ad70df397\" is invalid: [metadata.labels: Invalid value: \"'unite-kkp-master'\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'), spec.selector: Invalid value: \"'unite-kkp-master'\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]"


**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster-name in KubeVirt CCM args
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
