### PR TITLE
Prune stale vsphere CSI ValidatingWebhookConfiguration on upgrade

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -465,6 +465,9 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 			addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIVsphere,
+				supportFn: func() error {
+					return migrateVsphereCSIDriver(s)
+				},
 			},
 		)
 	default:

--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/resources"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,13 @@ const (
 	openstackCinderCSIControllerPluginName = "openstack-cinder-csi-controllerplugin"
 	openstackCinderCSINodePluginName       = "openstack-cinder-csi-nodeplugin"
 	vSphereDeploymentName                  = "vsphere-cloud-controller-manager"
+	// vsphereCSIValidatingWebhookConfigurationName is the name of the
+	// ValidatingWebhookConfiguration that older csi-vsphere addon versions
+	// used to deploy alongside a "vsphere-webhook-svc" Service. Both were
+	// removed from the addon (see addons/csi-vsphere/2-validatingwebhook.yaml),
+	// so the webhook configuration must be pruned on upgrade, otherwise it's
+	// left dangling and blocks all StorageClass/PV/PVC admission requests.
+	vsphereCSIValidatingWebhookConfigurationName = "validation.csi.vsphere.vmware.com"
 )
 
 var (
@@ -293,6 +301,14 @@ func migrateVsphereAddon(s *state.State) error {
 		s.Context,
 		s.DynamicClient,
 		genNamedObject[corev1.Service](vSphereDeploymentName, metav1.NamespaceSystem),
+	)
+}
+
+func migrateVsphereCSIDriver(s *state.State) error {
+	return clientutil.DeleteIfExists(
+		s.Context,
+		s.DynamicClient,
+		genNamedObject[admissionregistrationv1.ValidatingWebhookConfiguration](vsphereCSIValidatingWebhookConfigurationName),
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The csi-vsphere addon used to deploy a `vsphere-webhook-svc` Service and a `validation.csi.vsphere.vmware.com` ValidatingWebhookConfiguration alongside the CSI driver. Both were removed in #4096 as part of Kubernetes 1.36 support, since CSI migration is now permanently enabled and the webhook is no longer needed.

Clusters originally installed with an older KubeOne version still have this ValidatingWebhookConfiguration lying around after upgrading, since nothing prunes it. Because the object has `failurePolicy: Fail` and matches `CREATE`/`UPDATE` on storageclasses, `CREATE` on persistentvolumes, and `UPDATE`/`DELETE` on persistentvolumeclaims, it points at a Service that no longer exists and blocks all of those cluster-wide — not just during `kubeone apply`, but for any dynamic volume provisioning or PVC deletion happening on the cluster afterwards.

This adds `migrateVsphereCSIDriver`, following the same pattern already used for other providers (`migrateAWSCSIDriver`, `migrateAzureDiskCSI`, `migrateHetznerCSI`), wired up as the csi-vsphere addon's `supportFn` so the stale object is pruned automatically on the next apply.

**Which issue(s) this PR fixes**:
Fixes #4194

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
Verified live on two upgraded vSphere clusters (KubeOne 1.13.5 → 1.14.2): the stale webhook was present on both, blocking new PVC provisioning and even PVC deletion until manually removed. `go build`, `go vet`, and existing `pkg/addons` tests pass with this change.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed a bug where upgrading a vSphere cluster from an older KubeOne version left behind a stale `validation.csi.vsphere.vmware.com` ValidatingWebhookConfiguration, blocking StorageClass changes and all new dynamic volume provisioning/PVC deletion.
```

**Documentation**:
```documentation
NONE
```