### PR TITLE
Update OperatingSystemManager image to the latest with kubernetes 1.35 support

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -238,7 +238,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.4"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:01ad12aa435b2644bb76081ea7ebc00c451cf0dc"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.8.0"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:1e348be247afac47428e2e4b8fa0a4517a2a2d97"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:c5a49f8ce689d8bec53231243abbd115a9d1a30a"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull OSM version with Kubernetes 1.35 support merged in https://github.com/kubermatic/operating-system-manager/pull/556

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
