### PR TITLE
add etcd-defrag addon with CronJob configuration

### DIFF
--- a/addons/etcd-defrag/etcd-defrag.yaml
+++ b/addons/etcd-defrag/etcd-defrag.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+spec:
+  # Run weekly — every Sunday at 01:00 UTC (configurable via SCHEDULE param)
+  schedule: {{ default "0 1 * * 0" .Params.SCHEDULE | quote }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 5
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: etcd-defrag
+          hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+            operator: Exists
+          restartPolicy: OnFailure
+          volumes:
+          - name: host-pki
+            hostPath:
+              path: /etc/kubernetes/pki
+          containers:
+          - name: etcd-defrag
+            image: '{{ .InternalImages.Get "BackupResticSnapshotter" }}'
+            imagePullPolicy: IfNotPresent
+            command:
+              - etcdctl
+            args:
+              - defrag
+              - --cluster
+            env:
+            - name: ETCDCTL_API
+              value: "3"
+            - name: ETCDCTL_DIAL_TIMEOUT
+              value: {{ default "30s" .Params.DIAL_TIMEOUT | quote }}
+            - name: ETCDCTL_CACERT
+              value: /etc/kubernetes/pki/etcd/ca.crt
+            - name: ETCDCTL_CERT
+              value: /etc/kubernetes/pki/etcd/healthcheck-client.crt
+            - name: ETCDCTL_KEY
+              value: /etc/kubernetes/pki/etcd/healthcheck-client.key
+            - name: ETCDCTL_ENDPOINTS
+              value: {{ default "https://127.0.0.1:2379" .Params.ENDPOINTS | quote }}
+            volumeMounts:
+            - mountPath: /etc/kubernetes/pki
+              name: host-pki
+              readOnly: true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 128Mi

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -66,11 +66,9 @@ var embeddedAddons = map[string]string{
 	resources.AddonCSIOpenStackCinder:     "",
 	resources.AddonCSIVMwareCloudDirector: "",
 	resources.AddonCSIVsphere:             "",
-	resources.AddonMachineController:      "",
 	resources.AddonMetricsServer:          "",
 	resources.AddonNodeLocalDNS:           "",
 	resources.AddonNodeLocalDNSCilium:     "",
-	resources.AddonOperatingSystemManager: "",
 }
 
 type addonAction struct {
@@ -382,7 +380,8 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 
 	switch {
 	case s.Cluster.CloudProvider.AWS != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIAwsEBS,
 				supportFn: func() error {
@@ -391,7 +390,8 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.Azure != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIAzureDisk,
 				supportFn: func() error {
@@ -406,19 +406,22 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.GCE != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIGCPComputePD,
 			},
 		)
 	case s.Cluster.CloudProvider.DigitalOcean != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIDigitalOcean,
 			},
 		)
 	case s.Cluster.CloudProvider.Hetzner != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIHetzner,
 				supportFn: func() error {
@@ -427,19 +430,22 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.Kubevirt != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIKubeVirt,
 			},
 		)
 	case s.Cluster.CloudProvider.Nutanix != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSINutanix,
 			},
 		)
 	case s.Cluster.CloudProvider.Openstack != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIOpenStackCinder,
 				supportFn: func() error {
@@ -448,13 +454,15 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.VMwareCloudDirector != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIVMwareCloudDirector,
 			},
 		)
 	case s.Cluster.CloudProvider.Vsphere != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIVsphere,
 			},
@@ -476,31 +484,36 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 func ensureCCMAddons(s *state.State, addonsToDeploy []addonAction) []addonAction {
 	switch {
 	case s.Cluster.CloudProvider.AWS != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMAws,
 			},
 		)
 	case s.Cluster.CloudProvider.Azure != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMAzure,
 			},
 		)
 	case s.Cluster.CloudProvider.DigitalOcean != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMDigitalOcean,
 			},
 		)
 	case s.Cluster.CloudProvider.GCE != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMGCP,
 			},
 		)
 	case s.Cluster.CloudProvider.Hetzner != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMHetzner,
 				supportFn: func() error {
@@ -509,19 +522,22 @@ func ensureCCMAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.Kubevirt != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMKubeVirt,
 			},
 		)
 	case s.Cluster.CloudProvider.Nutanix != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMNutanix,
 			},
 		)
 	case s.Cluster.CloudProvider.Openstack != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMOpenStack,
 				supportFn: func() error {
@@ -530,7 +546,8 @@ func ensureCCMAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.Vsphere != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMVsphere,
 				supportFn: func() error {
@@ -539,7 +556,8 @@ func ensureCCMAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			},
 		)
 	case s.Cluster.CloudProvider.EquinixMetal != nil:
-		addonsToDeploy = append(addonsToDeploy,
+		addonsToDeploy = append(
+			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCCMEquinixMetal,
 				supportFn: func() error {

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -60,6 +60,7 @@ const (
 	AddonNodeLocalDNSCilium     = "nodelocaldns-cilium"
 	AddonOperatingSystemManager = "operating-system-manager"
 	AddonBackupsRestic          = "backups-restic"
+	AddonEtcdDefrag             = "etcd-defrag"
 )
 
 func CloudAddons() []string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new addon that will need to be enabled explicitly by the user
```
addons:
  addons:
  - name: etcd-defrag
```

That will periodically (weekly by default) call the defragment etcd's endpoint.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4119 

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
etcd-defrag addon with CronJob for periodic automatic etcd defragmentation
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
