### PR TITLE
Fix overridePath handling in ContainerRuntimeConfig.MachineControllerFlags

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -158,7 +158,7 @@ func (crc ContainerRuntimeConfig) MachineControllerFlags() []string {
 				kubermaticValues := url.Values{}
 				kubermaticValues.Add("override_path", "true")
 				mirrorQS.Add("kubermatic", kubermaticValues.Encode())
-				mirrorURL.RawPath = mirrorQS.Encode()
+				mirrorURL.RawQuery = mirrorQS.Encode()
 				mirror = mirrorURL.String()
 			}
 

--- a/pkg/apis/kubeone/helpers_test.go
+++ b/pkg/apis/kubeone/helpers_test.go
@@ -67,6 +67,22 @@ func TestContainerRuntimeConfig_MachineControllerFlags(t *testing.T) {
 				"-node-insecure-registries=registry.k8s.io",
 			},
 		},
+		{
+			name: "overridePath",
+			fields: fields{
+				Containerd: &ContainerRuntimeContainerd{
+					Registries: map[string]ContainerdRegistry{
+						"docker.io": {
+							Mirrors:      []string{"https://internal/v2/repo"},
+							OverridePath: true,
+						},
+					},
+				},
+			},
+			want: []string{
+				"-node-containerd-registry-mirrors=docker.io=https://internal/v2/repo?kubermatic=override_path%3Dtrue",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing override_path flag to OSM deployment to get OSP rendered with override_path containerd config option.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix overridePath handling in ContainerRuntimeConfig.MachineControllerFlags
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
