### PR TITLE
Implement reset --destroy-control-plane-load-balancer

### DIFF
--- a/pkg/cloudprovider/hetzner/provider.go
+++ b/pkg/cloudprovider/hetzner/provider.go
@@ -196,6 +196,37 @@ func (p *Provider) LookupLoadBalancer(s *state.State) error {
 	return nil
 }
 
+func (p *Provider) CleanupLoadBalancer(s *state.State) error {
+	providerCreds, err := credentials.ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, credentials.TypeUniversal)
+	if err != nil {
+		return err
+	}
+
+	hzclient := hcloud.NewClient(hcloud.WithToken(providerCreds[credentials.HetznerTokenKeyMC]))
+
+	clusterLBName := s.Cluster.CloudProvider.Hetzner.ControlPlane.LoadBalancer.Name
+	lbs, _, err := hzclient.LoadBalancer.List(s.Context, hcloud.LoadBalancerListOpts{
+		Name: clusterLBName,
+	})
+	if err != nil {
+		return fail.Cloud(err, "hetzner", "listing loadbalancers")
+	}
+
+	if len(lbs) == 0 {
+		s.Logger.Debugf("no loadbalancer %q found, skipping deletion", clusterLBName)
+
+		return nil
+	}
+
+	s.Logger.Debugf("deleting loadbalancer %q with id: %d", clusterLBName, lbs[0].ID)
+
+	if _, err := hzclient.LoadBalancer.Delete(s.Context, lbs[0]); err != nil {
+		return fail.Cloud(err, "hetzner", "deleting loadbalancer")
+	}
+
+	return nil
+}
+
 func createHetznerLoadBalancer(
 	ctx context.Context,
 	client hcloud.ILoadBalancerClient,

--- a/pkg/cloudprovider/kubevirt/provider.go
+++ b/pkg/cloudprovider/kubevirt/provider.go
@@ -189,6 +189,33 @@ func (p *Provider) LookupLoadBalancer(st *state.State) error {
 	return nil
 }
 
+func (p *Provider) CleanupLoadBalancer(st *state.State) error {
+	infraClient, ns, err := kubevirtInfraClient(st)
+	if err != nil {
+		return err
+	}
+
+	lbName := st.Cluster.CloudProvider.Kubevirt.ControlPlane.LoadBalancer.Name
+	svc := &corev1.Service{}
+	if err := infraClient.Get(st.Context, types.NamespacedName{Name: lbName, Namespace: ns}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			st.Logger.Debugf("no apiserver service %q found, skipping deletion", lbName)
+
+			return nil
+		}
+
+		return fail.KubeClient(err, "getting kubevirt apiserver service")
+	}
+
+	st.Logger.Debugf("deleting apiserver service %q", lbName)
+
+	if err := infraClient.Delete(st.Context, svc); err != nil {
+		return fail.KubeClient(err, "deleting kubevirt apiserver service")
+	}
+
+	return nil
+}
+
 func kubevirtLabels(clusterName string) map[string]string {
 	return map[string]string{
 		"kubeone_cluster_name": clusterName,

--- a/pkg/cloudprovider/openstack/provider.go
+++ b/pkg/cloudprovider/openstack/provider.go
@@ -156,6 +156,49 @@ func (p *Provider) LookupLoadBalancer(s *state.State) error {
 	return nil
 }
 
+func (p *Provider) CleanupLoadBalancer(s *state.State) error {
+	lbClient, err := openstackLBClient(s)
+	if err != nil {
+		return err
+	}
+
+	lbName := s.Cluster.CloudProvider.Openstack.ControlPlane.LoadBalancer.Name
+	if lbName == "" {
+		lbName = fmt.Sprintf("%s-kube-apiserver", s.Cluster.Name)
+	}
+
+	var lbID string
+	err = loadbalancers.List(lbClient, loadbalancers.ListOpts{Name: lbName}).EachPage(func(page pagination.Page) (bool, error) {
+		lbs, oserr := loadbalancers.ExtractLoadBalancers(page)
+		if oserr != nil {
+			return false, oserr
+		}
+		if len(lbs) > 0 {
+			lbID = lbs[0].ID
+			s.Logger.Debugf("found loadbalancer %q with id: %s", lbName, lbID)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fail.Cloud(err, "openstack", "listing load balancers")
+	}
+
+	if lbID == "" {
+		s.Logger.Debugf("no load balancer %q found, skipping deletion", lbName)
+
+		return nil
+	}
+
+	s.Logger.Debugf("deleting loadbalancer %q with id: %s", lbName, lbID)
+
+	if err := loadbalancers.Delete(lbClient, lbID, loadbalancers.DeleteOpts{}).ExtractErr(); err != nil {
+		return fail.Cloud(err, "openstack", "deleting load balancer")
+	}
+
+	return nil
+}
+
 func ensureOpenstackLBMembers(s *state.State) error {
 	osCP := s.Cluster.CloudProvider.Openstack.ControlPlane
 

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -79,6 +79,8 @@ type LoadBalancerProvider interface {
 	EnsureLoadBalancer(*state.State) error
 
 	LookupLoadBalancer(*state.State) error
+
+	CleanupLoadBalancer(*state.State) error
 }
 
 func HostConfigsFromMachines(machines []provisioner.Machine, nodeSets []kubeoneapi.NodeSet) []kubeoneapi.HostConfig {

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -32,12 +32,13 @@ import (
 
 type resetOpts struct {
 	globalOptions
-	AutoApprove                 bool `longflag:"auto-approve" shortflag:"y"`
-	DestroyWorkers              bool `longflag:"destroy-workers"`
-	DestroyControlPlaneMachines bool `longflag:"destroy-control-plane"`
-	RemoveVolumes               bool `longflag:"remove-volumes"`
-	RemoveLBServices            bool `longflag:"remove-lb-services"`
-	RemoveBinaries              bool `longflag:"remove-binaries"`
+	AutoApprove                     bool `longflag:"auto-approve" shortflag:"y"`
+	DestroyWorkers                  bool `longflag:"destroy-workers"`
+	DestroyControlPlaneMachines     bool `longflag:"destroy-control-plane"`
+	DestroyControlPlaneLoadBalancer bool `longflag:"destroy-control-plane-load-balancer"`
+	RemoveVolumes                   bool `longflag:"remove-volumes"`
+	RemoveLBServices                bool `longflag:"remove-lb-services"`
+	RemoveBinaries                  bool `longflag:"remove-binaries"`
 }
 
 func (opts *resetOpts) BuildState() (*state.State, error) {
@@ -48,6 +49,7 @@ func (opts *resetOpts) BuildState() (*state.State, error) {
 
 	s.DestroyWorkers = opts.DestroyWorkers
 	s.DestroyControlPlaneMachines = opts.DestroyControlPlaneMachines
+	s.DestroyControlPlaneLoadBalancer = opts.DestroyControlPlaneLoadBalancer
 	s.RemoveVolumes = opts.RemoveVolumes
 	s.RemoveLBServices = opts.RemoveLBServices
 	s.RemoveBinaries = opts.RemoveBinaries
@@ -101,6 +103,13 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		longFlagName(opts, "DestroyControlPlaneMachines"),
 		false,
 		"destroy the control plane machines instead of resetting them",
+	)
+
+	cmd.Flags().BoolVar(
+		&opts.DestroyControlPlaneLoadBalancer,
+		longFlagName(opts, "DestroyControlPlaneLoadBalancer"),
+		false,
+		"destroy the control plane load balancer on the cloud provider (requires --destroy-control-plane)",
 	)
 
 	cmd.Flags().BoolVar(
@@ -194,6 +203,10 @@ func runReset(opts *resetOpts) error {
 	if opts.DestroyControlPlaneMachines {
 		s.Logger.Warnln("destroy-control-plane command will PERMANENTLY destroy the control plane machines on the cloud provider.")
 		s.Logger.Warnln("KubeOne will NOT reset the control plane nodes; they will be destroyed instead.")
+
+		if opts.DestroyControlPlaneLoadBalancer {
+			s.Logger.Warnln("destroy-control-plane-load-balancer command will PERMANENTLY destroy the control plane load balancer on the cloud provider.")
+		}
 	} else {
 		for _, node := range s.Cluster.ControlPlane.Hosts {
 			fmt.Printf("\t- reset control plane node %q (%s)\n", node.Hostname, node.PrivateAddress)

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -91,34 +91,35 @@ func New(ctx context.Context, opts ...Option) (*State, error) {
 // State holds together currently test flags and parsed info, along with
 // utilities like logger
 type State struct {
-	Cluster                     *kubeoneapi.KubeOneCluster
-	LiveCluster                 *Cluster
-	Logger                      logrus.FieldLogger
-	Executor                    executor.Adapter
-	Configuration               *configupload.Configuration
-	Images                      *images.Resolver
-	Runner                      *runner.Runner
-	Context                     context.Context
-	WorkDir                     string
-	JoinCommand                 string
-	JoinToken                   string
-	RESTConfig                  *rest.Config
-	DynamicClient               dynclient.Client
-	Verbose                     bool
-	BackupFile                  string
-	DestroyWorkers              bool
-	DestroyControlPlaneMachines bool
-	RemoveVolumes               bool
-	RemoveLBServices            bool
-	RemoveBinaries              bool
-	ForceUpgrade                bool
-	ForceInstall                bool
-	PruneImages                 bool
-	UpgradeMachineDeployments   bool
-	CreateMachineDeployments    bool
-	CredentialsFilePath         string
-	ManifestFilePath            string
-	PauseImage                  string
+	Cluster                         *kubeoneapi.KubeOneCluster
+	LiveCluster                     *Cluster
+	Logger                          logrus.FieldLogger
+	Executor                        executor.Adapter
+	Configuration                   *configupload.Configuration
+	Images                          *images.Resolver
+	Runner                          *runner.Runner
+	Context                         context.Context
+	WorkDir                         string
+	JoinCommand                     string
+	JoinToken                       string
+	RESTConfig                      *rest.Config
+	DynamicClient                   dynclient.Client
+	Verbose                         bool
+	BackupFile                      string
+	DestroyWorkers                  bool
+	DestroyControlPlaneMachines     bool
+	DestroyControlPlaneLoadBalancer bool
+	RemoveVolumes                   bool
+	RemoveLBServices                bool
+	RemoveBinaries                  bool
+	ForceUpgrade                    bool
+	ForceInstall                    bool
+	PruneImages                     bool
+	UpgradeMachineDeployments       bool
+	CreateMachineDeployments        bool
+	CredentialsFilePath             string
+	ManifestFilePath                string
+	PauseImage                      string
 }
 
 func (s *State) KubeadmVerboseFlag() string {

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -179,6 +179,31 @@ func destroyControlPlaneMachines(s *state.State) error {
 	return nil
 }
 
+func destroyControlPlaneLoadBalancer(s *state.State) error {
+	if !s.DestroyControlPlaneLoadBalancer || !s.DestroyControlPlaneMachines {
+		return nil
+	}
+
+	s.Logger.Infoln("Destroying control plane load balancer...")
+
+	for _, p := range cloudprovider.ControlPlaneProviders() {
+		if !p.Enabled(s) {
+			continue
+		}
+
+		lb, ok := p.(cloudprovider.LoadBalancerProvider)
+		if !ok || !lb.HasLoadBalancer(s) {
+			continue
+		}
+
+		if err := lb.CleanupLoadBalancer(s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resetAllNodes(s *state.State) error {
 	if s.DestroyControlPlaneMachines {
 		s.Logger.Infoln("Resetting static worker nodes...")

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -440,6 +440,7 @@ func WithReset(t Tasks) Tasks {
 		},
 		{Fn: destroyWorkers, Operation: "destroying workers"},
 		{Fn: destroyControlPlaneMachines, Operation: "destroying control plane machines"},
+		{Fn: destroyControlPlaneLoadBalancer, Operation: "destroying control plane load balancer"},
 		{Fn: resetAllNodes, Operation: "resetting all nodes"},
 		{Fn: removeBinariesAllNodes, Operation: "removing kubernetes binaries from nodes"},
 	}...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Additionally to [destroying VMs](https://github.com/kubermatic/kubeone/pull/4210), also cleanup kubeapi loadbalancer

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implement reset --destroy-control-plane-load-balancer
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
