### PR TITLE
Support per-addon secret params in credentials.yaml via addonParams

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -65,6 +65,10 @@ type applier struct {
 	TemplateData templateData
 	LocalFS      fs.FS
 	EmbeddedFS   fs.FS
+	// AddonParams holds per-addon secret parameters from the credentials
+	// file's "addonParams" section, keyed by addon name. See
+	// credentials.AddonParams for details.
+	AddonParams map[string]map[string]string
 }
 
 // TemplateData is data available in the addons render template
@@ -107,6 +111,11 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	}
 
 	customCreds, err := credentials.Custom(s.CredentialsFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	addonParams, err := credentials.AddonParams(s.CredentialsFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -247,6 +256,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		TemplateData: data,
 		LocalFS:      localFS,
 		EmbeddedFS:   embeddedaddons.FS,
+		AddonParams:  addonParams,
 	}, nil
 }
 

--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -204,6 +204,24 @@ func (a *applier) loadAddonsManifests(
 			// Make a copy and merge Params
 			tplDataParams := map[string]string{}
 			maps.Copy(tplDataParams, a.TemplateData.Params)
+
+			if credAddonParams := a.AddonParams[addonName]; len(credAddonParams) > 0 {
+				for k, v := range credAddonParams {
+					if _, exists := addonParams[k]; exists {
+						return nil, fail.RuntimeError{
+							Op: "merging addon params",
+							Err: fmt.Errorf(
+								"param %q for addon %q is set both in the KubeOneCluster manifest and in "+
+									"the credentials file's addonParams section - remove it from one of them",
+								k, addonName,
+							),
+						}
+					}
+
+					tplDataParams[k] = v
+				}
+			}
+
 			maps.Copy(tplDataParams, addonParams)
 
 			defaultAddonParams(k1cluster, addonName, tplDataParams)

--- a/pkg/addons/manifest_test.go
+++ b/pkg/addons/manifest_test.go
@@ -674,3 +674,96 @@ stringData:
 		t.Fatalf("expected rendered manifest to contain custom credential value, got:\n%s", string(manifests[0].Raw))
 	}
 }
+
+func TestAddonParamsFromCredentialsInAddonTemplate(t *testing.T) {
+	t.Parallel()
+
+	const addonManifest = `kind: Secret
+apiVersion: v1
+metadata:
+  name: backups-restic
+  namespace: kube-system
+stringData:
+  password: "{{ .Params.resticPassword }}"
+`
+
+	addonsDir := t.TempDir()
+
+	if mkdirErr := os.Mkdir(path.Join(addonsDir, "backups-restic"), 0o700); mkdirErr != nil {
+		t.Fatalf("unable to create temporary addon directory: %v", mkdirErr)
+	}
+
+	if writeErr := os.WriteFile(path.Join(addonsDir, "backups-restic", "secret.yaml"), []byte(addonManifest), 0o600); writeErr != nil {
+		t.Fatalf("unable to create temporary addon manifest: %v", writeErr)
+	}
+
+	applier := &applier{
+		TemplateData: templateData{
+			Config: &kubeoneapi.KubeOneCluster{Name: "kubeone-test"},
+		},
+		LocalFS: os.DirFS(addonsDir),
+		AddonParams: map[string]map[string]string{
+			"backups-restic": {"resticPassword": "from-credentials"},
+		},
+	}
+
+	manifests, err := applier.loadAddonsManifests(applier.LocalFS, "backups-restic", nil, nil, false, &kubeoneapi.KubeOneCluster{}, false)
+	if err != nil {
+		t.Fatalf("unable to load manifests: %v", err)
+	}
+
+	if len(manifests) != 1 {
+		t.Fatalf("expected to load 1 manifest, got %d", len(manifests))
+	}
+
+	if !strings.Contains(string(manifests[0].Raw), "from-credentials") {
+		t.Fatalf("expected rendered manifest to contain addon param from credentials file, got:\n%s", string(manifests[0].Raw))
+	}
+}
+
+func TestAddonParamsConflictBetweenCredentialsAndManifest(t *testing.T) {
+	t.Parallel()
+
+	const addonManifest = `kind: Secret
+apiVersion: v1
+metadata:
+  name: backups-restic
+  namespace: kube-system
+stringData:
+  password: "{{ .Params.resticPassword }}"
+`
+
+	addonsDir := t.TempDir()
+
+	if mkdirErr := os.Mkdir(path.Join(addonsDir, "backups-restic"), 0o700); mkdirErr != nil {
+		t.Fatalf("unable to create temporary addon directory: %v", mkdirErr)
+	}
+
+	if writeErr := os.WriteFile(path.Join(addonsDir, "backups-restic", "secret.yaml"), []byte(addonManifest), 0o600); writeErr != nil {
+		t.Fatalf("unable to create temporary addon manifest: %v", writeErr)
+	}
+
+	applier := &applier{
+		TemplateData: templateData{
+			Config: &kubeoneapi.KubeOneCluster{Name: "kubeone-test"},
+		},
+		LocalFS: os.DirFS(addonsDir),
+		AddonParams: map[string]map[string]string{
+			"backups-restic": {"resticPassword": "from-credentials"},
+		},
+	}
+
+	// Same key ("resticPassword") also set via the KubeOneCluster manifest's
+	// addon params - this must be rejected rather than silently resolved
+	// either way.
+	manifestAddonParams := map[string]string{"resticPassword": "from-manifest"}
+
+	_, err := applier.loadAddonsManifests(applier.LocalFS, "backups-restic", manifestAddonParams, nil, false, &kubeoneapi.KubeOneCluster{}, false)
+	if err == nil {
+		t.Fatal("expected an error due to conflicting resticPassword definitions, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "resticPassword") || !strings.Contains(err.Error(), "backups-restic") {
+		t.Fatalf("expected error to mention the conflicting key and addon name, got: %v", err)
+	}
+}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -179,6 +179,39 @@ func Custom(credentialsFilePath string) (map[string]string, error) {
 	return custom, nil
 }
 
+// AddonParamsKey is the reserved top-level key in the credentials file under
+// which users can provide secret parameters for specific addons (built-in or
+// custom), keyed by addon name. Its value is expected to be a YAML mapping
+// of addon name to a mapping of string keys to string values, encoded as a
+// block string, following the same convention as the "customSecrets" key.
+const AddonParamsKey = "addonParams"
+
+// AddonParams returns user-defined, per-addon secret parameters from the
+// "addonParams" section of the credentials file, keyed by addon name. This
+// lets operators keep addon secrets (e.g. a restic password for the
+// built-in backups-restic addon) out of the KubeOneCluster manifest and in
+// the credentials file instead, without requiring the addon's template to
+// know about ".CustomCredentials" - the values are merged into that addon's
+// regular ".Params" at render time.
+func AddonParams(credentialsFilePath string) (map[string]map[string]string, error) {
+	credentialsFinder, err := newCredentialsFinder(withYAMLFile(credentialsFilePath))
+	if err != nil {
+		return nil, err
+	}
+
+	raw, ok := credentialsFinder.static[AddonParamsKey]
+	if !ok || raw == "" {
+		return map[string]map[string]string{}, nil
+	}
+
+	addonParams := map[string]map[string]string{}
+	if err := yaml.Unmarshal([]byte(raw), &addonParams); err != nil {
+		return nil, fail.Runtime(err, "unmarshalling addonParams from credentials file")
+	}
+
+	return addonParams, nil
+}
+
 func Any(credentialsFilePath string) (map[string]string, error) {
 	credentialsFinder, err := newCredentialsFinder(withYAMLFile(credentialsFilePath))
 	if err != nil {

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -419,3 +419,84 @@ customSecrets: |
 		})
 	}
 }
+
+func TestAddonParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		credentialsFile  string
+		want             map[string]map[string]string
+		wantErrSubstring string
+	}{
+		{
+			name: "addonParams present, multiple addons",
+			credentialsFile: `
+AWS_ACCESS_KEY_ID: "AAAA"
+AWS_SECRET_ACCESS_KEY: "BBBB"
+addonParams: |
+  backups-restic:
+    resticPassword: supersecret
+  prometheus-auth-proxy:
+    prometheusHtpasswd: "monitorprom:hash"
+`,
+			want: map[string]map[string]string{
+				"backups-restic": {
+					"resticPassword": "supersecret",
+				},
+				"prometheus-auth-proxy": {
+					"prometheusHtpasswd": "monitorprom:hash",
+				},
+			},
+		},
+		{
+			name: "addonParams absent",
+			credentialsFile: `
+AWS_ACCESS_KEY_ID: "AAAA"
+AWS_SECRET_ACCESS_KEY: "BBBB"
+`,
+			want: map[string]map[string]string{},
+		},
+		{
+			name:            "empty credentials file",
+			credentialsFile: ``,
+			want:            map[string]map[string]string{},
+		},
+		{
+			name: "addonParams is not a valid YAML mapping of mappings",
+			credentialsFile: `
+addonParams: |
+  backups-restic: not-a-mapping
+`,
+			wantErrSubstring: "unmarshalling addonParams",
+		},
+	}
+
+	for _, tcase := range tests {
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			credentialsFilePath := filepath.Join(t.TempDir(), "credentials.yaml")
+			if err := os.WriteFile(credentialsFilePath, []byte(tcase.credentialsFile), 0o600); err != nil {
+				t.Fatalf("unable to write temporary credentials file: %v", err)
+			}
+
+			got, err := AddonParams(credentialsFilePath)
+			if tcase.wantErrSubstring != "" {
+				if err == nil || !strings.Contains(err.Error(), tcase.wantErrSubstring) {
+					t.Fatalf("AddonParams() error = %v, want substring %q", err, tcase.wantErrSubstring)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("AddonParams() unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tcase.want) {
+				t.Errorf("AddonParams() = %#v, want %#v", got, tcase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a reserved `addonParams` top-level key to the KubeOne credentials file (`-c credentials.yaml`), following the same "embedded YAML block string" convention already used by `customSecrets` (#4156). Its value is a YAML mapping of addon name to a mapping of param name to value:

```yaml
addonParams: |
  backups-restic:
    resticPassword: "..."
```

At render time, these are merged into that specific addon's regular `.Params` map (the same map populated from the KubeOneCluster manifest's `addons[].params` in `pkg/addons/manifest.go`), so existing addon templates - built-in or custom - work completely unmodified; they don't need to know about `.CustomCredentials` at all.

This solves a gap that `customSecrets` (#4156) doesn't cover: built-in addons (e.g. `backups-restic`) already read secret-like values via `.Params.KEY` (e.g. `resticPassword`), which today can only be set via `kubeone.yaml`'s `Addon.Params` - a file that's typically committed to VCS and not intended for secrets. With `addonParams`, operators can move those values into `credentials.yaml` instead, without needing a local addon override just to reference `.CustomCredentials`.

If the same param key is set both in `credentials.yaml`'s `addonParams` and in the KubeOneCluster manifest's `addons[].params` for the same addon, rendering now fails with an explicit error rather than silently picking one.

**Which issue(s) this PR fixes**:
N/A (no tracking issue)

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

- Chose a dedicated `addonParams:` block, keyed by addon name, over reusing addon names directly as top-level reserved keys in `credentials.yaml` - the credentials file parses into a `map[string]string` (`credentialsFinder.static`), so any nested/structured value has to go through the same "block string, parsed again" trick already used by `customSecrets`/`registriesAuth`/`cloudConfig`/`csiConfig`. A single reserved key avoids turning every current and future addon name into an implicitly reserved word in `credentials.yaml`.
- Erroring on a key defined in both places (rather than silently letting one win) is a deliberate choice to avoid confusing "which source actually applied" situations; happy to change this to "KubeOneCluster manifest wins" if reviewers prefer the more permissive behavior.
- No changes were needed in `pkg/apis/kubeone/config/config.go` - this is addon-scoped only, resolved entirely in `pkg/credentials` and `pkg/addons`.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Added support for an `addonParams` section in the credentials file, allowing addon secret parameters (e.g. the built-in `backups-restic` addon's `resticPassword`) to be provided via `credentials.yaml` instead of the KubeOneCluster manifest.
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/2273
```
