### PR TITLE
Fix busy loop when pod eviction is blocked during node drain

### DIFF
--- a/pkg/nodeutils/drain.go
+++ b/pkg/nodeutils/drain.go
@@ -18,6 +18,7 @@ package nodeutils
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -86,12 +87,13 @@ func (dr *drainer) drainHelper(ctx context.Context) (*drain.Helper, error) {
 		Client: kubeClinet,
 		// Force is used to force deleting standalone pods (i.e. not managed by
 		// ReplicaSet)
-		Force:               true,
-		GracePeriodSeconds:  -1,
-		IgnoreAllDaemonSets: true,
-		DeleteEmptyDirData:  true,
-		Out:                 loggerIoWriter(dr.logger.Infof),
-		ErrOut:              loggerIoWriter(dr.logger.Errorf),
+		Force:                true,
+		GracePeriodSeconds:   -1,
+		IgnoreAllDaemonSets:  true,
+		DeleteEmptyDirData:   true,
+		EvictErrorRetryDelay: 5 * time.Second,
+		Out:                  loggerIoWriter(dr.logger.Infof),
+		ErrOut:               loggerIoWriter(dr.logger.Errorf),
 		OnPodDeletedOrEvicted: func(pod *corev1.Pod, usingEviction bool) {
 			evicted := "evicted"
 			if !usingEviction {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a PodDisruptionBudget blocks a pod eviction, KubeOne retries immediately
without any delay. This creates a busy loop that sends requests as quickly as
the API server responds. The logs in #4105 show multiple attempts per second,
each reporting `will retry after 0s`.

In kubectl v0.35.0, the eviction retry loop in `drain.Helper` changed from a
hard-coded five-second sleep to the configurable `EvictErrorRetryDelay` field.
The field has no nonzero default, so callers that construct `drain.Helper`
directly must set it explicitly. kubectl configures a five-second delay in
`pkg/cmd/drain/drain.go`, but KubeOne's helper in `pkg/nodeutils/drain.go` did
not set the new field.

This PR configures `EvictErrorRetryDelay` to five seconds, matching the behavior
of `kubectl drain` and restoring the delay KubeOne had before the dependency
upgrade.

The regression was introduced when #3973 upgraded kubectl from v0.33.4 to
v0.35.0 for initial Kubernetes 1.35 support. That change is present on `main`
and `release/v1.13`, while `release/v1.12` still uses v0.33.4, where the delay
is hard-coded. This matches the reported behavior change after upgrading
KubeOne from 1.12 to 1.13.

**Which issue(s) this PR fixes**:

Fixes #4105

**What type of PR is this?**

/kind bug
/kind regression

**Special notes for your reviewer**:

The only other `drain.Helper` construction in the repository is in
`pkg/clientutil/volumes.go`. It sets `DisableEviction: true`, so it uses pod
deletion instead of eviction and never consults `EvictErrorRetryDelay`. No
change is needed at that call site.

There are currently no tests under `pkg/nodeutils`. This change sets the
upstream-recommended value on a `drain.Helper` field and does not alter local
control flow. I can add focused coverage for the helper configuration if the
additional test setup is considered worthwhile.

Because `release/v1.13` contains the same dependency upgrade and regression,
this change is also a candidate for backport to that branch.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fix KubeOne retrying PodDisruptionBudget-blocked pod evictions without a delay during node drain.
```

**Documentation**:

```documentation
NONE
```
