### PR TITLE
Fix: bastion host can have different ssh key

### DIFF
--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -231,16 +231,17 @@ func NewConnection(connector *Connector, opts Opts) (executor.Interface, error) 
 		agentClient := agent.NewClient(socket)
 
 		signers, signersErr := agentClient.Signers()
-		if signersErr != nil {
+		switch {
+		case signersErr != nil:
 			socket.Close()
 
 			return nil, fail.SSHError{
 				Op:  "creating signer for SSH agent",
 				Err: signersErr,
 			}
-		} else if len(signers) == 0 {
+		case len(signers) == 0:
 			socket.Close()
-		} else {
+		default:
 			nodeAuthMethods = append(nodeAuthMethods, ssh.PublicKeys(signers...))
 			// only add agent keys to bastion if no dedicated bastion key was set
 			if len(opts.BastionPrivateKey) == 0 {

--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -141,10 +141,11 @@ func NewConnection(connector *Connector, opts Opts) (executor.Interface, error) 
 		return nil, err
 	}
 
-	authMethods := make([]ssh.AuthMethod, 0)
+	// nodeAuthMethods are used to authenticate to the target node.
+	nodeAuthMethods := make([]ssh.AuthMethod, 0)
 
 	if len(opts.Password) > 0 {
-		authMethods = append(authMethods, ssh.Password(opts.Password))
+		nodeAuthMethods = append(nodeAuthMethods, ssh.Password(opts.Password))
 	}
 
 	if len(opts.PrivateKey) > 0 {
@@ -181,11 +182,17 @@ func NewConnection(connector *Connector, opts Opts) (executor.Interface, error) 
 				}
 			}
 
-			authMethods = append(authMethods, ssh.PublicKeys(certSigner))
+			nodeAuthMethods = append(nodeAuthMethods, ssh.PublicKeys(certSigner))
 		} else {
-			authMethods = append(authMethods, ssh.PublicKeys(signer))
+			nodeAuthMethods = append(nodeAuthMethods, ssh.PublicKeys(signer))
 		}
 	}
+
+	// bastionAuthMethods are used exclusively for the bastion hop. When a
+	// dedicated bastion key is provided we use only that key so we never waste
+	// MaxAuthTries attempts on the node key (which the bastion does not know).
+	// If no bastion key is configured we fall back to the node auth methods.
+	bastionAuthMethods := nodeAuthMethods
 
 	if len(opts.BastionPrivateKey) > 0 {
 		signer, parseErr := ssh.ParsePrivateKey(opts.BastionPrivateKey)
@@ -195,7 +202,7 @@ func NewConnection(connector *Connector, opts Opts) (executor.Interface, error) 
 				Err: errors.Wrap(parseErr, "bastion SSH key could not be parsed (note that password-protected keys are not supported)"),
 			}
 		}
-		authMethods = append(authMethods, ssh.PublicKeys(signer))
+		bastionAuthMethods = []ssh.AuthMethod{ssh.PublicKeys(signer)}
 	}
 
 	if len(opts.AgentSocket) > 0 {
@@ -233,83 +240,85 @@ func NewConnection(connector *Connector, opts Opts) (executor.Interface, error) 
 			}
 		} else if len(signers) == 0 {
 			socket.Close()
-
-			return nil, fail.SSHError{
-				Err: errors.New("could not retrieve signers"),
-				Op:  "creating signer for SSH agent",
+		} else {
+			nodeAuthMethods = append(nodeAuthMethods, ssh.PublicKeys(signers...))
+			// only add agent keys to bastion if no dedicated bastion key was set
+			if len(opts.BastionPrivateKey) == 0 {
+				bastionAuthMethods = nodeAuthMethods
 			}
 		}
-
-		authMethods = append(authMethods, ssh.PublicKeys(signers...))
 	}
 
-	sshConfig := &ssh.ClientConfig{
+	nodeConfig := &ssh.ClientConfig{
 		User:            opts.Username,
 		Timeout:         opts.Timeout,
-		Auth:            authMethods,
+		Auth:            nodeAuthMethods,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 	}
 
 	if opts.HostPublicKey != nil {
-		sshConfig.HostKeyCallback = hostKeyCallback(opts.HostPublicKey)
+		nodeConfig.HostKeyCallback = hostKeyCallback(opts.HostPublicKey)
 	}
 
-	targetHost := opts.Hostname
-	targetPort := strconv.Itoa(opts.Port)
-
-	if opts.Bastion != "" {
-		targetHost = opts.Bastion
-		targetPort = strconv.Itoa(opts.BastionPort)
-		sshConfig.User = opts.BastionUser
-
-		if opts.BastionHostPublicKey != nil {
-			sshConfig.HostKeyCallback = hostKeyCallback(opts.BastionHostPublicKey)
-		}
-	}
-
-	// do not use fmt.Sprintf() to allow proper IPv6 handling if hostname is an IP address
-	endpoint := net.JoinHostPort(targetHost, targetPort)
-
-	client, err := ssh.Dial("tcp", endpoint, sshConfig)
-	if err != nil {
-		return nil, fail.SSH(fail.Connection(err, endpoint), "dialing")
-	}
-
-	ctx, cancelFn := context.WithCancel(connector.ctx)
-	sshConn := &connection{
-		connector: connector,
-		ctx:       ctx,
-		cancel:    cancelFn,
-	}
-
+	// No bastion: connect directly to the node.
 	if opts.Bastion == "" {
-		sshConn.sshclient = client
-		// connection established
-		return sshConn, nil
+		endpoint := net.JoinHostPort(opts.Hostname, strconv.Itoa(opts.Port))
+
+		client, dialErr := ssh.Dial("tcp", endpoint, nodeConfig)
+		if dialErr != nil {
+			return nil, fail.SSH(fail.Connection(dialErr, endpoint), "dialing")
+		}
+
+		ctx, cancelFn := context.WithCancel(connector.ctx)
+
+		return &connection{
+			sshclient: client,
+			connector: connector,
+			ctx:       ctx,
+			cancel:    cancelFn,
+		}, nil
 	}
 
-	// continue to setup if we are running over bastion
-	endpointBehindBastion := net.JoinHostPort(opts.Hostname, strconv.Itoa(opts.Port))
+	// Connect to the bastion with its own dedicated auth methods.
+	bastionConfig := &ssh.ClientConfig{
+		User:            opts.BastionUser,
+		Timeout:         opts.Timeout,
+		Auth:            bastionAuthMethods,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+	}
 
-	if opts.HostPublicKey != nil {
-		sshConfig.HostKeyCallback = hostKeyCallback(opts.HostPublicKey)
+	if opts.BastionHostPublicKey != nil {
+		bastionConfig.HostKeyCallback = hostKeyCallback(opts.BastionHostPublicKey)
+	}
+
+	bastionEndpoint := net.JoinHostPort(opts.Bastion, strconv.Itoa(opts.BastionPort))
+
+	bastionClient, err := ssh.Dial("tcp", bastionEndpoint, bastionConfig)
+	if err != nil {
+		return nil, fail.SSH(fail.Connection(err, bastionEndpoint), "dialing")
 	}
 
 	// Dial a connection to the service host, from the bastion
-	conn, err := client.Dial("tcp", endpointBehindBastion)
+	endpointBehindBastion := net.JoinHostPort(opts.Hostname, strconv.Itoa(opts.Port))
+
+	conn, err := bastionClient.Dial("tcp", endpointBehindBastion)
 	if err != nil {
 		return nil, fail.SSH(fail.Connection(err, endpointBehindBastion), "dialing behind the bastion")
 	}
 
-	sshConfig.User = opts.Username
-	ncc, chans, reqs, err := ssh.NewClientConn(conn, endpointBehindBastion, sshConfig)
+	ncc, chans, reqs, err := ssh.NewClientConn(conn, endpointBehindBastion, nodeConfig)
 	if err != nil {
 		return nil, fail.SSH(fail.Connection(err, endpointBehindBastion), "new client")
 	}
 
-	sshConn.sshclient = ssh.NewClient(ncc, chans, reqs)
+	ctx, cancelFn := context.WithCancel(connector.ctx)
 
-	return sshConn, nil
+	return &connection{
+		sshclient: ssh.NewClient(ncc, chans, reqs),
+		connector: connector,
+		ctx:       ctx,
+		cancel:    cancelFn,
+	}, nil
 }
 
 func hostKeyCallback(knownKey []byte) ssh.HostKeyCallback {


### PR DESCRIPTION

**What this PR does / why we need it**:

When `bastionPrivateKeyFile` and `sshPrivateKeyFile` were different, KubeOne was using both keys for both the bastion and the target node.

This caused the wrong key (node key) to be tried first on the bastion, which often fails and exhausts authentication attempts before the correct key is used.

On strict servers, this leads to SSH connection failure.

Also, if `sshAgentSocket` was set but the agent had no keys, KubeOne failed instead of falling back to the configured key files.

This PR ensures the following: 

* Use separate SSH keys for bastion and node:

  * bastion uses only `bastionPrivateKeyFile`
  * node uses only `sshPrivateKeyFile`
* Create separate SSH configs for bastion and node connections
* Ensure correct key is used at each step
* If SSH agent is empty, ignore it and continue using key files instead of failing

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The jump host can have a different SSH key.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
