### PR TITLE
Use hostNetwork for hcloud-ccm to fix DNS resolution failures on Hetzner

### DIFF
--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -147,6 +147,10 @@ spec:
             requests:
               cpu: 100m
               memory: 50Mi
+      # hostNetwork so DNS lookups (e.g. api.hetzner.cloud) go out over the
+      # node's real interfaces instead of the CNI pod network, which may be
+      # IPv4-only while the node's resolv.conf only has IPv6 resolvers.
+      hostNetwork: true
       dnsPolicy: Default
       priorityClassName: system-cluster-critical
       serviceAccountName: hcloud-cloud-controller-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
Use hostNetwork for hcloud-ccm to fix DNS resolution failures on Hetzner

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use hostNetwork for hcloud-ccm to fix DNS resolution failures on Hetzner
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
