### PR TITLE
Add successfulJobsHistoryLimit param to backups-restic addon

### DIFF
--- a/addons/backups-restic/backups-restic.yaml
+++ b/addons/backups-restic/backups-restic.yaml
@@ -26,7 +26,7 @@ spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
   schedule: '@every 30m'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: {{ default 1 .Params.successfulJobsHistoryLimit }}
   suspend: false
   jobTemplate:
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `backups-restic` embedded addon deploys a `CronJob` (`etcd-s3-backup`) that periodically snapshots etcd state and pushes it to an S3-compatible backend using restic. Prior to this change the `successfulJobsHistoryLimit` field on that CronJob was hardcoded to `0`, meaning Kubernetes would immediately garbage-collect every completed (successful) Job pod. This made it impossible to inspect pod logs after a backup run to confirm the backup actually succeeded — operators had to rely on the absence of a failure alert rather than a positive confirmation. The previous default of `0` was also inconsistent with the general Kubernetes ecosystem convention (e.g. KKP's own `etcd-defragger` CronJob uses `1`) and with the already-present `failedJobsHistoryLimit: 1` on the same CronJob.

This PR makes `successfulJobsHistoryLimit` a user-tuneable addon parameter while changing the built-in default from `0` to `1`. With `1` as the default, one successful Job pod is retained after each backup cycle, giving operators the ability to run `kubectl logs -n kube-system <pod>` to verify that the restic upload actually completed without errors. Users who want the previous space-saving behaviour of `0`, or who prefer a larger retention window, can override the value via the addon `Params` map in their `kubeone.yaml`:

```yaml
addons:
  enable: true
  addons:
    - name: backups-restic
      params:
        resticPassword: "<secret>"
        successfulJobsHistoryLimit: 3   # keep last 3 successful job pods
```

The implementation follows the existing pattern already used by other parameters in this addon (e.g. `resticPassword`) and uses the `default` template function so that clusters that do not set the parameter continue to work with the new sensible default of `1`.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4101

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add successfulJobsHistoryLimit param to backups-restic addon
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
