### PR TITLE
Upgrade Go to 1.27

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,6 @@ runs:
   steps:
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.26
+        go-version: 1.27
         check-latest: true
         cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,7 +102,10 @@ formatters:
   settings:
     gofumpt:
       module-path: k8c.io/kubeone
-      extra-rules: true
+      extra:
+        group-params: true
+        clothe-returns: true
+        balance-calls: true
     goimports:
       local-prefixes:
         - k8c.io

--- a/.prow/generated.yaml
+++ b/.prow/generated.yaml
@@ -19,7 +19,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -44,7 +44,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -69,7 +69,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -94,7 +94,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -119,7 +119,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -146,7 +146,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -173,7 +173,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -201,7 +201,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -228,7 +228,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -253,7 +253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -278,7 +278,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -303,7 +303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -328,7 +328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -353,7 +353,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -378,7 +378,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -405,7 +405,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -432,7 +432,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -459,7 +459,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -486,7 +486,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -513,7 +513,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -538,7 +538,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -563,7 +563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -588,7 +588,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -613,7 +613,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -638,7 +638,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -665,7 +665,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -692,7 +692,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -720,7 +720,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -747,7 +747,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -772,7 +772,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -797,7 +797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -822,7 +822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -847,7 +847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -872,7 +872,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -897,7 +897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -924,7 +924,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -951,7 +951,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -978,7 +978,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1005,7 +1005,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1032,7 +1032,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1058,7 +1058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1083,7 +1083,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1108,7 +1108,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1133,7 +1133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1158,7 +1158,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1185,7 +1185,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1212,7 +1212,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1240,7 +1240,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1267,7 +1267,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1292,7 +1292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1317,7 +1317,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1342,7 +1342,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1367,7 +1367,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1392,7 +1392,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1417,7 +1417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1444,7 +1444,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1471,7 +1471,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1498,7 +1498,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1525,7 +1525,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1552,7 +1552,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1582,7 +1582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1612,7 +1612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1642,7 +1642,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1674,7 +1674,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1706,7 +1706,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1736,7 +1736,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1766,7 +1766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1796,7 +1796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1828,7 +1828,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1860,7 +1860,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1892,7 +1892,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1924,7 +1924,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1954,7 +1954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1984,7 +1984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2017,7 +2017,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2049,7 +2049,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2079,7 +2079,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2109,7 +2109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2141,7 +2141,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2173,7 +2173,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2203,7 +2203,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2233,7 +2233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2263,7 +2263,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2295,7 +2295,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2327,7 +2327,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2357,7 +2357,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2387,7 +2387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2417,7 +2417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2449,7 +2449,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2481,7 +2481,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2513,7 +2513,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2545,7 +2545,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2575,7 +2575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2605,7 +2605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2638,7 +2638,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2670,7 +2670,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2700,7 +2700,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2730,7 +2730,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2762,7 +2762,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2794,7 +2794,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2819,7 +2819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2844,7 +2844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2869,7 +2869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2894,7 +2894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2921,7 +2921,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2948,7 +2948,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2976,7 +2976,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3003,7 +3003,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3028,7 +3028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3053,7 +3053,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3078,7 +3078,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3103,7 +3103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3128,7 +3128,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3153,7 +3153,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3180,7 +3180,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3207,7 +3207,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3234,7 +3234,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3261,7 +3261,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3288,7 +3288,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3313,7 +3313,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3338,7 +3338,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3363,7 +3363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3388,7 +3388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3415,7 +3415,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3442,7 +3442,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3470,7 +3470,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3497,7 +3497,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3522,7 +3522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3547,7 +3547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3572,7 +3572,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3597,7 +3597,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3622,7 +3622,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3647,7 +3647,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3674,7 +3674,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3701,7 +3701,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3728,7 +3728,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3755,7 +3755,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3782,7 +3782,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3807,7 +3807,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3832,7 +3832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3857,7 +3857,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3882,7 +3882,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3909,7 +3909,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3936,7 +3936,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3964,7 +3964,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3991,7 +3991,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4016,7 +4016,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4041,7 +4041,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4066,7 +4066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4091,7 +4091,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4116,7 +4116,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4141,7 +4141,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4168,7 +4168,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4195,7 +4195,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4222,7 +4222,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4249,7 +4249,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4276,7 +4276,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4301,7 +4301,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4326,7 +4326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4351,7 +4351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4376,7 +4376,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4403,7 +4403,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4430,7 +4430,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4458,7 +4458,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4485,7 +4485,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4510,7 +4510,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4535,7 +4535,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4560,7 +4560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4585,7 +4585,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4610,7 +4610,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4635,7 +4635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4662,7 +4662,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4689,7 +4689,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4716,7 +4716,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4743,7 +4743,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4770,7 +4770,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4795,7 +4795,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4820,7 +4820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4845,7 +4845,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4870,7 +4870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4897,7 +4897,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4924,7 +4924,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4952,7 +4952,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4979,7 +4979,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5004,7 +5004,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5029,7 +5029,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5054,7 +5054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5079,7 +5079,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5104,7 +5104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5129,7 +5129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5156,7 +5156,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5183,7 +5183,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5210,7 +5210,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5237,7 +5237,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5264,7 +5264,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5289,7 +5289,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5314,7 +5314,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5339,7 +5339,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5364,7 +5364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5391,7 +5391,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5418,7 +5418,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5446,7 +5446,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5473,7 +5473,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5498,7 +5498,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5523,7 +5523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5548,7 +5548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5573,7 +5573,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5598,7 +5598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5623,7 +5623,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5650,7 +5650,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5677,7 +5677,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5704,7 +5704,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5731,7 +5731,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5758,7 +5758,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5788,7 +5788,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5818,7 +5818,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5850,7 +5850,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5882,7 +5882,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5912,7 +5912,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5942,7 +5942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5972,7 +5972,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6004,7 +6004,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6036,7 +6036,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6068,7 +6068,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6100,7 +6100,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6130,7 +6130,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6160,7 +6160,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6193,7 +6193,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6225,7 +6225,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6255,7 +6255,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6285,7 +6285,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6317,7 +6317,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6349,7 +6349,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6379,7 +6379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6409,7 +6409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6441,7 +6441,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6473,7 +6473,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6503,7 +6503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6533,7 +6533,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6563,7 +6563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6595,7 +6595,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6627,7 +6627,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6659,7 +6659,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6691,7 +6691,7 @@ presubmits:
         value: vsphere
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6721,7 +6721,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6751,7 +6751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6784,7 +6784,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6816,7 +6816,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6846,7 +6846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6876,7 +6876,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6908,7 +6908,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6940,7 +6940,7 @@ presubmits:
         value: openstack
       - name: TEST_TIMEOUT
         value: 180m
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6965,7 +6965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6990,7 +6990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7015,7 +7015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7040,7 +7040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7065,7 +7065,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7090,7 +7090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/build:go-1.26-node-22-9
+      image: docker.io/golang:1.27
       imagePullPolicy: Always
       name: ""
       resources:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.26 as builder
+FROM docker.io/golang:1.27 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,8 @@ verify-apidocs: vendor
 
 .PHONY: shfmt
 shfmt:
-	shfmt -w -sr -i 2 hack
+	shfmt -w -sr -i 2 hack/
+	shfmt -w -sr -i 2 test/
 
 .PHONY: prowfmt
 prowfmt:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8c.io/kubeone
 
-go 1.26.0
+go 1.27
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -38,7 +38,7 @@ gocaches="./gocaches"
 for ARCH in ${ARCHITECTURES}; do
   cacheDir="$gocaches/$ARCH"
   mkdir -p "$cacheDir"
- 
+
   # try to get a gocache for this arch; this can "fail" but still exit with 0
   echodate "Attempting to fetch gocache for ${ARCH}..."
   TARGET_DIRECTORY="$cacheDir" GOARCH="${ARCH}" ./hack/ci/download-gocache.sh

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -38,7 +38,7 @@ ensure_github_host_pubkey
 git clone git@github.com:kubermatic/docs.git $TARGET_DIR
 cd $TARGET_DIR
 
-find ../docs/api_reference -name '*.en.md' -print0 | while IFS= read -r -d '' docsPath; do 
+find ../docs/api_reference -name '*.en.md' -print0 | while IFS= read -r -d '' docsPath; do
   # Convert ../docs/api_reference/v1beta2.en.md -> v1beta2
   apiVersion=$(basename ${docsPath} | awk -F. '{print $1}')
   echodate "Copying ${apiVersion} docs..."

--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -75,13 +75,13 @@ git_branch="$(git rev-parse --abbrev-ref HEAD)"
 branch=${CHANGELOG_BRANCH:-"$git_branch"}
 
 release-notes generate \
-    --org="$org" \
-    --repo="$repo" \
-    --start-rev="$CHANGELOG_START_REV" \
-    --end-sha="$CHANGELOG_END_SHA" \
-    --branch="$branch" \
-    --go-template="go-template:$tpl" \
-    --output="$output" \
-    --required-author "" \
-    --markdown-links \
-    --dependencies=false
+  --org="$org" \
+  --repo="$repo" \
+  --start-rev="$CHANGELOG_START_REV" \
+  --end-sha="$CHANGELOG_END_SHA" \
+  --branch="$branch" \
+  --go-template="go-template:$tpl" \
+  --output="$output" \
+  --required-author "" \
+  --markdown-links \
+  --dependencies=false

--- a/hack/image-loader.sh
+++ b/hack/image-loader.sh
@@ -110,7 +110,7 @@ optionalimages=$(kubeone config images list --filter=optional --kubernetes-versi
 
 for IMAGE in $k8simages; do
   # The CoreDNS image has a different override semantics than other images.
-  # If you provide a custom registry, kubeadm will override the CoreDNS image 
+  # If you provide a custom registry, kubeadm will override the CoreDNS image
   # in the following way:
   #   <default-registry>/coredns/coredns -> <custom-registry>/coredns
   # We have an issue because we enforce `registry.k8s.io` for all Kubernetes versions:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -17,7 +17,10 @@
 set -eu -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+CODEGEN_PKG=${CODEGEN_PKG:-$(
+  cd "${SCRIPT_ROOT}"
+  ls -d -1 ./vendor/k8s.io/code-generator 2> /dev/null || echo ../code-generator
+)}
 TERRAFORM_DOCS="go run github.com/terraform-docs/terraform-docs@v0.16.0"
 
 source "${SCRIPT_ROOT}/hack/lib.sh"
@@ -35,8 +38,8 @@ done
 
 echodate "Generating Kubernetes helpers..."
 kube::codegen::gen_helpers \
-    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate/boilerplate.go.txt" \
-    "${SCRIPT_ROOT}/pkg/apis/kubeone"
+  --boilerplate "${SCRIPT_ROOT}/hack/boilerplate/boilerplate.go.txt" \
+  "${SCRIPT_ROOT}/pkg/apis/kubeone"
 
 echodate "Generating Go code..."
 make gogenerate

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -23,7 +23,7 @@ boiler="${boilerDir}/boilerplate.py"
 
 files_need_boilerplate=()
 while IFS=$'\n' read -r line; do
-  files_need_boilerplate+=( "$line" )
+  files_need_boilerplate+=("$line")
 done < <("${boiler}" "$@")
 
 # Run boilerplate check

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	json "encoding/json"
+	jsontext "encoding/json/jsontext"
 	unsafe "unsafe"
 
 	kubeone "k8c.io/kubeone/pkg/apis/kubeone"
@@ -1764,7 +1764,7 @@ func Convert_kubeone_HelmRelease_To_v1beta2_HelmRelease(in *kubeone.HelmRelease,
 
 func autoConvert_v1beta2_HelmValues_To_kubeone_HelmValues(in *HelmValues, out *kubeone.HelmValues, s conversion.Scope) error {
 	out.ValuesFile = in.ValuesFile
-	out.Inline = *(*json.RawMessage)(unsafe.Pointer(&in.Inline))
+	out.Inline = *(*jsontext.Value)(unsafe.Pointer(&in.Inline))
 	return nil
 }
 
@@ -1775,7 +1775,7 @@ func Convert_v1beta2_HelmValues_To_kubeone_HelmValues(in *HelmValues, out *kubeo
 
 func autoConvert_kubeone_HelmValues_To_v1beta2_HelmValues(in *kubeone.HelmValues, out *HelmValues, s conversion.Scope) error {
 	out.ValuesFile = in.ValuesFile
-	out.Inline = *(*json.RawMessage)(unsafe.Pointer(&in.Inline))
+	out.Inline = *(*jsontext.Value)(unsafe.Pointer(&in.Inline))
 	return nil
 }
 
@@ -2338,7 +2338,7 @@ func autoConvert_v1beta2_NodeSet_To_kubeone_NodeSet(in *NodeSet, out *kubeone.No
 	if err := Convert_v1beta2_SSHSpec_To_kubeone_SSHSpec(&in.SSH, &out.SSH, s); err != nil {
 		return err
 	}
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	return nil
 }
 
@@ -2361,7 +2361,7 @@ func autoConvert_kubeone_NodeSet_To_v1beta2_NodeSet(in *kubeone.NodeSet, out *No
 	if err := Convert_kubeone_SSHSpec_To_v1beta2_SSHSpec(&in.SSH, &out.SSH, s); err != nil {
 		return err
 	}
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	return nil
 }
 
@@ -2647,7 +2647,7 @@ func Convert_kubeone_PodNodeSelectorConfig_To_v1beta2_PodNodeSelectorConfig(in *
 }
 
 func autoConvert_v1beta2_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out *kubeone.ProviderSpec, s conversion.Scope) error {
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
 	// WARNING: in.MachineAnnotations requires manual conversion: does not exist in peer-type
 	out.NodeAnnotations = *(*map[string]string)(unsafe.Pointer(&in.NodeAnnotations))
@@ -2656,14 +2656,14 @@ func autoConvert_v1beta2_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, 
 	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
 	out.OperatingSystem = in.OperatingSystem
-	out.OperatingSystemSpec = *(*json.RawMessage)(unsafe.Pointer(&in.OperatingSystemSpec))
+	out.OperatingSystemSpec = *(*jsontext.Value)(unsafe.Pointer(&in.OperatingSystemSpec))
 	out.Network = (*kubeone.ProviderStaticNetworkConfig)(unsafe.Pointer(in.Network))
 	out.OverwriteCloudConfig = (*string)(unsafe.Pointer(in.OverwriteCloudConfig))
 	return nil
 }
 
 func autoConvert_kubeone_ProviderSpec_To_v1beta2_ProviderSpec(in *kubeone.ProviderSpec, out *ProviderSpec, s conversion.Scope) error {
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
 	out.NodeAnnotations = *(*map[string]string)(unsafe.Pointer(&in.NodeAnnotations))
 	out.MachineObjectAnnotations = *(*map[string]string)(unsafe.Pointer(&in.MachineObjectAnnotations))
@@ -2671,7 +2671,7 @@ func autoConvert_kubeone_ProviderSpec_To_v1beta2_ProviderSpec(in *kubeone.Provid
 	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
 	out.OperatingSystem = in.OperatingSystem
-	out.OperatingSystemSpec = *(*json.RawMessage)(unsafe.Pointer(&in.OperatingSystemSpec))
+	out.OperatingSystemSpec = *(*jsontext.Value)(unsafe.Pointer(&in.OperatingSystemSpec))
 	out.Network = (*ProviderStaticNetworkConfig)(unsafe.Pointer(in.Network))
 	out.OverwriteCloudConfig = (*string)(unsafe.Pointer(in.OverwriteCloudConfig))
 	return nil

--- a/pkg/apis/kubeone/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	json "encoding/json"
+	jsontext "encoding/json/jsontext"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -926,7 +926,7 @@ func (in *HelmValues) DeepCopyInto(out *HelmValues) {
 	*out = *in
 	if in.Inline != nil {
 		in, out := &in.Inline, &out.Inline
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1396,7 +1396,7 @@ func (in *NodeSet) DeepCopyInto(out *NodeSet) {
 	in.SSH.DeepCopyInto(&out.SSH)
 	if in.CloudProviderSpec != nil {
 		in, out := &in.CloudProviderSpec, &out.CloudProviderSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1654,7 +1654,7 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 	*out = *in
 	if in.CloudProviderSpec != nil {
 		in, out := &in.CloudProviderSpec, &out.CloudProviderSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	if in.Annotations != nil {
@@ -1706,7 +1706,7 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 	}
 	if in.OperatingSystemSpec != nil {
 		in, out := &in.OperatingSystemSpec, &out.OperatingSystemSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	if in.Network != nil {

--- a/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.conversion.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta3
 
 import (
-	json "encoding/json"
+	jsontext "encoding/json/jsontext"
 	unsafe "unsafe"
 
 	kubeone "k8c.io/kubeone/pkg/apis/kubeone"
@@ -1797,7 +1797,7 @@ func Convert_kubeone_HelmRelease_To_v1beta3_HelmRelease(in *kubeone.HelmRelease,
 
 func autoConvert_v1beta3_HelmValues_To_kubeone_HelmValues(in *HelmValues, out *kubeone.HelmValues, s conversion.Scope) error {
 	out.ValuesFile = in.ValuesFile
-	out.Inline = *(*json.RawMessage)(unsafe.Pointer(&in.Inline))
+	out.Inline = *(*jsontext.Value)(unsafe.Pointer(&in.Inline))
 	return nil
 }
 
@@ -1808,7 +1808,7 @@ func Convert_v1beta3_HelmValues_To_kubeone_HelmValues(in *HelmValues, out *kubeo
 
 func autoConvert_kubeone_HelmValues_To_v1beta3_HelmValues(in *kubeone.HelmValues, out *HelmValues, s conversion.Scope) error {
 	out.ValuesFile = in.ValuesFile
-	out.Inline = *(*json.RawMessage)(unsafe.Pointer(&in.Inline))
+	out.Inline = *(*jsontext.Value)(unsafe.Pointer(&in.Inline))
 	return nil
 }
 
@@ -2345,7 +2345,7 @@ func autoConvert_v1beta3_NodeSet_To_kubeone_NodeSet(in *NodeSet, out *kubeone.No
 	if err := Convert_v1beta3_SSHSpec_To_kubeone_SSHSpec(&in.SSH, &out.SSH, s); err != nil {
 		return err
 	}
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	return nil
 }
 
@@ -2368,7 +2368,7 @@ func autoConvert_kubeone_NodeSet_To_v1beta3_NodeSet(in *kubeone.NodeSet, out *No
 	if err := Convert_kubeone_SSHSpec_To_v1beta3_SSHSpec(&in.SSH, &out.SSH, s); err != nil {
 		return err
 	}
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	return nil
 }
 
@@ -2654,7 +2654,7 @@ func Convert_kubeone_PodNodeSelectorConfig_To_v1beta3_PodNodeSelectorConfig(in *
 }
 
 func autoConvert_v1beta3_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out *kubeone.ProviderSpec, s conversion.Scope) error {
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
 	out.NodeAnnotations = *(*map[string]string)(unsafe.Pointer(&in.NodeAnnotations))
 	out.MachineObjectAnnotations = *(*map[string]string)(unsafe.Pointer(&in.MachineObjectAnnotations))
@@ -2662,7 +2662,7 @@ func autoConvert_v1beta3_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, 
 	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
 	out.OperatingSystem = in.OperatingSystem
-	out.OperatingSystemSpec = *(*json.RawMessage)(unsafe.Pointer(&in.OperatingSystemSpec))
+	out.OperatingSystemSpec = *(*jsontext.Value)(unsafe.Pointer(&in.OperatingSystemSpec))
 	out.Network = (*kubeone.ProviderStaticNetworkConfig)(unsafe.Pointer(in.Network))
 	out.OverwriteCloudConfig = (*string)(unsafe.Pointer(in.OverwriteCloudConfig))
 	return nil
@@ -2674,7 +2674,7 @@ func Convert_v1beta3_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out 
 }
 
 func autoConvert_kubeone_ProviderSpec_To_v1beta3_ProviderSpec(in *kubeone.ProviderSpec, out *ProviderSpec, s conversion.Scope) error {
-	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
+	out.CloudProviderSpec = *(*jsontext.Value)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
 	out.NodeAnnotations = *(*map[string]string)(unsafe.Pointer(&in.NodeAnnotations))
 	out.MachineObjectAnnotations = *(*map[string]string)(unsafe.Pointer(&in.MachineObjectAnnotations))
@@ -2682,7 +2682,7 @@ func autoConvert_kubeone_ProviderSpec_To_v1beta3_ProviderSpec(in *kubeone.Provid
 	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
 	out.OperatingSystem = in.OperatingSystem
-	out.OperatingSystemSpec = *(*json.RawMessage)(unsafe.Pointer(&in.OperatingSystemSpec))
+	out.OperatingSystemSpec = *(*jsontext.Value)(unsafe.Pointer(&in.OperatingSystemSpec))
 	out.Network = (*ProviderStaticNetworkConfig)(unsafe.Pointer(in.Network))
 	out.OverwriteCloudConfig = (*string)(unsafe.Pointer(in.OverwriteCloudConfig))
 	return nil

--- a/pkg/apis/kubeone/v1beta3/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1beta3/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1beta3
 
 import (
-	json "encoding/json"
+	jsontext "encoding/json/jsontext"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -919,7 +919,7 @@ func (in *HelmValues) DeepCopyInto(out *HelmValues) {
 	*out = *in
 	if in.Inline != nil {
 		in, out := &in.Inline, &out.Inline
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1387,7 +1387,7 @@ func (in *NodeSet) DeepCopyInto(out *NodeSet) {
 	in.SSH.DeepCopyInto(&out.SSH)
 	if in.CloudProviderSpec != nil {
 		in, out := &in.CloudProviderSpec, &out.CloudProviderSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1629,7 +1629,7 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 	*out = *in
 	if in.CloudProviderSpec != nil {
 		in, out := &in.CloudProviderSpec, &out.CloudProviderSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	if in.Annotations != nil {
@@ -1674,7 +1674,7 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 	}
 	if in.OperatingSystemSpec != nil {
 		in, out := &in.OperatingSystemSpec, &out.OperatingSystemSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	if in.Network != nil {

--- a/pkg/apis/kubeone/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package kubeone
 
 import (
-	json "encoding/json"
+	jsontext "encoding/json/jsontext"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -959,7 +959,7 @@ func (in *HelmValues) DeepCopyInto(out *HelmValues) {
 	*out = *in
 	if in.Inline != nil {
 		in, out := &in.Inline, &out.Inline
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1444,7 +1444,7 @@ func (in *NodeSet) DeepCopyInto(out *NodeSet) {
 	in.SSH.DeepCopyInto(&out.SSH)
 	if in.CloudProviderSpec != nil {
 		in, out := &in.CloudProviderSpec, &out.CloudProviderSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1686,7 +1686,7 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 	*out = *in
 	if in.CloudProviderSpec != nil {
 		in, out := &in.CloudProviderSpec, &out.CloudProviderSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	if in.Annotations != nil {
@@ -1731,7 +1731,7 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 	}
 	if in.OperatingSystemSpec != nil {
 		in, out := &in.OperatingSystemSpec, &out.OperatingSystemSpec
-		*out = make(json.RawMessage, len(*in))
+		*out = make(jsontext.Value, len(*in))
 		copy(*out, *in)
 	}
 	if in.Network != nil {

--- a/pkg/containerruntime/containerd_config.go
+++ b/pkg/containerruntime/containerd_config.go
@@ -380,8 +380,8 @@ func marshalContainerdConfigs(cluster *kubeoneapi.KubeOneCluster) (*maputils.Ord
 //	"myregistry.io:5000/path" -> "myregistry.io:5000"
 //	"docker.io" -> "docker.io"
 func RegistryHost(name string) string {
-	if i := strings.IndexByte(name, '/'); i >= 0 {
-		return name[:i]
+	if before, _, ok := strings.Cut(name, "/"); ok {
+		return before
 	}
 
 	return name

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -105,7 +105,7 @@ func safeguard(s *state.State) error {
 			continue
 		}
 
-		nodesContainerRuntime := strings.Split(node.Status.NodeInfo.ContainerRuntimeVersion, ":")[0]
+		nodesContainerRuntime, _, _ := strings.Cut(node.Status.NodeInfo.ContainerRuntimeVersion, ":")
 
 		if nodesContainerRuntime != configuredClusterContainerRuntime {
 			errMsg := "Migration is not supported yet"
@@ -447,7 +447,7 @@ func investigateHost(s *state.State, node *kubeoneapi.HostConfig, conn executor.
 }
 
 func kernelSemver(krelease string) (*semver.Version, error) {
-	kver := strings.SplitN(krelease, "-", 2)[0]
+	kver, _, _ := strings.Cut(krelease, "-")
 	kver = strings.SplitN(kver, "+", 2)[0]
 
 	return semver.NewVersion(kver)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowjobImage          = "quay.io/kubermatic/build:go-1.26-node-22-9"
+	prowjobImage          = "docker.io/golang:1.27"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/protokol.go
+++ b/test/e2e/protokol.go
@@ -61,13 +61,15 @@ func (p *protokolBin) build(proxyURL string, args ...string) *testexec.Exec {
 	env := os.Environ()
 
 	if proxyURL != "" {
-		env = append(env,
+		env = append(
+			env,
 			fmt.Sprintf("HTTPS_PROXY=%s", proxyURL),
 			fmt.Sprintf("HTTP_PROXY=%s", proxyURL),
 		)
 	}
 
-	return testexec.NewExec("protokol",
+	return testexec.NewExec(
+		"protokol",
 		testexec.WithArgs(args...),
 		testexec.WithEnv(env),
 		testexec.StderrTo(io.Discard),

--- a/test/e2e/sonobuoy.go
+++ b/test/e2e/sonobuoy.go
@@ -123,7 +123,8 @@ func (sbb *sonobuoyBin) run(ctx context.Context, args ...string) error {
 }
 
 func (sbb *sonobuoyBin) build(args ...string) *testexec.Exec {
-	exe := testexec.NewExec("sonobuoy",
+	exe := testexec.NewExec(
+		"sonobuoy",
 		testexec.WithArgs(args...),
 		testexec.WithEnv(os.Environ()),
 		testexec.InDir(sbb.dir),

--- a/test/go-test-e2e.sh
+++ b/test/go-test-e2e.sh
@@ -31,6 +31,31 @@ SSH_PRIVATE_KEY_FILE=${SSH_PRIVATE_KEY_FILE:-"${BUILD_DIR}/ssh_key_kubeone_e2e"}
 PATH=$PATH:$(go env GOPATH)/bin
 SSH_PUBLIC_KEY_FILE="${SSH_PRIVATE_KEY_FILE}.pub"
 CREDENTIALS_FILE_PATH=""
+TERRAFORM_VERSION=${TERRAFORM_VERSION:-"1.13.3"}
+SONOBUOY_VERSION=${SONOBUOY_VERSION:-"0.57.3"}
+PROTOKOL_VERSION=${PROTOKOL_VERSION:-"0.7.5"}
+TOOLS_CACHE_DIR=${TOOLS_CACHE_DIR:-"${HOME}/.cache/kubeone-e2e/tools"}
+OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+case $(uname -m) in
+x86_64) ARCH_NAME=amd64 ;;
+aarch64 | arm64) ARCH_NAME=arm64 ;;
+*) ARCH_NAME=$(uname -m) ;;
+esac
+
+# tool name -> version, used to keep ensure_tool() cache dirs version-scoped
+declare -A TOOL_VERSIONS=(
+  [terraform]="${TERRAFORM_VERSION}"
+  [sonobuoy]="${SONOBUOY_VERSION}"
+  [protokol]="${PROTOKOL_VERSION}"
+)
+
+# tool name -> release download URL, used by ensure_tool()
+declare -A TOOL_DOWNLOAD_URLS=(
+  [terraform]="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS_NAME}_${ARCH_NAME}.zip"
+  [sonobuoy]="https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_${OS_NAME}_${ARCH_NAME}.tar.gz"
+  [protokol]="https://codeberg.org/xrstf/protokol/releases/download/v${PROTOKOL_VERSION}/protokol_${PROTOKOL_VERSION}_${OS_NAME}_${ARCH_NAME}.tar.gz"
+)
 
 export PATH
 export TF_VAR_cluster_name=k1-${BUILD_ID}
@@ -45,6 +70,54 @@ trap cleanup EXIT
 function fatal() {
   echo "$1"
   exit 1
+}
+
+# ensure_tool downloads $1 into a versioned cache dir and prepends it to PATH unless already on PATH
+function ensure_tool() {
+  local tool=$1
+
+  if command -v "${tool}" > /dev/null 2>&1; then
+    return
+  fi
+
+  local url=${TOOL_DOWNLOAD_URLS[${tool}]:-}
+  if [ -z "${url}" ]; then
+    fatal "no download URL configured for ${tool}"
+  fi
+
+  local archive_name
+  archive_name=$(basename "${url}")
+  local install_dir="${TOOLS_CACHE_DIR}/${tool}/${TOOL_VERSIONS[${tool}]}"
+
+  if [ ! -x "${install_dir}/${tool}" ]; then
+    echo "Downloading ${tool} from ${url}"
+    mkdir -p "${install_dir}"
+
+    local archive_path="${BUILD_DIR}/${archive_name}"
+    curl --fail --location --output "${archive_path}" "${url}"
+
+    # extract to a scratch dir first, some archives nest the binary in a subdirectory
+    local extract_dir="${BUILD_DIR}/${tool}-extracted"
+    mkdir -p "${extract_dir}"
+    case "${archive_name}" in
+    *.zip) unzip -o -q "${archive_path}" -d "${extract_dir}" ;;
+    *.tar.gz) tar -xzf "${archive_path}" -C "${extract_dir}" ;;
+    *) fatal "unsupported archive format for ${tool}: ${archive_name}" ;;
+    esac
+
+    local extracted_bin
+    extracted_bin=$(find "${extract_dir}" -type f -name "${tool}" | head -n 1)
+    if [ -z "${extracted_bin}" ]; then
+      fatal "could not find ${tool} binary inside ${archive_name}"
+    fi
+
+    mv "${extracted_bin}" "${install_dir}/${tool}"
+    rm -rf "${extract_dir}"
+    chmod +x "${install_dir}/${tool}"
+  fi
+
+  PATH="${install_dir}:${PATH}"
+  export PATH
 }
 
 function generate_ssh_key() {
@@ -191,6 +264,15 @@ EOL
     ;;
   esac
 }
+
+if ! command -v unzip > /dev/null 2>&1; then
+  # assume debian like
+  apt update && apt install unzip -y
+fi
+
+ensure_tool "terraform"
+ensure_tool "sonobuoy"
+ensure_tool "protokol"
 
 generate_ssh_key "${SSH_PRIVATE_KEY_FILE}"
 ssh_agent "${SSH_PRIVATE_KEY_FILE}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the way KubeOne build. From now we will use upstream golang image, with the automatic using of latest and greatest available version everywhere, in GH action and Prow jobs so we don't have to run around and produce Go version updates for every single patch version in multiple files.

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade Go to 1.27
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
