### PR TITLE
Upgrade static workers using individual tasks

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -388,7 +388,7 @@ func runApplyUpgradeIfNeeded(s *state.State, opts *applyOpts) error {
 			tasksToRun = tasks.WithDisableEncryptionProviders(tasksToRun, s.LiveCluster.EncryptionConfiguration.Custom)
 		}
 
-		tasksToRun = tasks.WithUpgrade(tasksToRun, s.Cluster.Followers()...)
+		tasksToRun = tasks.WithUpgrade(tasksToRun, s.Cluster.Followers(), s.Cluster.StaticWorkers.Hosts)
 
 		if s.ShouldEnableEncryption() {
 			operations = append(operations, "enable Encryption Provider support")

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -361,7 +361,7 @@ func WithResources(t Tasks) Tasks {
 	)
 }
 
-func WithUpgrade(t Tasks, followers ...kubeoneapi.HostConfig) Tasks {
+func WithUpgrade(t Tasks, followers, staticWorkers []kubeoneapi.HostConfig) Tasks {
 	return WithHostnameOSAndProbes(t).
 		append(KubernetesConfigFiles()...). // this, in the upgrade process where config rails are handled
 		append(
@@ -382,7 +382,9 @@ func WithUpgrade(t Tasks, followers ...kubeoneapi.HostConfig) Tasks {
 		append(WithResources(nil)...).
 		append(
 			Task{Fn: restartKubeAPIServer, Operation: "restarting unhealthy kube-apiserver"},
-			Task{Fn: upgradeStaticWorkers, Operation: "upgrading static worker nodes"},
+		).
+		append(generateUpgradeStaticWorkersTasks(staticWorkers)...).
+		append(
 			Task{Fn: updateAllKubelets, Operation: "upgrading kubelets"},
 			Task{
 				Fn:          migratePVCAllocatedResourceStatus,

--- a/pkg/tasks/upgrade_static_workers.go
+++ b/pkg/tasks/upgrade_static_workers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
@@ -26,9 +27,21 @@ import (
 	"k8c.io/kubeone/pkg/state"
 )
 
-func upgradeStaticWorkers(s *state.State) error {
+func generateUpgradeStaticWorkersTasks(staticWorkers []kubeoneapi.HostConfig) []Task {
+	var upgradeStaticWorkersTasks []Task
+
 	// we upgrade seqentially to minimize cluster disruption
-	return s.RunTaskOnStaticWorkers(upgradeStaticWorkersExecutor, state.RunSequentially)
+	for _, staticWorker := range staticWorkers {
+		upgradeStaticWorkersTasks = append(upgradeStaticWorkersTasks, Task{
+			Fn: func(s *state.State) error {
+				return s.RunTaskOnNodes([]kubeoneapi.HostConfig{staticWorker}, upgradeStaticWorkersExecutor, state.RunSequentially, nil)
+			},
+			Description: fmt.Sprintf("upgrading %s static worker node", staticWorker.PrivateAddress),
+			Operation:   "upgrading static worker nodes",
+		})
+	}
+
+	return upgradeStaticWorkersTasks
 }
 
 func upgradeStaticWorkersExecutor(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {

--- a/pkg/tasks/upgrade_static_workers_test.go
+++ b/pkg/tasks/upgrade_static_workers_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+	"k8c.io/kubeone/pkg/executor"
+	"k8c.io/kubeone/pkg/state"
+)
+
+var errRefusedByStub = errors.New("refused by stub executor")
+
+// hostRecordingExecutor records the hosts it was asked to connect to and then
+// refuses the connection, which ends the task after it selected a node but
+// before it touches one.
+type hostRecordingExecutor struct {
+	openedHosts []string
+}
+
+func (e *hostRecordingExecutor) Open(host kubeoneapi.HostConfig) (executor.Interface, error) {
+	e.openedHosts = append(e.openedHosts, host.PrivateAddress)
+
+	return nil, errRefusedByStub
+}
+
+func (e *hostRecordingExecutor) Tunnel(_ kubeoneapi.HostConfig) (executor.Tunneler, error) {
+	return nil, errRefusedByStub
+}
+
+func Test_generateUpgradeStaticWorkersTasks(t *testing.T) {
+	tests := []struct {
+		name             string
+		staticWorkers    []kubeoneapi.HostConfig
+		wantDescriptions []string
+	}{
+		{
+			name: "no static workers",
+		},
+		{
+			name: "single static worker",
+			staticWorkers: []kubeoneapi.HostConfig{
+				{PrivateAddress: "192.168.1.1"},
+			},
+			wantDescriptions: []string{
+				"upgrading 192.168.1.1 static worker node",
+			},
+		},
+		{
+			name: "one task per static worker",
+			staticWorkers: []kubeoneapi.HostConfig{
+				{PrivateAddress: "192.168.1.1"},
+				{PrivateAddress: "192.168.1.2"},
+				{PrivateAddress: "192.168.1.3"},
+			},
+			wantDescriptions: []string{
+				"upgrading 192.168.1.1 static worker node",
+				"upgrading 192.168.1.2 static worker node",
+				"upgrading 192.168.1.3 static worker node",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateUpgradeStaticWorkersTasks(tt.staticWorkers)
+
+			if len(got) != len(tt.wantDescriptions) {
+				t.Fatalf(
+					"generateUpgradeStaticWorkersTasks() = %d tasks, want %d",
+					len(got),
+					len(tt.wantDescriptions),
+				)
+			}
+
+			for idx, task := range got {
+				if task.Description != tt.wantDescriptions[idx] {
+					t.Errorf(
+						"task %d Description = %q, want %q",
+						idx,
+						task.Description,
+						tt.wantDescriptions[idx],
+					)
+				}
+
+				if task.Operation != "upgrading static worker nodes" {
+					t.Errorf(
+						"task %d Operation = %q, want %q",
+						idx,
+						task.Operation,
+						"upgrading static worker nodes",
+					)
+				}
+
+				if task.Fn == nil {
+					t.Errorf("task %d has no Fn", idx)
+				}
+			}
+		})
+	}
+}
+
+func Test_generateUpgradeStaticWorkersTasks_runsOnMatchingNode(t *testing.T) {
+	staticWorkers := []kubeoneapi.HostConfig{
+		{PrivateAddress: "192.168.1.1"},
+		{PrivateAddress: "192.168.1.2"},
+		{PrivateAddress: "192.168.1.3"},
+	}
+
+	got := generateUpgradeStaticWorkersTasks(staticWorkers)
+
+	if len(got) != len(staticWorkers) {
+		t.Fatalf(
+			"generateUpgradeStaticWorkersTasks() = %d tasks, want %d",
+			len(got),
+			len(staticWorkers),
+		)
+	}
+
+	for idx, task := range got {
+		stubExecutor := &hostRecordingExecutor{}
+
+		logger := logrus.New()
+		logger.SetOutput(io.Discard)
+
+		// The task is expected to fail because the stub executor refuses to
+		// connect. What matters is which host it tried to connect to first.
+		err := task.Fn(&state.State{
+			Logger:   logger,
+			Executor: stubExecutor,
+		})
+		if !errors.Is(err, errRefusedByStub) {
+			t.Fatalf("task %d error = %v, want %v", idx, err, errRefusedByStub)
+		}
+
+		if len(stubExecutor.openedHosts) != 1 {
+			t.Fatalf(
+				"task %d connected to %d hosts, want 1",
+				idx,
+				len(stubExecutor.openedHosts),
+			)
+		}
+
+		if stubExecutor.openedHosts[0] != staticWorkers[idx].PrivateAddress {
+			t.Errorf(
+				"task %d connected to host %q, want %q",
+				idx,
+				stubExecutor.openedHosts[0],
+				staticWorkers[idx].PrivateAddress,
+			)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Static worker upgrades currently run as one task that processes all workers
sequentially. If an upgrade fails on a later worker, the task retry starts from
the first worker and repeats the cordon, drain, and upgrade operations on nodes
that already succeeded.

Generate one task per static worker instead. Each task retains the existing
retry behavior, but a failure now retries only the affected worker. This
matches the existing approach used for control plane followers.

**Which issue(s) this PR fixes**:

Fixes #4059

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

The tests verify that:

- no tasks are generated when there are no static workers;
- one task is generated per static worker, in configuration order;
- each generated task targets only its corresponding worker.

Verified locally with:

```text
go test ./pkg/... ./test/...
go vet ./pkg/tasks ./pkg/cmd
go test -race ./pkg/tasks -count=1
golangci-lint run --timeout=5m -v ./pkg/... ./test/...
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Static worker upgrade retries now retry only the failed worker instead of repeating upgrades on workers that already succeeded.
```

**Documentation**:

```documentation
NONE
```
