### PR TITLE
fix: update Helm dry run strategy on release upgrade

### DIFF
--- a/pkg/localhelm/helm3.go
+++ b/pkg/localhelm/helm3.go
@@ -329,7 +329,7 @@ func upgradeRelease(
 	logger logrus.FieldLogger,
 ) error {
 	helmInstall := newHelmInstallClient(cfg, release)
-	helmInstall.DryRunStrategy = helmaction.DryRunClient
+	helmInstall.DryRunStrategy = helmaction.DryRunServer
 	dryRunHelmRelease, err := runInstallRelease(ctx, release, helmInstall, helmSettings, providers, vals)
 	if err != nil {
 		return err
@@ -344,7 +344,7 @@ func upgradeRelease(
 	helmUpgrade := helmaction.NewUpgrade(cfg)
 	helmUpgrade.Install = true
 	helmUpgrade.DependencyUpdate = true
-	helmUpgrade.ResetValues = true
+	helmUpgrade.ResetThenReuseValues = true
 	helmUpgrade.MaxHistory = 5
 	helmUpgrade.Namespace = release.Namespace
 	helmUpgrade.RepoURL = release.RepoURL

--- a/pkg/localhelm/helm3.go
+++ b/pkg/localhelm/helm3.go
@@ -479,6 +479,7 @@ func uninstallReleases(
 		}
 
 		helmUninstall := helmaction.NewUninstall(helmCfg)
+		helmUninstall.WaitStrategy = kube.HookOnlyStrategy
 		resp, err := helmUninstall.Run(releaseAcc.Name())
 		if err != nil {
 			return fail.Runtime(err, "uninstalling helm release %s/%s", releaseAcc.Namespace(), releaseAcc.Name())


### PR DESCRIPTION
**What this PR does / why we need it**:
Turns out, helm4 started to simply mutate `Configuration` object's storage driver from whatever has been configured to in-memory on a client dry-run release generation. That makes `Configuration` object unusable/spoiled after 1 client dry-run.

This PR switches to server dry-run mode, which avoids problematic code path and renders the chart against real API-server, just doesn't persist anything.

Bonus option from server dry-run: now chart sees real server capabilities/APIs/version.

**Which issue(s) this PR fixes**:
Fixes #4164

**What type of PR is this?**
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update Helm dry run strategy on release upgrade
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
