### PR TITLE
feat(cni-cilium) Add enable-l2-announcements configuration option

### DIFF
--- a/addons/cni-cilium/cilium-config-map.yaml
+++ b/addons/cni-cilium/cilium-config-map.yaml
@@ -67,6 +67,9 @@ data:
 {{ end }}
   enable-k8s-networkpolicy: "true"
   enable-k8s-terminating-endpoint: "true"
+{{ if .Config.ClusterNetwork.CNI.Cilium.EnableL2Announcements }}
+  enable-l2-announcements: "true"
+{{ end }}
   enable-l2-neigh-discovery: "true"
   enable-l7-proxy: "true"
   enable-local-redirect-policy: "false"

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2025-12-10T15:13:37+02:00
+date = 2026-02-23T21:01:35+01:00
 weight = 11
 +++
 ## v1beta2
@@ -173,6 +173,7 @@ CiliumSpec defines the Cilium CNI plugin
 | ----- | ----------- | ------ | -------- |
 | kubeProxyReplacement | KubeProxyReplacement defines weather cilium relies on underlying Kernel support to replace kube-proxy functionality by eBPF (strict), or disables a subset of those features so cilium does not bail out if the kernel support is missing (disabled). default is \"disabled\" | KubeProxyReplacementType | true |
 | enableHubble | EnableHubble to deploy Hubble relay and UI default value is false | bool | true |
+| enableL2Announcements | EnableL2Announcements enables the Layer 2 announcement feature for the Cilium CNI plugin. If not set, Cilium will use its default behavior. | bool | true |
 
 [Back to Group](#v1beta2)
 

--- a/docs/api_reference/v1beta3.en.md
+++ b/docs/api_reference/v1beta3.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta3 API Reference"
-date = 2025-12-10T15:13:37+02:00
+date = 2026-02-23T21:01:35+01:00
 weight = 11
 +++
 ## v1beta3
@@ -186,6 +186,7 @@ CiliumSpec defines the Cilium CNI plugin
 | ----- | ----------- | ------ | -------- |
 | kubeProxyReplacement | KubeProxyReplacement defines weather cilium relies on underlying Kernel support to replace kube-proxy functionality by eBPF (strict), or disables a subset of those features so cilium does not bail out if the kernel support is missing (disabled). default is false | bool | true |
 | enableHubble | EnableHubble to deploy Hubble relay and UI default value is false | bool | true |
+| enableL2Announcements | EnableL2Announcements enables the Layer 2 announcement feature for the Cilium CNI plugin. If not set, Cilium will use its default behavior. | bool | true |
 
 [Back to Group](#v1beta3)
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -688,6 +688,10 @@ type CiliumSpec struct {
 	// EnableHubble to deploy Hubble relay and UI
 	// default value is false
 	EnableHubble bool `json:"enableHubble"`
+
+	// EnableL2Announcements enables the Layer 2 announcement feature for the Cilium CNI plugin.
+	// If not set, Cilium will use its default behavior.
+	EnableL2Announcements bool `json:"enableL2Announcements"`
 }
 
 // WeaveNetSpec defines the WeaveNet CNI plugin

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -700,6 +700,10 @@ type CiliumSpec struct {
 	// EnableHubble to deploy Hubble relay and UI
 	// default value is false
 	EnableHubble bool `json:"enableHubble"`
+
+	// EnableL2Announcements enables the Layer 2 announcement feature for the Cilium CNI plugin.
+	// If not set, Cilium will use its default behavior.
+	EnableL2Announcements bool `json:"enableL2Announcements"`
 }
 
 // WeaveNetSpec defines the WeaveNet CNI plugin

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -918,12 +918,14 @@ func Convert_kubeone_CertificateAuthorithyConfig_To_v1beta2_CertificateAuthorith
 func autoConvert_v1beta2_CiliumSpec_To_kubeone_CiliumSpec(in *CiliumSpec, out *kubeone.CiliumSpec, s conversion.Scope) error {
 	// INFO: in.KubeProxyReplacement opted out of conversion generation
 	out.EnableHubble = in.EnableHubble
+	out.EnableL2Announcements = in.EnableL2Announcements
 	return nil
 }
 
 func autoConvert_kubeone_CiliumSpec_To_v1beta2_CiliumSpec(in *kubeone.CiliumSpec, out *CiliumSpec, s conversion.Scope) error {
 	// INFO: in.KubeProxyReplacement opted out of conversion generation
 	out.EnableHubble = in.EnableHubble
+	out.EnableL2Announcements = in.EnableL2Announcements
 	return nil
 }
 

--- a/pkg/apis/kubeone/v1beta3/types.go
+++ b/pkg/apis/kubeone/v1beta3/types.go
@@ -684,6 +684,10 @@ type CiliumSpec struct {
 	// EnableHubble to deploy Hubble relay and UI
 	// default value is false
 	EnableHubble bool `json:"enableHubble"`
+
+	// EnableL2Announcements enables the Layer 2 announcement feature for the Cilium CNI plugin.
+	// If not set, Cilium will use its default behavior.
+	EnableL2Announcements bool `json:"enableL2Announcements"`
 }
 
 // WeaveNetSpec defines the WeaveNet CNI plugin

--- a/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
@@ -973,12 +973,14 @@ func Convert_kubeone_CertificateAuthorithyConfig_To_v1beta3_CertificateAuthorith
 func autoConvert_v1beta3_CiliumSpec_To_kubeone_CiliumSpec(in *CiliumSpec, out *kubeone.CiliumSpec, s conversion.Scope) error {
 	out.KubeProxyReplacement = in.KubeProxyReplacement
 	out.EnableHubble = in.EnableHubble
+	out.EnableL2Announcements = in.EnableL2Announcements
 	return nil
 }
 
 func autoConvert_kubeone_CiliumSpec_To_v1beta3_CiliumSpec(in *kubeone.CiliumSpec, out *CiliumSpec, s conversion.Scope) error {
 	// INFO: in.KubeProxyReplacement opted out of conversion generation
 	out.EnableHubble = in.EnableHubble
+	out.EnableL2Announcements = in.EnableL2Announcements
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
- Adds config option for Cilium's L2 Announcements

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3990

**What type of PR is this?**
/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add enable-l2-announcements configuration option to Cilium
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
