### PR TITLE
Support user-defined custom secrets in credentials.yaml for addon templates

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -72,6 +72,7 @@ type templateData struct {
 	Config                                   *kubeoneapi.KubeOneCluster
 	Certificates                             map[string]string
 	Credentials                              map[string]string
+	CustomCredentials                        map[string]string
 	CredentialsCCM                           map[string]string
 	CredentialsCCMHash                       string
 	CCMClusterName                           string
@@ -101,6 +102,11 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	}
 
 	creds, err := credentials.Any(s.CredentialsFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	customCreds, err := credentials.Custom(s.CredentialsFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +182,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 			"KubernetesCA":                 mcCertsMap[resources.KubernetesCACertName],
 		},
 		Credentials:                         creds,
+		CustomCredentials:                   customCreds,
 		CredentialsCCM:                      credsCCM,
 		CredentialsCCMHash:                  credsCCMHash,
 		CCMClusterName:                      s.LiveCluster.CCMClusterName,

--- a/pkg/addons/manifest_test.go
+++ b/pkg/addons/manifest_test.go
@@ -628,3 +628,49 @@ func TestDisableTemplateForLoadManifests(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomCredentialsInAddonTemplate(t *testing.T) {
+	t.Parallel()
+
+	const customAddonManifest = `kind: Secret
+apiVersion: v1
+metadata:
+  name: custom-addon-secret
+  namespace: kube-system
+stringData:
+  token: "{{ .CustomCredentials.MY_APP_TOKEN }}"
+`
+
+	addonsDir := t.TempDir()
+
+	if writeErr := os.WriteFile(path.Join(addonsDir, "secret.yaml"), []byte(customAddonManifest), 0o600); writeErr != nil {
+		t.Fatalf("unable to create temporary addon manifest: %v", writeErr)
+	}
+
+	td := templateData{
+		Config: &kubeoneapi.KubeOneCluster{
+			Name: "kubeone-test",
+		},
+		CustomCredentials: map[string]string{
+			"MY_APP_TOKEN": "supersecret-value",
+		},
+	}
+
+	applier := &applier{
+		TemplateData: td,
+		LocalFS:      os.DirFS(addonsDir),
+	}
+
+	manifests, err := applier.loadAddonsManifests(applier.LocalFS, ".", nil, nil, false, &kubeoneapi.KubeOneCluster{}, false)
+	if err != nil {
+		t.Fatalf("unable to load manifests: %v", err)
+	}
+
+	if len(manifests) != 1 {
+		t.Fatalf("expected to load 1 manifest, got %d", len(manifests))
+	}
+
+	if !strings.Contains(string(manifests[0].Raw), "supersecret-value") {
+		t.Fatalf("expected rendered manifest to contain custom credential value, got:\n%s", string(manifests[0].Raw))
+	}
+}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -146,6 +146,39 @@ type ProviderEnvironmentVariable struct {
 	MachineControllerName string
 }
 
+// CustomSecretsKey is the reserved top-level key in the credentials file
+// under which users can provide arbitrary, addon-specific secrets that are
+// not known/interpreted by KubeOne itself. Its value is expected to be a
+// YAML mapping of string keys to string values, encoded as a block string,
+// following the same convention as the "registriesAuth" key.
+const CustomSecretsKey = "customSecrets"
+
+// Custom returns user-defined, addon-specific secrets from the
+// "customSecrets" section of the credentials file. Unlike Any(), which only
+// returns the fixed set of provider credential keys known to KubeOne, Custom
+// returns whatever the user has put under the reserved "customSecrets" key,
+// letting custom (and built-in) addon templates consume arbitrary secret
+// values via ".CustomCredentials.MY_KEY" without KubeOne needing to know
+// about them in advance.
+func Custom(credentialsFilePath string) (map[string]string, error) {
+	credentialsFinder, err := newCredentialsFinder(withYAMLFile(credentialsFilePath))
+	if err != nil {
+		return nil, err
+	}
+
+	raw, ok := credentialsFinder.static[CustomSecretsKey]
+	if !ok || raw == "" {
+		return map[string]string{}, nil
+	}
+
+	custom := map[string]string{}
+	if err := yaml.Unmarshal([]byte(raw), &custom); err != nil {
+		return nil, fail.Runtime(err, "unmarshalling customSecrets from credentials file")
+	}
+
+	return custom, nil
+}
+
 func Any(credentialsFilePath string) (map[string]string, error) {
 	credentialsFinder, err := newCredentialsFinder(withYAMLFile(credentialsFilePath))
 	if err != nil {

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -18,6 +18,10 @@ package credentials
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"k8c.io/kubeone/pkg/fail"
@@ -334,6 +338,83 @@ func TestCredentialsFinder(t *testing.T) {
 
 			if result := finder.get(tcase.key); result != tcase.want {
 				t.Errorf("get(%q)=%q, want %q", tcase.key, result, tcase.want)
+			}
+		})
+	}
+}
+
+func TestCustom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		credentialsFile  string
+		want             map[string]string
+		wantErrSubstring string
+	}{
+		{
+			name: "customSecrets present",
+			credentialsFile: `
+AWS_ACCESS_KEY_ID: "AAAA"
+AWS_SECRET_ACCESS_KEY: "BBBB"
+customSecrets: |
+  MY_APP_TOKEN: supersecret
+  ANOTHER_KEY: value
+`,
+			want: map[string]string{
+				"MY_APP_TOKEN": "supersecret",
+				"ANOTHER_KEY":  "value",
+			},
+		},
+		{
+			name: "customSecrets absent",
+			credentialsFile: `
+AWS_ACCESS_KEY_ID: "AAAA"
+AWS_SECRET_ACCESS_KEY: "BBBB"
+`,
+			want: map[string]string{},
+		},
+		{
+			name:            "empty credentials file",
+			credentialsFile: ``,
+			want:            map[string]string{},
+		},
+		{
+			name: "customSecrets is not a valid YAML mapping",
+			credentialsFile: `
+customSecrets: |
+  - not
+  - a
+  - mapping
+`,
+			wantErrSubstring: "unmarshalling customSecrets",
+		},
+	}
+
+	for _, tcase := range tests {
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			credentialsFilePath := filepath.Join(t.TempDir(), "credentials.yaml")
+			if err := os.WriteFile(credentialsFilePath, []byte(tcase.credentialsFile), 0o600); err != nil {
+				t.Fatalf("unable to write temporary credentials file: %v", err)
+			}
+
+			got, err := Custom(credentialsFilePath)
+			if tcase.wantErrSubstring != "" {
+				if err == nil || !strings.Contains(err.Error(), tcase.wantErrSubstring) {
+					t.Fatalf("Custom() error = %v, want substring %q", err, tcase.wantErrSubstring)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Custom() unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tcase.want) {
+				t.Errorf("Custom() = %#v, want %#v", got, tcase.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a reserved `customSecrets` top-level key to the KubeOne credentials file (`-c credentials.yaml`), following the same "embedded YAML block string" convention already used by `registriesAuth`. Values placed under `customSecrets` are parsed into a flat `map[string]string` and exposed to addon templates (both built-in and custom addons) as `.CustomCredentials.KEY`, using the exact same `templateData`/Go-template plumbing that already exposes provider credentials as `.Credentials.KEY` (see e.g. `addons/backups-restic/backups-restic.yaml`).

This lets users reference arbitrary secret values from `credentials.yaml` inside their own custom addon manifests, instead of having to pass them via `kubeone.yaml`'s `Addon.Params` (which is typically committed to VCS and not intended for secrets).

Example:
```yaml
# credentials.yaml
AWS_ACCESS_KEY_ID: xxx
AWS_SECRET_ACCESS_KEY: yyy
customSecrets: |
  MY_APP_TOKEN: supersecret
  ANOTHER_KEY: value
```
```yaml
# custom addon manifest
apiVersion: v1
kind: Secret
metadata:
  name: my-app-secret
stringData:
  token: "{{ .CustomCredentials.MY_APP_TOKEN }}"
```

**Which issue(s) this PR fixes**:
Fixes #3927

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

- Since custom and built-in addons share one `templateData`/template pipeline, there's no way to expose `customSecrets` only to custom addons as the issue title implies — built-in addon templates can reference `.CustomCredentials` too, same as they already can with `.Credentials`. Flagging this as a scope decision rather than resolving it silently.
- Chose a dedicated `customSecrets:` block (Option B) over a flat pass-through merge into the existing `.Credentials` map, to keep user-defined secrets namespaced separately from KubeOne's own provider-credential keys and avoid any future collision risk.
- No changes were needed to the cluster-config parsing in `pkg/apis/kubeone/config/config.go` since this feature is addon-scoped only (per the issue).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Added support for a `customSecrets` section in the credentials file, allowing arbitrary user-defined secrets to be referenced from addon templates (built-in and custom) as `.CustomCredentials.KEY`.
```

**Documentation**:
```documentation
TBD (documentation will be added in a follow-up kubermatic/docs PR, alongside the existing `cloudConfig` / `csiConfig` / `registriesAuth` credentials-file documentation)
```
