### PR TITLE
Remove backward incompatible enableLocalRedirectPolicy field from e2e test

### DIFF
--- a/test/e2e/testdata/containerd_cilium_external.yaml
+++ b/test/e2e/testdata/containerd_cilium_external.yaml
@@ -11,7 +11,6 @@ clusterNetwork:
     cilium:
       enableHubble: true
       kubeProxyReplacement: strict
-      enableLocalRedirectPolicy: true
 
 features:
   nodeLocalDNS:


### PR DESCRIPTION
**What this PR does / why we need it**:
This field was introduced in v1.14 milestone and it's not compatible with previous stable version (v1.13). This is needed to unblock cilium e2e upgrade testing.

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
