### PR TITLE
Images upgrades part 3

### DIFF
--- a/addons/ccm-digitalocean/Kustomization
+++ b/addons/ccm-digitalocean/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.64.yml
+  - https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.66.yml
 
 patches:
   - patch: |-

--- a/addons/ccm-digitalocean/README.md
+++ b/addons/ccm-digitalocean/README.md
@@ -4,5 +4,5 @@
 
 ### Generate manifest YAML
 ```shell
-kubectl kustomize . > ccm-digitalocean.yaml
+kubectl kustomize . | yq > ccm-digitalocean.yaml
 ```

--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -11,80 +11,80 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   name: system:cloud-controller-manager
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/status
-  verbs:
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -95,9 +95,9 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- kind: ServiceAccount
-  name: cloud-controller-manager
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -118,33 +118,33 @@ spec:
         app: digitalocean-cloud-controller-manager
     spec:
       containers:
-      - command:
-        - /bin/digitalocean-cloud-controller-manager
-        - --leader-elect=false
-        env:
-        - name: DO_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: DO_TOKEN
-              name: kubeone-ccm-credentials
-        image: '{{ .InternalImages.Get "DigitaloceanCCM" }}'
-        name: digitalocean-cloud-controller-manager
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
+        - command:
+            - /bin/digitalocean-cloud-controller-manager
+            - --leader-elect=false
+          env:
+            - name: DO_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: DO_TOKEN
+                  name: kubeone-ccm-credentials
+          image: '{{ .InternalImages.Get "DigitaloceanCCM" }}'
+          name: digitalocean-cloud-controller-manager
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
       dnsPolicy: Default
       hostNetwork: true
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
       volumes: []

--- a/addons/ccm-gcp/Kustomization
+++ b/addons/ccm-gcp/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/ccm/v33.1.1/deploy/packages/default/manifest.yaml
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/ccm/v35.0.2/deploy/packages/default/manifest.yaml
 
 patches:
   - target:

--- a/addons/csi-azuredisk/Kustomization
+++ b/addons/csi-azuredisk/Kustomization
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
 - name: azuredisk-csi-driver
   repo: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
-  version: v1.33.7
+  version: v1.34.2
   releaseName: azuredisk-csi-driver
   namespace: kube-system
   valuesFile: helm-values

--- a/addons/csi-azuredisk/csi-azuredisk.yaml
+++ b/addons/csi-azuredisk/csi-azuredisk.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: csi-azuredisk-controller-sa
   namespace: kube-system
 ---
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: csi-azuredisk-node-sa
   namespace: kube-system
 ---
@@ -29,8 +29,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-external-attacher-role
 rules:
   - apiGroups:
@@ -104,8 +104,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-external-provisioner-role
 rules:
   - apiGroups:
@@ -197,8 +197,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-external-resizer-role
 rules:
   - apiGroups:
@@ -272,8 +272,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-external-snapshotter-role
 rules:
   - apiGroups:
@@ -385,8 +385,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -404,8 +404,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -423,8 +423,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -442,8 +442,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: azuredisk-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -487,8 +487,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: csi-azuredisk-controller
   namespace: kube-system
 spec:
@@ -503,8 +503,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.33.7
-        helm.sh/chart: azuredisk-csi-driver-1.33.7
+        app.kubernetes.io/version: 1.34.2
+        helm.sh/chart: azuredisk-csi-driver-1.34.2
     spec:
       affinity:
         nodeAffinity:
@@ -548,7 +548,7 @@ spec:
         - args:
             - -v=2
             - -csi-address=$(ADDRESS)
-            - -timeout=1200s
+            - -timeout=600s
             - -leader-election
             - --leader-election-namespace=kube-system
             - -worker-threads=1000
@@ -605,7 +605,7 @@ spec:
             - -leader-election
             - --leader-election-namespace=kube-system
             - -handle-volume-inuse-error=false
-            - -feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true
+            - --feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true
             - -timeout=240s
             - --retry-interval-max=30m
           env:
@@ -663,6 +663,7 @@ spec:
             - --traffic-manager-port=7788
             - --enable-otel-tracing=false
             - --check-disk-lun-collision=true
+            - --vmss-detach-timeout-seconds=20
           env:
             - name: AZURE_CREDENTIAL_FILE
               valueFrom:
@@ -740,8 +741,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.33.7
-    helm.sh/chart: azuredisk-csi-driver-1.33.7
+    app.kubernetes.io/version: 1.34.2
+    helm.sh/chart: azuredisk-csi-driver-1.34.2
   name: csi-azuredisk-node
   namespace: kube-system
 spec:
@@ -755,8 +756,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.33.7
-        helm.sh/chart: azuredisk-csi-driver-1.33.7
+        app.kubernetes.io/version: 1.34.2
+        helm.sh/chart: azuredisk-csi-driver-1.34.2
     spec:
       affinity:
         nodeAffinity:
@@ -943,8 +944,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.33.7
-    snapshot: v8.4.0
+    csiDriver: v1.34.2
+    snapshot: v8.5.0
   name: disk.csi.azure.com
 spec:
   attachRequired: true

--- a/addons/csi-azurefile/Kustomization
+++ b/addons/csi-azurefile/Kustomization
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
 - name: azurefile-csi-driver
   repo: https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/charts
-  version: v1.34.2
+  version: v1.35.1
   releaseName: azurefile-csi-driver
   namespace: kube-system
   valuesFile: helm-values

--- a/addons/csi-azurefile/csi-azurefile.yaml
+++ b/addons/csi-azurefile/csi-azurefile.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-controller-sa
   namespace: kube-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-node-sa
   namespace: kube-system
 ---
@@ -35,8 +35,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-external-attacher-role
 rules:
   - apiGroups:
@@ -106,8 +106,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-external-provisioner-role
 rules:
   - apiGroups:
@@ -201,8 +201,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-external-resizer-role
 rules:
   - apiGroups:
@@ -262,8 +262,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-external-snapshotter-role
 rules:
   - apiGroups:
@@ -331,8 +331,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-controller-secret-role
 rules:
   - apiGroups:
@@ -352,8 +352,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-node-secret-role
 rules:
   - apiGroups:
@@ -372,8 +372,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -393,8 +393,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -414,8 +414,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -435,8 +435,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: azurefile-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -456,8 +456,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-controller-secret-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -477,8 +477,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-node-secret-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -499,8 +499,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-controllermanager
   namespace: kube-system
 spec:
@@ -521,8 +521,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azurefile-csi-driver
         app.kubernetes.io/part-of: azurefile-csi-driver
-        app.kubernetes.io/version: 1.34.2
-        helm.sh/chart: azurefile-csi-driver-1.34.2
+        app.kubernetes.io/version: 1.35.1
+        helm.sh/chart: azurefile-csi-driver-1.35.1
     spec:
       affinity:
         nodeAffinity:
@@ -741,8 +741,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: csi-azurefile-nodemanager
   namespace: kube-system
 spec:
@@ -760,8 +760,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azurefile-csi-driver
         app.kubernetes.io/part-of: azurefile-csi-driver
-        app.kubernetes.io/version: 1.34.2
-        helm.sh/chart: azurefile-csi-driver-1.34.2
+        app.kubernetes.io/version: 1.35.1
+        helm.sh/chart: azurefile-csi-driver-1.35.1
     spec:
       affinity:
         nodeAffinity:
@@ -995,16 +995,16 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.34.2
-    snapshot: v8.4.0
+    csiDriver: v1.35.1
+    snapshot: v8.5.0
   labels:
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/instance: azurefile-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.34.2
-    helm.sh/chart: azurefile-csi-driver-1.34.2
+    app.kubernetes.io/version: 1.35.1
+    helm.sh/chart: azurefile-csi-driver-1.35.1
   name: file.csi.azure.com
 spec:
   attachRequired: false

--- a/addons/csi-digitalocean/Kustomization
+++ b/addons/csi-digitalocean/Kustomization
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v4.15.0/driver.yaml
+  - https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v4.16.0/driver.yaml
 
 patches:
   - patch: |-

--- a/addons/csi-gcp-compute-persistent/Kustomization
+++ b/addons/csi-gcp-compute-persistent/Kustomization
@@ -3,8 +3,8 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/base/controller?ref=v1.22.1
-  - https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/base/node_linux?ref=v1.22.1
+  - https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/base/controller?ref=v1.23.3
+  - https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/kubernetes/base/node_linux?ref=v1.23.3
 
 patches:
   - patch: |-
@@ -34,25 +34,12 @@ patches:
                 image: '{{ .InternalImages.Get "GCPComputeCSIProvisioner" }}'
               - name: csi-attacher
                 image: '{{ .InternalImages.Get "GCPComputeCSIAttacher" }}'
-                args:
-                  - --v=5
-                  - --csi-address=/csi/csi.sock
-                  - --http-endpoint=:22012
-                  - --leader-election
-                  - --leader-election-namespace=$(PDCSI_NAMESPACE)
-                  - --timeout=250s
-                  - --default-fstype=ext4
               - name: csi-resizer
                 image: '{{ .InternalImages.Get "GCPComputeCSIResizer" }}'
               - name: csi-snapshotter
                 image: '{{ .InternalImages.Get "GCPComputeCSISnapshotter" }}'
               - name: gce-pd-driver
                 image: '{{ .InternalImages.Get "GCPComputeCSIDriver" }}'
-                args:
-                  - --v=5
-                  - --endpoint=unix:/csi/csi.sock
-                  - --supports-dynamic-iops-provisioning=hyperdisk-balanced,hyperdisk-extreme
-                  - --supports-dynamic-throughput-provisioning=hyperdisk-balanced,hyperdisk-throughput,hyperdisk-ml
 
   - target:
       group: apps
@@ -83,7 +70,3 @@ patches:
                 image: '{{ .InternalImages.Get "GCPComputeCSINodeDriverRegistrar" }}'
               - name: gce-pd-driver
                 image: '{{ .InternalImages.Get "GCPComputeCSIDriver" }}'
-                args:
-                  - --v=5
-                  - --endpoint=unix:/csi/csi.sock
-                  - --run-controller-service=false

--- a/addons/csi-gcp-compute-persistent/csi-gcp-compute-persistent.yaml
+++ b/addons/csi-gcp-compute-persistent/csi-gcp-compute-persistent.yaml
@@ -516,7 +516,6 @@ spec:
             - --leader-election
             - --leader-election-namespace=$(PDCSI_NAMESPACE)
             - --timeout=250s
-            - --default-fstype=ext4
           env:
             - name: PDCSI_NAMESPACE
               valueFrom:
@@ -591,6 +590,8 @@ spec:
             - --endpoint=unix:/csi/csi.sock
             - --supports-dynamic-iops-provisioning=hyperdisk-balanced,hyperdisk-extreme
             - --supports-dynamic-throughput-provisioning=hyperdisk-balanced,hyperdisk-throughput,hyperdisk-ml
+            - --enable-data-cache
+            - --run-node-service=false
           command:
             - /gce-pd-csi-driver
           env:
@@ -664,6 +665,8 @@ spec:
             - --v=5
             - --endpoint=unix:/csi/csi.sock
             - --run-controller-service=false
+            - --enable-data-cache
+            - --node-name=$(KUBE_NODE_NAME)
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -292,7 +292,7 @@ func optionalResources() map[Resource]map[string]string {
 		AzureDiskCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0"},
 
 		// DigitalOcean CCM
-		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.64"},
+		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.66"},
 
 		// DigitalOcean CSI
 		DigitalOceanCSI:                   {"*": "docker.io/digitalocean/do-csi-plugin:v4.15.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -283,13 +283,13 @@ func optionalResources() map[Resource]map[string]string {
 		AzureFileCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0"},
 
 		// AzureDisk CSI driver5
-		AzureDiskCSI:                   {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.33.7"},
-		AzureDiskCSIAttacher:           {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.10.0"},
-		AzureDiskCSILivenessProbe:      {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0"},
-		AzureDiskCSINodeDriverRegistar: {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0"},
-		AzureDiskCSIProvisioner:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.0.0"},
-		AzureDiskCSIResizer:            {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0"},
-		AzureDiskCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0"},
+		AzureDiskCSI:                   {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.2"},
+		AzureDiskCSIAttacher:           {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.11.0"},
+		AzureDiskCSILivenessProbe:      {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0"},
+		AzureDiskCSINodeDriverRegistar: {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0"},
+		AzureDiskCSIProvisioner:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.1"},
+		AzureDiskCSIResizer:            {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0"},
+		AzureDiskCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0"},
 
 		// DigitalOcean CCM
 		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.64"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -380,7 +380,7 @@ func optionalResources() map[Resource]map[string]string {
 
 		// GCP Compute Persistent Disk CSI
 		// see: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/images/stable-master/image.yaml
-		GCPComputeCSIDriver:              {"*": "registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.17.4"},
+		GCPComputeCSIDriver:              {"*": "registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.23.3"},
 		GCPComputeCSIProvisioner:         {"*": "registry.k8s.io/sig-storage/csi-provisioner:v6.0.0"},
 		GCPComputeCSIAttacher:            {"*": "registry.k8s.io/sig-storage/csi-attacher:v4.8.1"},
 		GCPComputeCSIResizer:             {"*": "registry.k8s.io/sig-storage/csi-resizer:v2.0.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -376,7 +376,7 @@ func optionalResources() map[Resource]map[string]string {
 		NutanixCSISnapshotter:           {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3"},
 
 		// GCP CCM
-		GCPCCM: {"*": "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1"},
+		GCPCCM: {"*": "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v35.0.2"},
 
 		// GCP Compute Persistent Disk CSI
 		// see: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/images/stable-master/image.yaml

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -295,11 +295,11 @@ func optionalResources() map[Resource]map[string]string {
 		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.66"},
 
 		// DigitalOcean CSI
-		DigitalOceanCSI:                   {"*": "docker.io/digitalocean/do-csi-plugin:v4.15.0"},
+		DigitalOceanCSI:                   {"*": "docker.io/digitalocean/do-csi-plugin:v4.16.0"},
 		DigitalOceanCSIAlpine:             {"*": "docker.io/alpine:3"},
 		DigitalOceanCSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v4.10.0"},
 		DigitalOceanCSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0"},
-		DigitalOceanCSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v6.0.0"},
+		DigitalOceanCSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v6.1.0"},
 		DigitalOceanCSIResizer:            {"*": "registry.k8s.io/sig-storage/csi-resizer:v2.0.0"},
 		DigitalOceanCSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0"},
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -275,12 +275,12 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// AzureFile CSI driver
-		AzureFileCSI:                   {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:v1.34.2"},
-		AzureFileCSILivenessProbe:      {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0"},
-		AzureFileCSINodeDriverRegistar: {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0"},
-		AzureFileCSIProvisioner:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.0.0"},
-		AzureFileCSIResizer:            {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0"},
-		AzureFileCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0"},
+		AzureFileCSI:                   {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:v1.35.1"},
+		AzureFileCSILivenessProbe:      {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0"},
+		AzureFileCSINodeDriverRegistar: {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0"},
+		AzureFileCSIProvisioner:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.1"},
+		AzureFileCSIResizer:            {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0"},
+		AzureFileCSISnapshotter:        {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0"},
 
 		// AzureDisk CSI driver5
 		AzureDiskCSI:                   {"*": "mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.33.7"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Refreshing system images for the latest stable (1.35 at the time) Kubernetes release.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3992

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade GCP CSI compute-persistent driver to v1.23.3
Upgrade GCP CCM to v35.0.2
Upgrade DigitalOceam CSI Driver to v4.16.0
Upgrade DigitalOcean CCM to v0.1.66
Upgrade AzureDisk CSI driver to 1.34.2
Upgrade AzureFile CSI driver to v1.35.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
