### PR TITLE
   Enables policy-cidr-match-mode: nodes in the Cilium CNI addon configuration.

### DIFF
--- a/addons/cni-cilium/cilium-config-map.yaml
+++ b/addons/cni-cilium/cilium-config-map.yaml
@@ -126,7 +126,7 @@ data:
   nodes-gc-interval: "5m0s"
   operator-api-serve-addr: "127.0.0.1:9234"
   operator-prometheus-serve-addr: :9963
-  policy-cidr-match-mode: ""
+  policy-cidr-match-mode: "nodes"
   preallocate-bpf-maps: "false"
   procfs: "/host/proc"
   proxy-connect-timeout: "2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

 By default, Cilium's reserved identities for nodes cause Kubernetes NetworkPolicy `ipBlock` CIDR rules to fail when targeting node IPs (e.g., kube-apiserver endpoints).

   References: https://github.com/cilium/cilium/issues/20550, https://github.com/cilium/cilium/pull/27464

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2977

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
   Enables policy-cidr-match-mode: nodes in the Cilium CNI addon configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
