### PR TITLE
Avoid modprobe ip_tables, as it's no more in the newer kernels

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11
+          version: v2.12
 
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -41,11 +41,9 @@ var libraryTemplate = heredoc.Doc(`
 		cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 		overlay
 		br_netfilter
-		ip_tables
 		EOF
 		sudo modprobe overlay
 		sudo modprobe br_netfilter
-		sudo modprobe ip_tables
 		if modinfo nf_conntrack_ipv4 &> /dev/null; then
 			sudo modprobe nf_conntrack_ipv4
 		else

--- a/pkg/scripts/testdata/TestDebScript-install_all.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all.golden
@@ -11,11 +11,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_force.golden
@@ -11,11 +11,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestDebScript-install_all_with_proxy.golden
@@ -11,11 +11,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl.golden
@@ -11,11 +11,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -11,11 +11,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestDebScript-upgrade_kubelet.golden
@@ -11,11 +11,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all.golden
@@ -22,11 +22,9 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_force.golden
@@ -22,11 +22,9 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-install_all_with_proxy.golden
@@ -22,11 +22,9 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl.golden
@@ -22,11 +22,9 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -22,11 +22,9 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestFlatcarScript-upgrade_kubelet.golden
@@ -22,11 +22,9 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestRHELLikeScript-install_all.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-install_all.golden
@@ -13,11 +13,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_force.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_force.golden
@@ -13,11 +13,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_proxy.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-install_all_with_proxy.golden
@@ -13,11 +13,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl.golden
@@ -13,11 +13,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl_with_force.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubeadm_and_kubectl_with_force.golden
@@ -13,11 +13,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubelet.golden
+++ b/pkg/scripts/testdata/TestRHELLikeScript-upgrade_kubelet.golden
@@ -13,11 +13,9 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
-ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
-sudo modprobe ip_tables
 if modinfo nf_conntrack_ipv4 &> /dev/null; then
 	sudo modprobe nf_conntrack_ipv4
 else

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -238,7 +238,7 @@ func baseResources() map[Resource]map[string]string {
 		Flannel:                {"*": "docker.io/flannel/flannel:v0.24.4"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.65.0"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.8.1"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.10.5"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:732717073b6fa61d4bce5874070173489de06d48"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
kubernetes has moved to the nftables and latest kernels don't have ip_tables

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3887

**What type of PR is this?**
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid modprobe ip_tables
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
