### PR TITLE
Fix v1.kubelet-config annotations in terraform examples

### DIFF
--- a/examples/terraform/aws-dualstack/output.tf
+++ b/examples/terraform/aws-dualstack/output.tf
@@ -96,6 +96,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -109,19 +120,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -163,6 +161,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -176,19 +185,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -230,6 +226,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -243,19 +250,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -96,6 +96,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -111,19 +122,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -162,6 +160,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -177,19 +186,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:
@@ -228,6 +224,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -243,19 +250,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -67,6 +67,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = local.worker_os
@@ -81,19 +92,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -65,6 +65,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [digitalocean_ssh_key.deployer.public_key]
         operatingSystem = local.worker_os
@@ -74,19 +85,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/equinixmetal/output.tf
+++ b/examples/terraform/equinixmetal/output.tf
@@ -55,6 +55,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = local.worker_os
@@ -66,15 +77,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -66,6 +66,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
@@ -75,19 +86,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -71,6 +71,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = local.worker_os
@@ -80,19 +91,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/nutanix/output.tf
+++ b/examples/terraform/nutanix/output.tf
@@ -71,6 +71,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
@@ -80,19 +91,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -77,6 +77,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
@@ -88,19 +99,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/vmware-cloud-director/output.tf
+++ b/examples/terraform/vmware-cloud-director/output.tf
@@ -74,6 +74,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
@@ -83,19 +94,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -71,6 +71,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
@@ -80,19 +91,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -265,7 +265,7 @@ variable "ip_family" {
 }
 
 variable "enable_disk_uuid" {
-  default = true
-  type = bool
+  default     = true
+  type        = bool
   description = "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest"
 }

--- a/examples/terraform/vsphere_flatcar/outputs.tf
+++ b/examples/terraform/vsphere_flatcar/outputs.tf
@@ -69,6 +69,17 @@ output "kubeone_workers" {
           "k8c.io/operating-system-profile"                           = var.initial_machinedeployment_operating_system_profile
           "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size" = tostring(local.cluster_autoscaler_min_replicas)
           "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size" = tostring(local.cluster_autoscaler_max_replicas)
+          # annotations are applied on resulting MachineDeployment objects
+          # uncomment to following to set those kubelet parameters. More into at:
+          # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
+          #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
@@ -80,19 +91,6 @@ output "kubeone_workers" {
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
         #   "key" = "value"
-        # }
-        # machineObjectAnnotations are applied on resulting Machine objects
-        # uncomment to following to set those kubelet parameters. More into at:
-        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
-        # machineObjectAnnotations = {
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved"              = "cpu=200m,memory=200Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"                = "cpu=200m,memory=300Mi"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"                = ""
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"                     = "110"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCHighThresholdPercent" = "85"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageGCLowThresholdPercent"  = "80"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMinimumGCAge"           = "2m"
-        #   "v1.kubelet-config.machine-controller.kubermatic.io/ImageMaximumGCAge"           = "0"
         # }
         cloudProviderSpec = {
           # provider specific fields:


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to make those annotations work they should be annotated at the MachineDeployment level, not Machine.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3987

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix v1.kubelet-config annotations in terraform examples
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://docs.kubermatic.com/operatingsystemmanager/guides/osm-configuration/#configuring-operating-system-profile
```
