### PR TITLE
Implement control plane machine destruction and cleanup functionality

### DIFF
--- a/pkg/cloudprovider/kubevirt/provider.go
+++ b/pkg/cloudprovider/kubevirt/provider.go
@@ -80,6 +80,10 @@ func (p *Provider) GenerateMachines(clusterName string, nodeSet []kubeoneapi.Nod
 	return generateKubevirtControlPlaneMachines(clusterName, nodeSet, kubeletVersion)
 }
 
+func (p *Provider) PrepareCleanup(s *state.State) error {
+	return prepareKubevirtEnv(s)
+}
+
 func (p *Provider) EnsureVM(st *state.State, capimachine clusterv1alpha1.Machine) error {
 	if err := prepareKubevirtEnv(st); err != nil {
 		return err

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -48,6 +48,31 @@ type ControlPlaneCloudProvider interface {
 	LookupVMs(*state.State) error
 }
 
+// CleanupVMs generates the control plane machines for the given provider and
+// destroys their instances at the cloud provider.
+func CleanupVMs(p ControlPlaneCloudProvider, s *state.State) error {
+	if prep, ok := p.(CleanupPreparer); ok {
+		if err := prep.PrepareCleanup(s); err != nil {
+			return err
+		}
+	}
+
+	machines, err := p.GenerateMachines(
+		s.Cluster.Name,
+		s.Cluster.ControlPlane.NodeSets,
+		s.Cluster.Versions.Kubernetes,
+	)
+	if err != nil {
+		return err
+	}
+
+	return provisioner.CleanupMachines(s.Context, machines, s.Logger)
+}
+
+type CleanupPreparer interface {
+	PrepareCleanup(*state.State) error
+}
+
 type LoadBalancerProvider interface {
 	HasLoadBalancer(*state.State) bool
 

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -32,11 +32,12 @@ import (
 
 type resetOpts struct {
 	globalOptions
-	AutoApprove      bool `longflag:"auto-approve" shortflag:"y"`
-	DestroyWorkers   bool `longflag:"destroy-workers"`
-	RemoveVolumes    bool `longflag:"remove-volumes"`
-	RemoveLBServices bool `longflag:"remove-lb-services"`
-	RemoveBinaries   bool `longflag:"remove-binaries"`
+	AutoApprove                 bool `longflag:"auto-approve" shortflag:"y"`
+	DestroyWorkers              bool `longflag:"destroy-workers"`
+	DestroyControlPlaneMachines bool `longflag:"destroy-control-plane"`
+	RemoveVolumes               bool `longflag:"remove-volumes"`
+	RemoveLBServices            bool `longflag:"remove-lb-services"`
+	RemoveBinaries              bool `longflag:"remove-binaries"`
 }
 
 func (opts *resetOpts) BuildState() (*state.State, error) {
@@ -46,6 +47,7 @@ func (opts *resetOpts) BuildState() (*state.State, error) {
 	}
 
 	s.DestroyWorkers = opts.DestroyWorkers
+	s.DestroyControlPlaneMachines = opts.DestroyControlPlaneMachines
 	s.RemoveVolumes = opts.RemoveVolumes
 	s.RemoveLBServices = opts.RemoveLBServices
 	s.RemoveBinaries = opts.RemoveBinaries
@@ -92,6 +94,13 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		longFlagName(opts, "DestroyWorkers"),
 		true,
 		"destroy all worker machines before resetting the cluster",
+	)
+
+	cmd.Flags().BoolVar(
+		&opts.DestroyControlPlaneMachines,
+		longFlagName(opts, "DestroyControlPlaneMachines"),
+		false,
+		"destroy the control plane machines instead of resetting them",
 	)
 
 	cmd.Flags().BoolVar(
@@ -182,8 +191,13 @@ func runReset(opts *resetOpts) error {
 		s.Logger.Warnln("If there are worker nodes in the cluster, you might have to delete them manually.")
 	}
 
-	for _, node := range s.Cluster.ControlPlane.Hosts {
-		fmt.Printf("\t- reset control plane node %q (%s)\n", node.Hostname, node.PrivateAddress)
+	if opts.DestroyControlPlaneMachines {
+		s.Logger.Warnln("destroy-control-plane command will PERMANENTLY destroy the control plane machines on the cloud provider.")
+		s.Logger.Warnln("KubeOne will NOT reset the control plane nodes; they will be destroyed instead.")
+	} else {
+		for _, node := range s.Cluster.ControlPlane.Hosts {
+			fmt.Printf("\t- reset control plane node %q (%s)\n", node.Hostname, node.PrivateAddress)
+		}
 	}
 	for _, node := range s.Cluster.StaticWorkers.Hosts {
 		fmt.Printf("\t- reset static worker nodes %q (%s)\n", node.Hostname, node.PrivateAddress)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -36,6 +36,8 @@ import (
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
 	"k8c.io/machine-controller/sdk/providerconfig"
 	"k8c.io/machine-controller/sdk/providerconfig/configvar"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -117,6 +119,44 @@ func FindMachines(ctx context.Context, machines []clusterv1alpha1.Machine, logge
 	}
 
 	return getMachineProvisionerOutput(instances), nil
+}
+
+// CleanupMachines deletes the instances associated with the given machines at
+// the cloud provider and waits for them to be fully cleaned up.
+func CleanupMachines(ctx context.Context, machines []clusterv1alpha1.Machine, logger logrus.FieldLogger) error {
+	providerData := &cloudprovidertypes.ProviderData{
+		Ctx: ctx,
+	}
+
+	rawLog := machinecontrollerlog.New(false, machinecontrollerlog.FormatConsole)
+	log := rawLog.Sugar()
+
+	for _, machine := range machines {
+		prov, err := getProvider(ctx, machine)
+		if err != nil {
+			return err
+		}
+
+		logger.Debugf("cleaning up control-plane %q VM", machine.Name)
+
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+			done, cleanupErr := prov.Cleanup(ctx, log, &machine, providerData)
+			if cleanupErr != nil {
+				if errors.Is(cleanupErr, cloudprovidererrors.ErrInstanceNotFound) {
+					return true, nil
+				}
+
+				return false, fail.MachineController(cleanupErr, "cleaning up machine at cloudprovider")
+			}
+
+			return done, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func FindOrCreateMachines(ctx context.Context, machines []clusterv1alpha1.Machine, logger logrus.FieldLogger) ([]Machine, error) {

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -91,33 +91,34 @@ func New(ctx context.Context, opts ...Option) (*State, error) {
 // State holds together currently test flags and parsed info, along with
 // utilities like logger
 type State struct {
-	Cluster                   *kubeoneapi.KubeOneCluster
-	LiveCluster               *Cluster
-	Logger                    logrus.FieldLogger
-	Executor                  executor.Adapter
-	Configuration             *configupload.Configuration
-	Images                    *images.Resolver
-	Runner                    *runner.Runner
-	Context                   context.Context
-	WorkDir                   string
-	JoinCommand               string
-	JoinToken                 string
-	RESTConfig                *rest.Config
-	DynamicClient             dynclient.Client
-	Verbose                   bool
-	BackupFile                string
-	DestroyWorkers            bool
-	RemoveVolumes             bool
-	RemoveLBServices          bool
-	RemoveBinaries            bool
-	ForceUpgrade              bool
-	ForceInstall              bool
-	PruneImages               bool
-	UpgradeMachineDeployments bool
-	CreateMachineDeployments  bool
-	CredentialsFilePath       string
-	ManifestFilePath          string
-	PauseImage                string
+	Cluster                     *kubeoneapi.KubeOneCluster
+	LiveCluster                 *Cluster
+	Logger                      logrus.FieldLogger
+	Executor                    executor.Adapter
+	Configuration               *configupload.Configuration
+	Images                      *images.Resolver
+	Runner                      *runner.Runner
+	Context                     context.Context
+	WorkDir                     string
+	JoinCommand                 string
+	JoinToken                   string
+	RESTConfig                  *rest.Config
+	DynamicClient               dynclient.Client
+	Verbose                     bool
+	BackupFile                  string
+	DestroyWorkers              bool
+	DestroyControlPlaneMachines bool
+	RemoveVolumes               bool
+	RemoveLBServices            bool
+	RemoveBinaries              bool
+	ForceUpgrade                bool
+	ForceInstall                bool
+	PruneImages                 bool
+	UpgradeMachineDeployments   bool
+	CreateMachineDeployments    bool
+	CredentialsFilePath         string
+	ManifestFilePath            string
+	PauseImage                  string
 }
 
 func (s *State) KubeadmVerboseFlag() string {

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -21,6 +21,7 @@ import (
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/clientutil"
+	"k8c.io/kubeone/pkg/cloudprovider"
 	"k8c.io/kubeone/pkg/executor"
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/kubeconfig"
@@ -158,7 +159,33 @@ func destroyWorkers(s *state.State) error {
 	return nil
 }
 
+func destroyControlPlaneMachines(s *state.State) error {
+	if !s.DestroyControlPlaneMachines {
+		return nil
+	}
+
+	s.Logger.Infoln("Destroying control plane machines...")
+
+	for _, p := range cloudprovider.ControlPlaneProviders() {
+		if !p.Enabled(s) {
+			continue
+		}
+
+		if err := cloudprovider.CleanupVMs(p, s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resetAllNodes(s *state.State) error {
+	if s.DestroyControlPlaneMachines {
+		s.Logger.Infoln("Resetting static worker nodes...")
+
+		return s.RunTaskOnStaticWorkers(resetNode, state.RunSequentially)
+	}
+
 	s.Logger.Infoln("Resettings all the nodes...")
 
 	return s.RunTaskOnAllNodes(resetNode, state.RunSequentially)
@@ -183,6 +210,10 @@ func removeBinariesAllNodes(s *state.State) error {
 	}
 
 	s.Logger.Infoln("Removing binaries from nodes...")
+
+	if s.DestroyControlPlaneMachines {
+		return s.RunTaskOnStaticWorkers(removeBinaries, state.RunParallel)
+	}
 
 	return s.RunTaskOnAllNodes(removeBinaries, state.RunParallel)
 }

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -439,6 +439,7 @@ func WithReset(t Tasks) Tasks {
 			},
 		},
 		{Fn: destroyWorkers, Operation: "destroying workers"},
+		{Fn: destroyControlPlaneMachines, Operation: "destroying control plane machines"},
 		{Fn: resetAllNodes, Operation: "resetting all nodes"},
 		{Fn: removeBinariesAllNodes, Operation: "removing kubernetes binaries from nodes"},
 	}...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `--destroy-control-plane` flag to `kubeone reset` that permanently destroys the control plane machines at the cloud provider instead of resetting (reprovisioning) them in place.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
When enabled, KubeOne:
- destroys control plane machines at the cloud provider (waiting up to 10 minutes per machine for cleanup to complete, tolerating already-missing instances)
- skips resetting the control plane nodes and only resets static workers
- removes Kubernetes binaries only from static workers

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a `--destroy-control-plane` flag to `kubeone reset` to destroy control plane machines at the cloud provider instead of resetting them
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
