### PR TITLE
Fix typo in cilium config

### DIFF
--- a/addons/cni-cilium/cilium-config-map.yaml
+++ b/addons/cni-cilium/cilium-config-map.yaml
@@ -131,7 +131,7 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   operator-prometheus-serve-addr: :9963
   packetization-layer-pmtud-mode: blackhole
-  policy-cidr-match-mode: "node"
+  policy-cidr-match-mode: "nodes"
   policy-default-local-cluster: "true"
   policy-deny-response: none
   policy-secrets-namespace: cilium-secrets


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the typo in cilium config map.

thanks @mawatech for spotting it!

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed typo in cilium configmap
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
