### PR TITLE
  Prevent gateway controllers from recreating LB services during reset

### DIFF
--- a/pkg/clientutil/service.go
+++ b/pkg/clientutil/service.go
@@ -29,7 +29,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// LBResources is the list of resources blocked by the LB creation-preventing webhook.
+var LBResources = []string{"services"}
+
 func CleanupLBs(ctx context.Context, logger logrus.FieldLogger, c client.Client) error {
+	// Block service creation so gateway/other controllers can't recreate LB services
+	// while we're deleting them.
+	logger.Infoln("Creating ValidatingWebhookConfiguration to disable future Service creation...")
+	if err := creationPreventingWebhook(ctx, c, "", LBResources); err != nil {
+		return fail.KubeClient(err, "disabling future Service creation")
+	}
+
 	serviceList := &corev1.ServiceList{}
 	if err := c.List(ctx, serviceList); err != nil {
 		return fail.KubeClient(err, "listing services")

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -41,6 +41,11 @@ func RemoveLBServices(s *state.State) error {
 	lastErr = clientutil.CleanupLBs(s.Context, s.Logger, s.DynamicClient)
 	if lastErr != nil {
 		s.Logger.Warn("Unable to delete services of type load balancer.")
+		s.Logger.Infoln("Deleting ValidatingWebhookConfiguration to enable future Service creation...")
+		if err := clientutil.DeletePreventingWebhook(s.Context, s.DynamicClient,
+			"kubernetes-cluster-cleanup-"+strings.Join(clientutil.LBResources, "-")); err != nil {
+			s.Logger.Warn("Unable to delete ValidatingWebhookConfiguration.")
+		}
 
 		return lastErr
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

This PR addresses the issue where Gateway controllers recreate Services during reset by introducing a `ValidatingWebhookConfiguration` that blocks all Service creation. This prevents Gateway and other controllers from recreating load balancer Services during teardown. If the deletion process fails, the webhook is removed to ensure the cluster is not left in a broken state.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent Gateway controllers from recreating LoadBalancer Services during reset.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
