### PR TITLE
docs: add managed control-plane guides for Hetzner and OpenStack

### DIFF
--- a/docs/hetzner_control_plane.md
+++ b/docs/hetzner_control_plane.md
@@ -1,0 +1,172 @@
+# Hetzner Managed Control Plane
+
+KubeOne can provision control-plane nodes directly on Hetzner Cloud using
+machine-controller, eliminating the need for pre-provisioned servers or
+external tooling (e.g. Terraform) to manage control-plane VMs.
+
+When `cloudProvider.hetzner.controlPlane` is configured in your
+`kubeone.yaml`, KubeOne will:
+
+1. Ensure a Hetzner Cloud load balancer exists (creates one if missing) and
+   set the `apiEndpoint` from its public IPv4 address.
+2. Provision control-plane servers via machine-controller's Hetzner driver,
+   driven by the `controlPlane.nodeSets` spec.
+3. Automatically attach the load balancer to the configured private network
+   and use label-based target selection to route traffic to control-plane
+   nodes.
+
+If `cloudProvider.hetzner.controlPlane` is omitted, existing behaviour is
+preserved — you must supply `apiEndpoint` and control-plane host IPs yourself
+(e.g. via Terraform's `kubeone_hosts` and `kubeone_api` outputs).
+
+## Prerequisites
+
+- A Hetzner Cloud API token with read/write access to servers, networks,
+  and load balancers.
+- An existing private network in Hetzner Cloud. The network name (or ID)
+  must be provided via `cloudProvider.hetzner.networkID`.
+- Control-plane nodes must be reachable via the private network for
+  kube-apiserver traffic.
+
+## Configuration
+
+```yaml
+apiVersion: kubeone.k8c.io/v1beta3
+kind: KubeOneCluster
+name: my-cluster
+
+versions:
+  kubernetes: 1.36.2
+
+cloudProvider:
+  hetzner:
+    # Private network name or ID. Required when controlPlane is set.
+    networkID: my-private-network
+
+    controlPlane:
+      loadBalancer:
+        # Name of the load balancer to create. Default: "<CLUSTER_NAME>-kubeapi"
+        name: my-cluster-kubeapi
+
+        # Load balancer type. Default: "lb11"
+        type: lb11
+
+        # Data center location. Default: "nbg1"
+        location: nbg1
+
+        # Assign a public IP to the load balancer. Default: true
+        publicIP: true
+
+        # Optional labels applied to the load balancer
+        labels:
+          env: production
+
+controlPlane:
+  nodeSets:
+    - name: cp
+      replicas: 3
+      operatingSystem: ubuntu
+      operatingSystemSpec:
+        distUpgradeOnBoot: false
+      ssh:
+        publicKeys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+        username: ubuntu
+      cloudProviderSpec:
+        serverType: cx22
+        location: nbg1
+        image: ubuntu-24.04
+        networks:
+          - my-private-network
+```
+
+## Load Balancer Configuration
+
+The `controlPlane.loadBalancer` section supports:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `name` | `<CLUSTER_NAME>-kubeapi` | Name of the Hetzner load balancer |
+| `type` | `lb11` | Hetzner load balancer type (size) |
+| `location` | `nbg1` | Data center location for the load balancer |
+| `publicIP` | `true` | Whether to assign a public IPv4 address |
+| `labels` | empty | Optional labels applied to the load balancer resource |
+
+### How the load balancer is provisioned
+
+During `kubeone apply`, KubeOne uses the Hetzner Cloud API to:
+
+1. Look up the named load balancer. If it already exists, it is reused as-is
+   and its public IPv4 address becomes `apiEndpoint.host`.
+
+2. If the load balancer does not exist, KubeOne creates one with:
+   - A TCP listener on port 6443
+   - Label-based target selection using `kubeone_cluster_name` and
+     `kubeone_role` tags (automatically applied to both the LB and VMs)
+   - One service per target (port 6443, private-network IP)
+   - Attached to the private network specified in `networkID`
+   - A health check on port 6443
+
+3. KubeOne provisions control-plane servers with matching labels so the load
+   balancer automatically picks them up as targets.
+
+When the load balancer IP is already known (e.g. from a previous
+`kubeone apply`), the LB creation step is skipped entirely.
+
+### Label-based target selection
+
+The load balancer uses Hetzner's label-selector feature to target
+control-plane servers. The following labels are automatically applied to
+both the load balancer and each provisioned server:
+
+| Label | Value | Purpose |
+|-------|-------|---------|
+| `kubeone_cluster_name` | Cluster name | Identifies the cluster |
+| `kubeone_role` | `control-plane` / `api` | Identifies node role |
+| `kubeone_own_since_timestamp` | Unix timestamp | Tracks when the resource was created |
+
+This means newly provisioned servers are automatically added as load
+balancer targets without KubeOne needing to call the member registration API.
+
+## Without Managed Control Plane
+
+If you prefer to manage control-plane servers with Terraform (or another
+tool), omit the `controlPlane` section on `hetzner` and use static hosts:
+
+```yaml
+cloudProvider:
+  hetzner:
+    networkID: my-private-network
+
+apiEndpoint:
+  host: 203.0.113.10
+  port: 6443
+
+controlPlane:
+  hosts:
+    - publicAddress: 203.0.113.10
+      privateAddress: 10.0.0.1
+      sshUsername: ubuntu
+      sshPrivateKeyFile: /path/to/ssh-key
+```
+
+In this mode, `networkID` can be omitted and `apiEndpoint.host` is required.
+
+## Credentials
+
+KubeOne reads the Hetzner Cloud API token from the credentials file using
+the `HCLOUD_TOKEN` key. The token must have read/write access to servers,
+networks, and load balancers.
+
+```ini
+HCLOUD_TOKEN=<your-api-token>
+```
+
+The `HCLOUD_TOKEN` environment variable is also supported for convenience
+during development.
+
+Pass the credentials file to KubeOne via the `--credentials` flag:
+
+```bash
+kubeone apply --manifest kubeone.yaml --credentials credentials.yaml
+```

--- a/docs/openstack_control_plane.md
+++ b/docs/openstack_control_plane.md
@@ -1,0 +1,174 @@
+# OpenStack Managed Control Plane
+
+KubeOne can provision control-plane nodes directly on OpenStack using
+machine-controller, eliminating the need to manually provision control-plane
+VMs with Terraform. An Octavia load balancer handles kube-apiserver traffic.
+
+When `cloudProvider.openstack.controlPlane` is configured in your
+`kubeone.yaml`, KubeOne will:
+
+1. Provision control-plane VMs via machine-controller's OpenStack driver,
+   driven by the `controlPlane.nodeSets` spec.
+2. Discover the pre-existing Octavia load balancer by name and set the
+   `apiEndpoint` from its VIP address.
+3. Register control-plane node IPs as members of the Octavia pool so
+   kube-apiserver traffic reaches the nodes.
+
+If `cloudProvider.openstack.controlPlane` is omitted, existing behaviour is
+preserved — you must supply `apiEndpoint` and control-plane host IPs yourself
+(e.g. via Terraform's `kubeone_hosts` and `kubeone_api` outputs).
+
+**Important:** Unlike Hetzner, KubeOne does **not** create the Octavia load
+balancer. The LB, its TCP listener (port 6443), pool, and health monitor must
+exist before running `kubeone apply`. Create them via Terraform
+(`examples/terraform/openstack/`) or any other tool.
+
+## Prerequisites
+
+- An existing Octavia load balancer with:
+  - A TCP listener on port 6443
+  - At least one pool (receiver) — members do not need to be pre-populated
+  - A health monitor for the pool
+- OpenStack credentials available via standard `OS_*` environment variables or
+  a credentials file (see [Credentials](#credentials)).
+- The Octavia load balancer name must match the configured
+  `controlPlane.loadBalancer.name` (default: `<clusterName>-kube-apiserver`).
+
+## Configuration
+
+```yaml
+apiVersion: kubeone.k8c.io/v1beta3
+kind: KubeOneCluster
+name: my-cluster
+
+versions:
+  kubernetes: 1.36.2
+
+cloudProvider:
+  openstack:
+    controlPlane:
+      loadBalancer:
+        # Name of the pre-existing Octavia load balancer.
+        # Default: "<CLUSTER_NAME>-kube-apiserver"
+        name: my-cluster-kube-apiserver
+
+        # Octavia pool ID. If empty, KubeOne discovers the pool
+        # automatically from the load balancer name.
+        # poolID: ""
+
+controlPlane:
+  nodeSets:
+    - name: cp
+      replicas: 3
+      operatingSystem: ubuntu
+      operatingSystemSpec:
+        distUpgradeOnBoot: false
+      ssh:
+        publicKeys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+        username: ubuntu
+      cloudProviderSpec:
+        image: ubuntu-24.04
+        flavor: m1.small
+        securityGroups:
+          - my-cluster-securitygroup
+        network: my-cluster-network
+        subnet: my-cluster-subnet
+        configDrive: false
+```
+
+## Load Balancer Configuration
+
+The `controlPlane.loadBalancer` section supports:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `name` | `<CLUSTER_NAME>-kube-apiserver` | Name of the pre-existing Octavia `loadbalancer_v2` resource |
+| `poolID` | empty (auto-discovered) | Optional Octavia pool ID. When empty, KubeOne lists pools on the named LB and uses the first match |
+
+### How the LB is discovered
+
+During `kubeone apply`, KubeOne uses the `openstackLBClient()` function to
+authenticate against the OpenStack API and:
+
+1. Resolves the load balancer by name to obtain its `vip_address`, which
+   becomes `apiEndpoint.host`.
+
+2. Discovers the associated pool (unless `poolID` is explicitly set).
+
+3. Registers each control-plane node's private (or public, as fallback) IP
+   address as a member of the pool on port 6443. Only members not already
+   registered are added — the operation is idempotent.
+
+When the load balancer VIP is already known (e.g. from a previous
+`kubeone apply`), the LB lookup step is skipped.
+
+## Terraform Setup
+
+The standard OpenStack Terraform configs (`examples/terraform/openstack/`)
+create all required resources: network, subnet, router, security groups,
+Octavia LB (listener, pool, health monitor), and optionally bastion.
+
+When using managed control plane, the Terraform still creates the LB and
+networking, but control-plane VMs are provisioned by KubeOne instead of
+Terraform. The `kubeone_hosts` output from Terraform is **not** used in this
+mode — KubeOne populates `controlPlane.hosts` automatically from the
+provisioned VMs.
+
+The LB name in Terraform must match the configured
+`controlPlane.loadBalancer.name`. The default in both is
+`<clusterName>-kube-apiserver`.
+
+## Without Managed Control Plane
+
+If you prefer to manage control-plane VMs with Terraform (or another tool),
+omit the `controlPlane` section and use static hosts:
+
+```yaml
+cloudProvider:
+  openstack: {}
+
+apiEndpoint:
+  host: 203.0.113.10
+  port: 6443
+
+controlPlane:
+  hosts:
+    - publicAddress: 10.0.0.1
+      privateAddress: 10.0.0.1
+      sshUsername: ubuntu
+      sshPrivateKeyFile: /path/to/ssh-key
+```
+
+In this mode, no `controlPlane` field is needed on `cloudProvider.openstack`,
+and `apiEndpoint.host` is required.
+
+## Credentials
+
+KubeOne reads OpenStack credentials from the standard `OS_*` environment
+variables. Both password-based authentication and application credentials
+are supported.
+
+**Password authentication:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OS_AUTH_URL` | Yes | Identity service endpoint (e.g. `https://identity.example.com/v3`) |
+| `OS_USERNAME` | Yes | OpenStack username |
+| `OS_PASSWORD` | Yes | OpenStack password |
+| `OS_DOMAIN_NAME` | Yes | Domain name |
+| `OS_TENANT_NAME` | No | Project/tenant name |
+| `OS_TENANT_ID` | No | Project/tenant ID |
+| `OS_REGION_NAME` | Yes | Region for the LB and compute services |
+
+**Application credentials:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OS_AUTH_URL` | Yes | Identity service endpoint |
+| `OS_APPLICATION_CREDENTIAL_ID` | Yes | Application credential ID |
+| `OS_APPLICATION_CREDENTIAL_SECRET` | Yes | Application credential secret |
+| `OS_REGION_NAME` | Yes | Region for the LB and compute services |
+
+Credentials can also be provided via a credentials file (`--credentials` flag).
+The file must contain key-value pairs in the format `KEY=VALUE`, one per line.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add two new documentation pages describing how to configure and use managed control-plane provisioning for:
- Hetzner Cloud
- OpenStack


**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
docs: add managed control-plane guides for Hetzner and OpenStack
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
this
```
