### PR TITLE
Add kubevirt as a supported provider for init command

### DIFF
--- a/pkg/cmd/initcmd/generate.go
+++ b/pkg/cmd/initcmd/generate.go
@@ -220,7 +220,7 @@ func genKubeOneClusterYAML(params *GenerateOpts) ([]byte, error) {
 	prov := ValidProviders[params.providerName]
 	clusterName := params.clusterName
 
-	if params.generateTerraform && params.providerName != "none" {
+	if params.generateTerraform && prov.terraformPath != "" {
 		clusterName = ""
 	}
 

--- a/pkg/cmd/initcmd/providers.go
+++ b/pkg/cmd/initcmd/providers.go
@@ -168,6 +168,12 @@ var ValidProviders = map[string]initProvider{
 			},
 		},
 	},
+	"kubevirt": {
+		title:    "KubeVirt",
+		external: true,
+		// terraformPath is intentionally empty: KubeVirt runs on an existing Kubernetes
+		// infra cluster, so there is no Terraform template to provision infrastructure.
+	},
 	"none": {
 		title:         "None (e.g. baremetal)",
 		terraformPath: "",

--- a/pkg/cmd/initcmd/testdata/TestGenKubeOneClusterYAML-default_on_kubevirt.golden
+++ b/pkg/cmd/initcmd/testdata/TestGenKubeOneClusterYAML-default_on_kubevirt.golden
@@ -1,0 +1,19 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+versions:
+  kubernetes: v1.24.4
+
+cloudProvider:
+  kubevirt: {}
+  external: true
+
+containerRuntime:
+  containerd: {}
+
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR registers KubeVirt in the init provider list and adds the corresponding cluster YAML template so the command generates a valid `kubeone.yaml` with `cloudProvider: { kubevirt: {} }`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #3941

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt as a supported provider for init command 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
