### PR TITLE
Regenerate apiserver.crt when APIEndpoint.AlternativeNames has something new

### DIFF
--- a/pkg/certificate/ca.go
+++ b/pkg/certificate/ca.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
-	KubernetesCACertPath = "/etc/kubernetes/pki/ca.crt"
-	KubernetesCAKeyPath  = "/etc/kubernetes/pki/ca.key"
+	KubernetesAPIServerPath = "/etc/kubernetes/pki/apiserver.crt"
+	KubernetesCACertPath    = "/etc/kubernetes/pki/ca.crt"
+	KubernetesCAKeyPath     = "/etc/kubernetes/pki/ca.key"
 )
 
-func kubernetesPKIFiles() []string {
+func kubernetesPKICAFiles() []string {
 	return []string{
 		KubernetesCACertPath,
 		KubernetesCAKeyPath,
@@ -49,7 +50,7 @@ func kubernetesPKIFiles() []string {
 func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	sshfs := s.Runner.NewFS()
 
-	for _, fname := range kubernetesPKIFiles() {
+	for _, fname := range kubernetesPKICAFiles() {
 		buf, err := fs.ReadFile(sshfs, fname)
 		if err != nil {
 			return err
@@ -74,13 +75,13 @@ func DownloadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interf
 func UploadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interface) error {
 	sshfs := s.Runner.NewFS()
 
-	for _, fname := range kubernetesPKIFiles() {
+	for _, fname := range kubernetesPKICAFiles() {
 		buf, found := s.Configuration.KubernetesPKI[fname]
 		if !found {
-			return fmt.Errorf("file %q found found in PKI", fname)
+			return fmt.Errorf("file %q not found in PKI", fname)
 		}
 
-		if err := sshfs.MkdirAll(path.Dir(fname), 0700); err != nil {
+		if err := sshfs.MkdirAll(path.Dir(fname), 0o700); err != nil {
 			return err
 		}
 
@@ -95,7 +96,7 @@ func UploadKubePKI(s *state.State, _ *kubeoneapi.HostConfig, _ executor.Interfac
 			return err
 		}
 
-		if err = fw.Chmod(0600); err != nil {
+		if err = fw.Chmod(0o600); err != nil {
 			return err
 		}
 

--- a/pkg/certificate/ca.go
+++ b/pkg/certificate/ca.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	KubernetesAPIServerPath = "/etc/kubernetes/pki/apiserver.crt"
-	KubernetesCACertPath    = "/etc/kubernetes/pki/ca.crt"
-	KubernetesCAKeyPath     = "/etc/kubernetes/pki/ca.key"
+	KubernetesAPIServerCertPath = "/etc/kubernetes/pki/apiserver.crt"
+	KubernetesAPIServerKeyPath  = "/etc/kubernetes/pki/apiserver.key"
+	KubernetesCACertPath        = "/etc/kubernetes/pki/ca.crt"
+	KubernetesCAKeyPath         = "/etc/kubernetes/pki/ca.key"
 )
 
 func kubernetesPKICAFiles() []string {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -21,8 +21,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"io/fs"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -93,7 +96,7 @@ func CAKeyPair(config *configupload.Configuration) (crypto.Signer, *x509.Certifi
 
 func NewSignedKubernetesServiceTLSCert(name, namespace, domain string, caKey crypto.Signer, caCert *x509.Certificate) (map[string]string, error) {
 	serviceCommonName := strings.Join([]string{name, namespace, "svc"}, ".")
-	serviceFQDNCommonName := strings.Join([]string{serviceCommonName, domain, ""}, ".")
+	serviceFQDNCommonName := strings.Join([]string{serviceCommonName, domain}, ".")
 
 	altdnsNames := []string{
 		serviceFQDNCommonName,
@@ -140,7 +143,43 @@ func RenewAll(st *state.State) error {
 		logger := ctx.Logger.WithField("node", node.PublicAddress)
 		logger.Infoln("Renew certificates...")
 
-		_, _, err := ctx.Runner.RunRaw("sudo kubeadm certs renew all")
+		sshfs := ctx.Runner.NewFS()
+		apiserverCertFile, err := fs.ReadFile(sshfs, KubernetesAPIServerPath)
+		if err != nil {
+			return fail.SSH(err, "reading Kubernetes API server certificate")
+		}
+
+		apiserverPEM, _ := pem.Decode(apiserverCertFile)
+		if apiserverPEM == nil {
+			return fail.Runtime(fmt.Errorf("PEM block is empty"), "decoding Kubernetes API server certificate PEM")
+		}
+
+		apiserverCert, err := x509.ParseCertificate(apiserverPEM.Bytes)
+		if err != nil {
+			return fail.Runtime(err, "parsing Kubernetes API server certificate")
+		}
+
+		needToRecreateAPIServerCerts := false
+		for _, san := range ctx.Cluster.APIEndpoint.AlternativeNames {
+			if !slices.Contains(apiserverCert.DNSNames, san) {
+				needToRecreateAPIServerCerts = true
+			}
+		}
+
+		var certsCmd strings.Builder
+		if needToRecreateAPIServerCerts {
+			fmt.Fprintf(&certsCmd, "sudo rm %q\n", KubernetesAPIServerPath)
+			kubeadmInitAllCertsCmd, serr := scripts.KubeadmCertsAll(ctx.WorkDir, node.ID, ctx.KubeadmVerboseFlag())
+			if serr != nil {
+				return serr
+			}
+			certsCmd.WriteString(kubeadmInitAllCertsCmd)
+			certsCmd.WriteString("\n")
+		}
+
+		certsCmd.WriteString("sudo kubeadm certs renew all")
+
+		_, _, err = ctx.Runner.RunRaw(certsCmd.String())
 		if err != nil {
 			return fail.SSH(err, "renewing certificates")
 		}

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -144,7 +144,7 @@ func RenewAll(st *state.State) error {
 		logger.Infoln("Renew certificates...")
 
 		sshfs := ctx.Runner.NewFS()
-		apiserverCertFile, err := fs.ReadFile(sshfs, KubernetesAPIServerPath)
+		apiserverCertFile, err := fs.ReadFile(sshfs, KubernetesAPIServerCertPath)
 		if err != nil {
 			return fail.SSH(err, "reading Kubernetes API server certificate")
 		}
@@ -168,7 +168,7 @@ func RenewAll(st *state.State) error {
 
 		var certsCmd strings.Builder
 		if needToRecreateAPIServerCerts {
-			fmt.Fprintf(&certsCmd, "sudo rm %q\n", KubernetesAPIServerPath)
+			fmt.Fprintf(&certsCmd, "sudo rm %q %q\n", KubernetesAPIServerCertPath, KubernetesAPIServerKeyPath)
 			kubeadmInitAllCertsCmd, serr := scripts.KubeadmCertsAll(ctx.WorkDir, node.ID, ctx.KubeadmVerboseFlag())
 			if serr != nil {
 				return serr

--- a/pkg/cmd/certificates.go
+++ b/pkg/cmd/certificates.go
@@ -65,15 +65,26 @@ func certificatesRenewCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 				return err
 			}
 
-			renew := tasks.Tasks{
-				{Fn: certificate.RenewAll, Operation: "renew all the certificates of the Kubernetes control plane and kubelets"},
-				{Fn: kubeconfig.BuildKubernetesClientset, Operation: "building kubernetes clientset"},
-				{
-					Fn: func(s *state.State) error {
-						return s.RunTaskOnLeader(tasks.ApprovePendingCSR)
-					},
-				},
+			probbing := tasks.WithHostnameOS(nil)
+			probbing = tasks.WithProbesAndSafeguard(probbing)
+
+			if err := probbing.Run(st); err != nil {
+				return err
 			}
+
+			renew := append(
+				tasks.KubernetesConfigFiles(),
+				tasks.Tasks{
+					{Fn: certificate.RenewAll, Description: "Renew all the certificates of the Kubernetes control plane and kubelets"},
+					{Fn: kubeconfig.BuildKubernetesClientset, Operation: "building Kubernetes clientset"},
+					{
+						Fn: func(s *state.State) error {
+							return s.RunTaskOnLeader(tasks.ApprovePendingCSR)
+						},
+						Description: "Approve pending kubelet CSRs",
+					},
+				}...,
+			)
 
 			return renew.Run(st)
 		},

--- a/pkg/configupload/configuration.go
+++ b/pkg/configupload/configuration.go
@@ -80,7 +80,7 @@ func (c *Configuration) UploadTo(conn executor.Interface, directory string) erro
 
 		// ensure the base dir exists
 		dir := filepath.Dir(target)
-		if err := virtfs.MkdirAll(dir, 0700); err != nil {
+		if err := virtfs.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 
@@ -105,7 +105,7 @@ func (c *Configuration) UploadTo(conn executor.Interface, directory string) erro
 			return fail.Runtime(err, "copying to %s file", target)
 		}
 
-		if err := file.Chmod(0600); err != nil {
+		if err := file.Chmod(0o600); err != nil {
 			return err
 		}
 	}

--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -39,7 +39,7 @@ var (
 		sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;
 	`)
 
-	kubeadmCertScriptTemplate = heredoc.Doc(`
+	kubeadmCertsAllScriptTemplate = heredoc.Doc(`
 		sudo kubeadm {{ .VERBOSE }} init phase certs all \
 			--config={{ .WORK_DIR }}/cfg/control_plane_full_{{ .NODE_ID }}.yaml
 		sudo find /etc/kubernetes/pki/ -name *.crt -exec chmod 600 {} \;
@@ -97,14 +97,14 @@ func KubeadmJoinWorker(workdir string, nodeID int, verboseFlag string) (string, 
 	return result, fail.Runtime(err, "rendering kubeadmWorkerJoinScriptTemplate script")
 }
 
-func KubeadmCert(workdir string, nodeID int, verboseFlag string) (string, error) {
-	result, err := Render(kubeadmCertScriptTemplate, Data{
+func KubeadmCertsAll(workdir string, nodeID int, verboseFlag string) (string, error) {
+	result, err := Render(kubeadmCertsAllScriptTemplate, Data{
 		"WORK_DIR": workdir,
 		"NODE_ID":  nodeID,
 		"VERBOSE":  verboseFlag,
 	})
 
-	return result, fail.Runtime(err, "rendering kubeadmCertScriptTemplate script")
+	return result, fail.Runtime(err, "rendering kubeadmCertsAllScriptTemplate script")
 }
 
 func KubeadmInit(workdir string, nodeID int, verboseFlag, token, tokenTTL string, skipPhases string) (string, error) {

--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -146,7 +146,7 @@ func TestKubeadmCert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := KubeadmCert(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
+			got, err := KubeadmCertsAll(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
 			if !errors.Is(err, tt.err) {
 				t.Errorf("KubeadmCert() error = %v, wantErr %v", err, tt.err)
 

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -55,7 +55,7 @@ func joinControlPlaneNodeInternal(s *state.State, node *kubeoneapi.HostConfig, c
 
 func kubeadmCertsExecutor(s *state.State, node *kubeoneapi.HostConfig, _ executor.Interface) error {
 	s.Logger.Infoln("Ensuring Certificates...")
-	cmd, err := scripts.KubeadmCert(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
+	cmd, err := scripts.KubeadmCertsAll(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/kubeadm_config.go
+++ b/pkg/tasks/kubeadm_config.go
@@ -58,8 +58,6 @@ func determinePauseImageExecutor(s *state.State, _ *kubeoneapi.HostConfig, _ exe
 }
 
 func generateKubeadm(s *state.State) error {
-	s.Logger.Infoln("Generating kubeadm config file...")
-
 	if err := determinePauseImage(s); err != nil {
 		return err
 	}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -133,7 +133,7 @@ func WithFullInstall(t Tasks) Tasks {
 			Operation: "installing prerequisites",
 		},
 	}...).
-		append(kubernetesConfigFiles()...).
+		append(KubernetesConfigFiles()...).
 		append(Tasks{
 			{
 				Fn:        kubeadmPreflightChecks,
@@ -363,7 +363,7 @@ func WithResources(t Tasks) Tasks {
 
 func WithUpgrade(t Tasks, followers ...kubeoneapi.HostConfig) Tasks {
 	return WithHostnameOSAndProbes(t).
-		append(kubernetesConfigFiles()...). // this, in the upgrade process where config rails are handled
+		append(KubernetesConfigFiles()...). // this, in the upgrade process where config rails are handled
 		append(
 			Task{Fn: kubeconfig.BuildKubernetesClientset, Operation: "building kubernetes clientset"},
 			Task{Fn: uploadKubeadmToConfigMaps, Operation: "updating kubeadm configmaps"},
@@ -489,11 +489,11 @@ func WithClusterStatus(t Tasks) Tasks {
 		}...)
 }
 
-func kubernetesConfigFiles() Tasks {
+func KubernetesConfigFiles() Tasks {
 	return Tasks{
-		{Fn: generateKubeadm, Operation: "generating kubeadm config files"},
-		{Fn: generateConfigurationFiles, Operation: "generating config files"},
-		{Fn: uploadConfigurationFiles, Operation: "uploading config files"},
+		{Fn: generateKubeadm, Description: "Generating kubeadm config files"},
+		{Fn: generateConfigurationFiles, Description: "Generating config files"},
+		{Fn: uploadConfigurationFiles, Description: "Uploading config files"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubeadm` preserves the existing SANs of a certificate when renewing it. Kubeadm will not inject new Subject Alternative Names into an already-present cert, even if the kubeadm config has changed. This means that adding a new entry to `apiEndpoint.alternativeNames` in a `KubeOneCluster` manifest and running `kubeone apply --force-upgrade` or `kubeone certificates renew` did not actually update the SAN list of the `kube-apiserver` certificate.

This PR fixes the issue by detecting the mismatch before renewal: it reads the current `apiserver.crt` from each control-plane node, compares its `DNSNames` against the `APIEndpoint.AlternativeNames` in the cluster config and if any names are missing — deletes the certificate so that the subsequent `kubeadm init phase certs all` regenerates it with the full, updated SAN list. The standard `kubeadm certs renew all` then follows as usual.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4060

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`kubeone certificates renew` will detect and fix the drift between apiserver certificate and APIEndpoint.AlternativeNames
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
